### PR TITLE
Github ribbon on the main page

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -5,8 +5,13 @@
 
 .. _contents:
 
+
 Welcome to BigARTM's documentation!
 ===================================
+
+.. raw:: html
+
+   <a href="https://github.com/bigartm/bigartm"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Added "Fork me on github" ribbon in the top of first page.
[See updated main page](http://bigartm-test.readthedocs.org/en/github-ribbon/)