### PR TITLE
[python] Fix segfault during conversion between c and python string

### DIFF
--- a/src/python/artm/library.py
+++ b/src/python/artm/library.py
@@ -66,8 +66,8 @@ class NetworkException(BaseException): pass
 
 
 def GetLastErrorMessage(lib):
-    error_message = lib.ArtmGetLastErrorMessage()
-    return ctypes.c_char_p(error_message).value
+    lib.ArtmGetLastErrorMessage.restype = ctypes.c_char_p
+    return lib.ArtmGetLastErrorMessage()
 
 
 def HandleErrorCode(lib, artm_error_code):


### PR DESCRIPTION
On OSX, on any internal error (missing parsed file, etc.) program exits with segfault without any error message.
This problem is described here: http://stackoverflow.com/questions/14944367/ctypes-segfault-on-osx-only
Not sure, whether it's ctypes bug, but this diff fixes problem on my OSX and works correctly on Ubuntu 14.04 VM.