### PR TITLE
Use boost::mt19937 as random number generator

### DIFF
--- a/src/artm/core/helpers.cc
+++ b/src/artm/core/helpers.cc
@@ -8,6 +8,8 @@
 
 #include "boost/filesystem.hpp"
 #include "boost/lexical_cast.hpp"
+#include "boost/random/uniform_real.hpp"
+#include "boost/random/variate_generator.hpp"
 #include "boost/uuid/uuid_io.hpp"
 #include "boost/uuid/uuid_generators.hpp"
 
@@ -815,20 +817,13 @@ std::vector<float> Helpers::GenerateRandomVector(int size, size_t seed) {
   std::vector<float> retval;
   retval.reserve(size);
 
-#if defined(_WIN32) || defined(_WIN64)
-  // http://msdn.microsoft.com/en-us/library/aa272875(v=vs.60).aspx
-  // rand() is thread-safe on Windows when linked with LIBCMT.LIB
+  boost::mt19937 rng(seed);
+  boost::uniform_real<float> u(0.0f, 1.0f);
+  boost::variate_generator<boost::mt19937&, boost::uniform_real<float> > gen(rng, u);
 
-  srand(seed);
   for (int i = 0; i < size; ++i) {
-    retval.push_back(static_cast<float>(rand()) / static_cast<float>(RAND_MAX));  // NOLINT
+    retval.push_back(gen());
   }
-#else
-  unsigned int int_seed = static_cast<unsigned int>(seed);
-  for (int i = 0; i < size; ++i) {
-    retval.push_back(static_cast<float>(rand_r(&int_seed)) / static_cast<float>(RAND_MAX));
-  }
-#endif
 
   float sum = 0.0f;
   for (int i = 0; i < size; ++i) sum += retval[i];

--- a/utils/cpplint_all.bat
+++ b/utils/cpplint_all.bat
@@ -1,1 +1,1 @@
-for /f %%x in (cpplint_files.txt) do python .\cpplint.py --linelength=120 %%x
+for /f %%x in (cpplint_files.txt) do python .\cpplint.py --linelength=120 ../%%x


### PR DESCRIPTION
BigARTM needs to generate random values in order to initialize p(w|t) distributions. The behaviour from run to run is still deterministic, because BigARTM uses token's hash as seed. 

'''
// src/artm/core/phi_matrix_operations.cc
Helpers::GenerateRandomVector(phi_matrix->topic_size(), TokenHasher()(token)); 
'''

The problem is that the behavior is OS-dependent (different results on Windows and on Linux). According to [StackOverflow](http://stackoverflow.com/questions/922358/consistent-pseudo-random-numbers-across-platforms) boost::mt19937 should give consistent behavior across OS.