### PR TITLE
fit_offline fixes

### DIFF
--- a/python/artm/master_component.py
+++ b/python/artm/master_component.py
@@ -108,7 +108,8 @@ class MasterComponent(object):
 
     def process_batches(self, pwt, nwt, num_inner_iterations=None, batches_folder=None,
                         batches=None, regularizer_name=None, regularizer_tau=None,
-                        class_ids=None, class_weights=None, find_theta=False, reset_scores=False):
+                        class_ids=None, class_weights=None,
+                        find_theta=False, reset_scores=False, reuse_theta=False):
         """Args:
            - pwt(str): name of pwt matrix in BigARTM
            - nwt(str): name of nwt matrix in BigARTM
@@ -121,6 +122,7 @@ class MasterComponent(object):
            - class_weights(list of double): list of corresponding weights of class ids
            - find_theat(bool): find theta matrix for 'batches' (if alternative 2)
            - reset_scores(bool): reset scores after iterations or not
+           - reuse_theta(bool): initialize by theta from previous collection pass
            Returns:
            - tuple (messages.ThetaMatrix, numpy.ndarray) --- the info about Theta (find_theta==True)
            - messages.ThetaMatrix --- the info about Theta (find_theta==False)
@@ -139,7 +141,9 @@ class MasterComponent(object):
 
         if num_inner_iterations is not None:
             args.inner_iterations_count = num_inner_iterations
+
         args.reset_scores = reset_scores
+        args.reuse_theta = reuse_theta
 
         if regularizer_name is not None and regularizer_tau is not None:
             for name, tau in zip(regularizer_name, regularizer_tau):

--- a/python/artm/scores.py
+++ b/python/artm/scores.py
@@ -490,8 +490,8 @@ class TopicKernelScore(BaseScore):
 
         self._dictionary_name = ''
         if dictionary_name is not None:
-            self._self._dictionary_name = dictionary_name
-            config.cooccurrence_dictionary_name = dictionary_name
+            self._dictionary_name = dictionary_name
+            self.config.cooccurrence_dictionary_name = dictionary_name
 
         self._probability_mass_threshold = 0.1
         if probability_mass_threshold is not None:


### PR DESCRIPTION
- ARTM model has no longer num_document_passes field
- fit_offline has no longer reset_scores parameter, it is True forever
- fit_offline has no longer apply_weight, decay_weight parameters, they are redundant
- fit_offline has num_document_passes=1, reuse_theta=True parameters
- process_batches has reuse_theta=False parameter
- bug with dictionary_name for TopicKernelScore fixed