### PR TITLE
Use boost::hash for hasing strings

### DIFF
--- a/src/artm/core/common.h
+++ b/src/artm/core/common.h
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <unordered_map>
 
+#include "boost/functional/hash.hpp"
 #include "boost/uuid/uuid.hpp"
 
 #include "glog/logging.h"
@@ -29,9 +30,9 @@ typedef std::string ClassId;
 
 struct Token {
  public:
-  Token(ClassId _class_id, std::string _keyword)
+  Token(const ClassId& _class_id, const std::string& _keyword)
       : keyword(_keyword), class_id(_class_id),
-        hash_(std::hash<std::string>()(_keyword + _class_id)) {}
+        hash_(calcHash(_class_id, _keyword)) {}
 
   Token& operator=(const Token &rhs) {
     if (this != &rhs) {
@@ -64,6 +65,13 @@ struct Token {
  private:
   friend struct TokenHasher;
   const size_t hash_;
+
+  static size_t calcHash(const ClassId& class_id, const std::string& keyword) {
+    size_t hash = 0;
+    boost::hash_combine<std::string>(hash, keyword);
+    boost::hash_combine<std::string>(hash, class_id);
+    return hash;
+  }
 };
 
 struct TokenHasher {

--- a/src/artm_tests/repeatable_result_test.cc
+++ b/src/artm_tests/repeatable_result_test.cc
@@ -6,6 +6,7 @@
 #include "boost/filesystem.hpp"
 
 #include "artm/cpp_interface.h"
+#include "artm/core/common.h"
 #include "artm/core/exceptions.h"
 #include "artm/core/helpers.h"
 #include "artm/messages.pb.h"
@@ -78,6 +79,17 @@ TEST(RepeatableResult, RandomGenerator) {
     ASSERT_EQ(first_result[i], second_result[i]);
     ASSERT_NE(first_result[i - 1], first_result[i]);
   }
+}
+
+// artm_tests.exe --gtest_filter=RepeatableResult.TokenHasher
+TEST(RepeatableResult, TokenHasher) {
+  auto token_hasher = artm::core::TokenHasher();
+  EXPECT_EQ(token_hasher(artm::core::Token("class_id_1", "")), 14257342049058733748);
+  EXPECT_EQ(token_hasher(artm::core::Token("1_class_id", "")), 4746014843600301604);
+  EXPECT_EQ(token_hasher(artm::core::Token("", "token_1")), 16997208685286627075);
+  EXPECT_EQ(token_hasher(artm::core::Token("", "1_token")), 16937404881261379982);
+  EXPECT_EQ(token_hasher(artm::core::Token("class_id_1", "token_1")), 2667808992958584549);
+  EXPECT_EQ(token_hasher(artm::core::Token("class_id_2", "token_2")), 2667808992958584487);
 }
 
 void OverwriteTopicModel_internal(::artm::GetTopicModelArgs_RequestType request_type,


### PR DESCRIPTION
std::hash<string> has different behavior depending on OS.
boost::hash appears to be cross-platform.