### PR TITLE
ArtmImportBatches (in-memory processing of batches)

### DIFF
--- a/python/artm/messages_pb2.py
+++ b/python/artm/messages_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import descriptor_pb2
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='artm/messages.proto',
   package='artm',
-  serialized_pb='\n\x13\x61rtm/messages.proto\x12\x04\x61rtm\" \n\x0b\x44oubleArray\x12\x11\n\x05value\x18\x01 \x03(\x01\x42\x02\x10\x01\"\x1f\n\nFloatArray\x12\x11\n\x05value\x18\x01 \x03(\x02\x42\x02\x10\x01\"\x1e\n\tBoolArray\x12\x11\n\x05value\x18\x01 \x03(\x08\x42\x02\x10\x01\"\x1d\n\x08IntArray\x12\x11\n\x05value\x18\x01 \x03(\x05\x42\x02\x10\x01\"\x1c\n\x0bStringArray\x12\r\n\x05value\x18\x01 \x03(\t\"=\n\x04Item\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x05\x66ield\x18\x02 \x03(\x0b\x32\x0b.artm.Field\x12\r\n\x05title\x18\x03 \x01(\t\"\x95\x02\n\x05\x46ield\x12\x13\n\x04name\x18\x01 \x01(\t:\x05@body\x12\x10\n\x08token_id\x18\x02 \x03(\x05\x12\x13\n\x0btoken_count\x18\x03 \x03(\x05\x12\x14\n\x0ctoken_offset\x18\x04 \x03(\x05\x12\x14\n\x0cstring_value\x18\x05 \x01(\t\x12\x11\n\tint_value\x18\x06 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x07 \x01(\x01\x12\x12\n\ndate_value\x18\x08 \x01(\t\x12\x14\n\x0cstring_array\x18\x10 \x03(\t\x12\x11\n\tint_array\x18\x11 \x03(\x03\x12\x14\n\x0c\x64ouble_array\x18\x12 \x03(\x01\x12\x12\n\ndate_array\x18\x13 \x03(\t\x12\x14\n\x0ctoken_weight\x18\x14 \x03(\x02\"c\n\x05\x42\x61tch\x12\r\n\x05token\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x18\n\x04item\x18\x03 \x03(\x0b\x32\n.artm.Item\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\"\x93\x01\n\x06Stream\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x11.artm.Stream.Type:\x06Global\x12\x15\n\x04name\x18\x02 \x01(\t:\x07@global\x12\x0f\n\x07modulus\x18\x03 \x01(\x05\x12\x11\n\tresiduals\x18\x04 \x03(\x05\"%\n\x04Type\x12\n\n\x06Global\x10\x00\x12\x11\n\rItemIdModulus\x10\x01\"\xd0\x02\n\x15MasterComponentConfig\x12\x11\n\tdisk_path\x18\x02 \x01(\t\x12\x1c\n\x06stream\x18\x03 \x03(\x0b\x32\x0c.artm.Stream\x12\x1d\n\x0f\x63ompact_batches\x18\x04 \x01(\x08:\x04true\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10processors_count\x18\x06 \x01(\x05\x12$\n\x18processor_queue_max_size\x18\x07 \x01(\x05:\x02\x31\x30\x12!\n\x15merger_queue_max_size\x18\x08 \x01(\x05:\x02\x31\x30\x12\'\n\x0cscore_config\x18\t \x03(\x0b\x32\x11.artm.ScoreConfig\x12&\n\x17online_batch_processing\x18\r \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x64isk_cache_path\x18\x0f \x01(\t\"d\n\x13RegularizerSettings\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03tau\x18\x02 \x01(\x01\x12#\n\x1buse_relative_regularization\x18\x03 \x01(\x08\x12\r\n\x05gamma\x18\x04 \x01(\x01\"\xa1\x04\n\x0bModelConfig\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x18\n\x0ctopics_count\x18\x02 \x01(\x05:\x02\x33\x32\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x15\n\x07\x65nabled\x18\x04 \x01(\x08:\x04true\x12\"\n\x16inner_iterations_count\x18\x05 \x01(\x05:\x02\x31\x30\x12\x19\n\nfield_name\x18\x06 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x07 \x01(\t:\x07@global\x12\x12\n\nscore_name\x18\x08 \x03(\t\x12\x1a\n\x0breuse_theta\x18\t \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10regularizer_name\x18\n \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x0b \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x0c \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\r \x03(\x02\x12\x1c\n\x0euse_sparse_bow\x18\x0e \x01(\x08:\x04true\x12\x1f\n\x10use_random_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\x12\x1c\n\x0euse_new_tokens\x18\x10 \x01(\x08:\x04true\x12\x19\n\x0bopt_for_avx\x18\x11 \x01(\x08:\x04true\x12\x37\n\x14regularizer_settings\x18\x12 \x03(\x0b\x32\x19.artm.RegularizerSettings\x12\x1e\n\x0fuse_ptdw_matrix\x18\x13 \x01(\x08:\x05\x66\x61lse\"\x8a\x02\n\x11RegularizerConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\x04type\x18\x02 \x01(\x0e\x32\x1c.artm.RegularizerConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\xaa\x01\n\x04Type\x12\x15\n\x11SmoothSparseTheta\x10\x00\x12\x13\n\x0fSmoothSparsePhi\x10\x01\x12\x13\n\x0f\x44\x65\x63orrelatorPhi\x10\x02\x12\x14\n\x10MultiLanguagePhi\x10\x03\x12\x1a\n\x16LabelRegularizationPhi\x10\x04\x12\x16\n\x12SpecifiedSparsePhi\x10\x05\x12\x17\n\x13ImproveCoherencePhi\x10\x06\"A\n\x17SmoothSparseThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x12\n\nalpha_iter\x18\x02 \x03(\x02\"V\n\x15SmoothSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"=\n\x15\x44\x65\x63orrelatorPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\"\x18\n\x16MultiLanguagePhiConfig\"]\n\x1cLabelRegularizationPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x82\x02\n\x18SpecifiedSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x1e\n\x12max_elements_count\x18\x03 \x01(\x05:\x02\x32\x30\x12#\n\x15probability_threshold\x18\x04 \x01(\x02:\x04\x30.99\x12?\n\x04mode\x18\x05 \x01(\x0e\x32#.artm.SpecifiedSparsePhiConfig.Mode:\x0cSparseTopics\"*\n\x04Mode\x12\x10\n\x0cSparseTopics\x10\x00\x12\x10\n\x0cSparseTokens\x10\x01\"Z\n\x19ImproveCoherencePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x87\x01\n\x18RegularizerInternalState\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.artm.RegularizerInternalState.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x1c\n\x04Type\x12\x14\n\x10MultiLanguagePhi\x10\x03\"C\n\x1dMultiLanguagePhiInternalState\x12\"\n\x17no_regularization_calls\x18\x01 \x01(\x05:\x01\x30\"\xd1\x01\n\x10\x44ictionaryConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x05\x65ntry\x18\x02 \x03(\x0b\x32\x15.artm.DictionaryEntry\x12\x19\n\x11total_token_count\x18\x03 \x01(\x05\x12\x19\n\x11total_items_count\x18\x04 \x01(\x05\x12\x37\n\x0c\x63ooc_entries\x18\x05 \x01(\x0b\x32!.artm.DictionaryCoocurenceEntries\x12\x1a\n\x12total_token_weight\x18\x06 \x01(\x02\"\xbd\x01\n\x0f\x44ictionaryEntry\x12\x11\n\tkey_token\x18\x01 \x01(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x02\x12\x14\n\x0cvalue_tokens\x18\x04 \x03(\t\x12 \n\x06values\x18\x05 \x01(\x0b\x32\x10.artm.FloatArray\x12\x13\n\x0btoken_count\x18\x06 \x01(\x05\x12\x13\n\x0bitems_count\x18\x07 \x01(\x05\x12\x14\n\x0ctoken_weight\x18\x08 \x01(\x02\"}\n\x1b\x44ictionaryCoocurenceEntries\x12\x13\n\x0b\x66irst_index\x18\x01 \x03(\x05\x12\x14\n\x0csecond_index\x18\x02 \x03(\x05\x12\r\n\x05value\x18\x03 \x03(\x02\x12$\n\x15symmetric_cooc_values\x18\x04 \x01(\x08:\x05\x66\x61lse\"\xe6\x01\n\x0bScoreConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x04type\x18\x02 \x01(\x0e\x32\x16.artm.ScoreConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xe0\x01\n\tScoreData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x04type\x18\x02 \x01(\x0e\x32\x14.artm.ScoreData.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xcc\x02\n\x15PerplexityScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12J\n\nmodel_type\x18\x03 \x01(\x0e\x32 .artm.PerplexityScoreConfig.Type:\x14UnigramDocumentModel\x12\x17\n\x0f\x64ictionary_name\x18\x04 \x01(\t\x12\"\n\x12theta_sparsity_eps\x18\x05 \x01(\x02:\x06\x31\x65-037\x12!\n\x19theta_sparsity_topic_name\x18\x06 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x07 \x03(\t\"<\n\x04Type\x12\x18\n\x14UnigramDocumentModel\x10\x00\x12\x1a\n\x16UnigramCollectionModel\x10\x01\"\xbc\x01\n\x0fPerplexityScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x0b\n\x03raw\x18\x02 \x01(\x01\x12\x12\n\nnormalizer\x18\x03 \x01(\x01\x12\x12\n\nzero_words\x18\x04 \x01(\x05\x12\x1c\n\x14theta_sparsity_value\x18\x05 \x01(\x01\x12\"\n\x1atheta_sparsity_zero_topics\x18\x06 \x01(\x05\x12#\n\x1btheta_sparsity_total_topics\x18\x07 \x01(\x05\"|\n\x18SparsityThetaScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x03\x65ps\x18\x03 \x01(\x02:\x06\x31\x65-037\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"N\n\x12SparsityThetaScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_topics\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_topics\x18\x03 \x01(\x05\"c\n\x16SparsityPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"L\n\x10SparsityPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_tokens\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x05\"T\n\x19ItemsProcessedScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\"$\n\x13ItemsProcessedScore\x12\r\n\x05value\x18\x01 \x01(\x05\"\x8a\x01\n\x14TopTokensScoreConfig\x12\x16\n\nnum_tokens\x18\x01 \x01(\x05:\x02\x31\x30\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x04 \x01(\t\"\xad\x01\n\x0eTopTokensScore\x12\x13\n\x0bnum_entries\x18\x01 \x01(\x05\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_index\x18\x03 \x03(\x05\x12\r\n\x05token\x18\x04 \x03(\t\x12\x0e\n\x06weight\x18\x05 \x03(\x02\x12#\n\tcoherence\x18\x06 \x01(\x0b\x32\x10.artm.FloatArray\x12\x19\n\x11\x61verage_coherence\x18\x07 \x01(\x02\"\x7f\n\x17ThetaSnippetScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x07item_id\x18\x03 \x03(\x05\x42\x02\x10\x01\x12\x16\n\nitem_count\x18\x04 \x01(\x05:\x02\x31\x30\"F\n\x11ThetaSnippetScore\x12\x0f\n\x07item_id\x18\x01 \x03(\x05\x12 \n\x06values\x18\x02 \x03(\x0b\x32\x10.artm.FloatArray\"\xb2\x01\n\x16TopicKernelScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\'\n\x1aprobability_mass_threshold\x18\x04 \x01(\x01:\x03\x30.1\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x05 \x01(\t\"\xff\x02\n\x10TopicKernelScore\x12&\n\x0bkernel_size\x18\x01 \x01(\x0b\x32\x11.artm.DoubleArray\x12(\n\rkernel_purity\x18\x02 \x01(\x0b\x32\x11.artm.DoubleArray\x12*\n\x0fkernel_contrast\x18\x03 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x1b\n\x13\x61verage_kernel_size\x18\x04 \x01(\x01\x12\x1d\n\x15\x61verage_kernel_purity\x18\x05 \x01(\x01\x12\x1f\n\x17\x61verage_kernel_contrast\x18\x06 \x01(\x01\x12$\n\tcoherence\x18\x07 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x19\n\x11\x61verage_coherence\x18\x08 \x01(\x02\x12(\n\rkernel_tokens\x18\t \x03(\x0b\x32\x11.artm.StringArray\x12%\n\ntopic_name\x18\n \x01(\x0b\x32\x11.artm.StringArray\"d\n\x17TopicMassPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"_\n\x11TopicMassPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_ratio\x18\x03 \x03(\x01\x12\x12\n\ntopic_mass\x18\x04 \x03(\x01\"\x94\x03\n\nTopicModel\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x14\n\x0ctopics_count\x18\x02 \x01(\x05\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\r\n\x05token\x18\x04 \x03(\t\x12\'\n\rtoken_weights\x18\x05 \x03(\x0b\x32\x10.artm.FloatArray\x12\x10\n\x08\x63lass_id\x18\x06 \x03(\t\x12\x11\n\tinternals\x18\x07 \x01(\x0c\x12#\n\x0btopic_index\x18\x08 \x03(\x0b\x32\x0e.artm.IntArray\x12\x36\n\x0eoperation_type\x18\t \x03(\x0e\x32\x1e.artm.TopicModel.OperationType\x1a\x35\n\x13TopicModelInternals\x12\x1e\n\x04n_wt\x18\x01 \x03(\x0b\x32\x10.artm.FloatArray\"U\n\rOperationType\x12\x0e\n\nInitialize\x10\x00\x12\r\n\tIncrement\x10\x01\x12\r\n\tOverwrite\x10\x02\x12\n\n\x06Remove\x10\x03\x12\n\n\x06Ignore\x10\x04\"\xc5\x01\n\x0bThetaMatrix\x12\x1a\n\nmodel_name\x18\x01 \x01(\t:\x06@model\x12\x0f\n\x07item_id\x18\x02 \x03(\x05\x12&\n\x0citem_weights\x18\x03 \x03(\x0b\x32\x10.artm.FloatArray\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x14\n\x0ctopics_count\x18\x05 \x01(\x05\x12\x12\n\nitem_title\x18\x06 \x03(\t\x12#\n\x0btopic_index\x18\x07 \x03(\x0b\x32\x0e.artm.IntArray\"\xe3\x03\n\x16\x43ollectionParserConfig\x12\x42\n\x06\x66ormat\x18\x01 \x01(\x0e\x32#.artm.CollectionParserConfig.Format:\rBagOfWordsUci\x12\x19\n\x11\x64ocword_file_path\x18\x02 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x03 \x01(\t\x12\x15\n\rtarget_folder\x18\x04 \x01(\t\x12\x1c\n\x14\x64ictionary_file_name\x18\x05 \x01(\t\x12!\n\x13num_items_per_batch\x18\x06 \x01(\x05:\x04\x31\x30\x30\x30\x12\x1a\n\x12\x63ooccurrence_token\x18\x07 \x03(\t\x12%\n\x17use_unity_based_indices\x18\x08 \x01(\x08:\x04true\x12\x1a\n\x0bgather_cooc\x18\t \x01(\x08:\x05\x66\x61lse\x12\x1d\n\x15\x63ooccurrence_class_id\x18\n \x03(\t\x12(\n\x19use_symmetric_cooc_values\x18\x0b \x01(\x08:\x05\x66\x61lse\"Q\n\x06\x46ormat\x12\x11\n\rBagOfWordsUci\x10\x00\x12\x10\n\x0cMatrixMarket\x10\x01\x12\x10\n\x0cVowpalWabbit\x10\x02\x12\x10\n\x0c\x43ooccurrence\x10\x03\"\x7f\n\x14SynchronizeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0c\x64\x65\x63\x61y_weight\x18\x02 \x01(\x02:\x01\x30\x12!\n\x13invoke_regularizers\x18\x03 \x01(\x08:\x04true\x12\x17\n\x0c\x61pply_weight\x18\x04 \x01(\x02:\x01\x31\"\xcb\x03\n\x13InitializeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\x12\x45\n\x0bsource_type\x18\x03 \x01(\x0e\x32$.artm.InitializeModelArgs.SourceType:\nDictionary\x12\x11\n\tdisk_path\x18\x04 \x01(\t\x12\x30\n\x06\x66ilter\x18\x05 \x03(\x0b\x32 .artm.InitializeModelArgs.Filter\x12\x14\n\x0ctopics_count\x18\x06 \x01(\x05\x12\x12\n\ntopic_name\x18\x07 \x03(\t\x1a\xa5\x01\n\x06\x46ilter\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\t\x12\x16\n\x0emin_percentage\x18\x02 \x01(\x02\x12\x16\n\x0emax_percentage\x18\x03 \x01(\x02\x12\x11\n\tmin_items\x18\x04 \x01(\x05\x12\x11\n\tmax_items\x18\x05 \x01(\x05\x12\x17\n\x0fmin_total_count\x18\x06 \x01(\x05\x12\x1a\n\x12min_one_item_count\x18\x07 \x01(\x05\")\n\nSourceType\x12\x0e\n\nDictionary\x10\x00\x12\x0b\n\x07\x42\x61tches\x10\x01\"\xf4\x02\n\x11GetTopicModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\r\n\x05token\x18\x03 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x03(\t\x12\x19\n\x11use_sparse_format\x18\x05 \x01(\x08\x12\x13\n\x03\x65ps\x18\x06 \x01(\x02:\x06\x31\x65-037\x12>\n\x0crequest_type\x18\x07 \x01(\x0e\x32#.artm.GetTopicModelArgs.RequestType:\x03Pwt\x12\x42\n\rmatrix_layout\x18\x08 \x01(\x0e\x32$.artm.GetTopicModelArgs.MatrixLayout:\x05\x44\x65nse\";\n\x0bRequestType\x12\x07\n\x03Pwt\x10\x00\x12\x07\n\x03Nwt\x10\x01\x12\x0e\n\nTopicNames\x10\x02\x12\n\n\x06Tokens\x10\x03\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"\xa5\x02\n\x12GetThetaMatrixArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x02 \x01(\x0b\x32\x0b.artm.Batch\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x13\n\x0btopic_index\x18\x04 \x03(\x05\x12\x1a\n\x0b\x63lean_cache\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11use_sparse_format\x18\x06 \x01(\x08\x12\x13\n\x03\x65ps\x18\x07 \x01(\x02:\x06\x31\x65-037\x12\x43\n\rmatrix_layout\x18\x08 \x01(\x0e\x32%.artm.GetThetaMatrixArgs.MatrixLayout:\x05\x44\x65nse\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"W\n\x11GetScoreValueArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\nscore_name\x18\x02 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x01(\x0b\x32\x0b.artm.Batch\"\x82\x01\n\x0c\x41\x64\x64\x42\x61tchArgs\x12\x1a\n\x05\x62\x61tch\x18\x01 \x01(\x0b\x32\x0b.artm.Batch\x12 \n\x14timeout_milliseconds\x18\x02 \x01(\x05:\x02-1\x12\x1b\n\x0creset_scores\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x62\x61tch_file_name\x18\x04 \x01(\t\"a\n\x13InvokeIterationArgs\x12\x1b\n\x10iterations_count\x18\x01 \x01(\x05:\x01\x31\x12\x1a\n\x0creset_scores\x18\x02 \x01(\x08:\x04true\x12\x11\n\tdisk_path\x18\x03 \x01(\t\"0\n\x0cWaitIdleArgs\x12 \n\x14timeout_milliseconds\x18\x01 \x01(\x05:\x02-1\"8\n\x0f\x45xportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"8\n\x0fImportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"%\n\x0f\x41ttachModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\"\xad\x04\n\x12ProcessBatchesArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12\x17\n\x0fpwt_source_name\x18\x03 \x01(\t\x12\"\n\x16inner_iterations_count\x18\x04 \x01(\x05:\x02\x31\x30\x12\x1c\n\x0bstream_name\x18\x05 \x01(\t:\x07@global\x12\x18\n\x10regularizer_name\x18\x06 \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x07 \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x08 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\t \x03(\x02\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12\x1a\n\x0creset_scores\x18\r \x01(\x08:\x04true\x12J\n\x11theta_matrix_type\x18\x0e \x01(\x0e\x32(.artm.ProcessBatchesArgs.ThetaMatrixType:\x05\x43\x61\x63he\x12\x14\n\x0c\x62\x61tch_weight\x18\x0f \x03(\x02\x12\x1e\n\x0fuse_ptdw_matrix\x18\x10 \x01(\x08:\x05\x66\x61lse\"=\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\"d\n\x14ProcessBatchesResult\x12#\n\nscore_data\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\x12\'\n\x0ctheta_matrix\x18\x02 \x01(\x0b\x32\x11.artm.ThetaMatrix\"m\n\x0eMergeModelArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x03(\t\x12\x15\n\rsource_weight\x18\x03 \x03(\x02\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"\x99\x01\n\x13RegularizeModelArgs\x12\x17\n\x0frwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fpwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x03 \x01(\t\x12\x37\n\x14regularizer_settings\x18\x04 \x03(\x0b\x32\x19.artm.RegularizerSettings\"_\n\x12NormalizeModelArgs\x12\x17\n\x0fpwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0frwt_source_name\x18\x03 \x01(\t\"B\n\x14ImportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"\xc1\x01\n\x15\x43opyRequestResultArgs\x12Q\n\x0crequest_type\x18\x01 \x01(\x0e\x32\'.artm.CopyRequestResultArgs.RequestType:\x12\x44\x65\x66\x61ultRequestType\"U\n\x0bRequestType\x12\x16\n\x12\x44\x65\x66\x61ultRequestType\x10\x00\x12\x16\n\x12GetThetaSecondPass\x10\x01\x12\x16\n\x12GetModelSecondPass\x10\x02\"\x1e\n\x1c\x44uplicateMasterComponentArgs\"\x1c\n\x1aGetMasterComponentInfoArgs\"\xc8\x05\n\x13MasterComponentInfo\x12\x11\n\tmaster_id\x18\x01 \x01(\x05\x12+\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x1b.artm.MasterComponentConfig\x12>\n\x0bregularizer\x18\x03 \x03(\x0b\x32).artm.MasterComponentInfo.RegularizerInfo\x12\x32\n\x05score\x18\x04 \x03(\x0b\x32#.artm.MasterComponentInfo.ScoreInfo\x12<\n\ndictionary\x18\x05 \x03(\x0b\x32(.artm.MasterComponentInfo.DictionaryInfo\x12\x32\n\x05model\x18\x06 \x03(\x0b\x32#.artm.MasterComponentInfo.ModelInfo\x12=\n\x0b\x63\x61\x63he_entry\x18\x07 \x03(\x0b\x32(.artm.MasterComponentInfo.CacheEntryInfo\x12\x19\n\x11merger_queue_size\x18\x08 \x01(\x05\x12\x1c\n\x14processor_queue_size\x18\t \x01(\x05\x1a-\n\x0fRegularizerInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\'\n\tScoreInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\x35\n\x0e\x44ictionaryInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rentries_count\x18\x02 \x01(\x03\x1aR\n\tModelInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x13\n\x0btoken_count\x18\x04 \x01(\x05\x1a\x30\n\x0e\x43\x61\x63heEntryInfo\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tbyte_size\x18\x02 \x01(\x05')
+  serialized_pb='\n\x13\x61rtm/messages.proto\x12\x04\x61rtm\" \n\x0b\x44oubleArray\x12\x11\n\x05value\x18\x01 \x03(\x01\x42\x02\x10\x01\"\x1f\n\nFloatArray\x12\x11\n\x05value\x18\x01 \x03(\x02\x42\x02\x10\x01\"\x1e\n\tBoolArray\x12\x11\n\x05value\x18\x01 \x03(\x08\x42\x02\x10\x01\"\x1d\n\x08IntArray\x12\x11\n\x05value\x18\x01 \x03(\x05\x42\x02\x10\x01\"\x1c\n\x0bStringArray\x12\r\n\x05value\x18\x01 \x03(\t\"=\n\x04Item\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x05\x66ield\x18\x02 \x03(\x0b\x32\x0b.artm.Field\x12\r\n\x05title\x18\x03 \x01(\t\"\x95\x02\n\x05\x46ield\x12\x13\n\x04name\x18\x01 \x01(\t:\x05@body\x12\x10\n\x08token_id\x18\x02 \x03(\x05\x12\x13\n\x0btoken_count\x18\x03 \x03(\x05\x12\x14\n\x0ctoken_offset\x18\x04 \x03(\x05\x12\x14\n\x0cstring_value\x18\x05 \x01(\t\x12\x11\n\tint_value\x18\x06 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x07 \x01(\x01\x12\x12\n\ndate_value\x18\x08 \x01(\t\x12\x14\n\x0cstring_array\x18\x10 \x03(\t\x12\x11\n\tint_array\x18\x11 \x03(\x03\x12\x14\n\x0c\x64ouble_array\x18\x12 \x03(\x01\x12\x12\n\ndate_array\x18\x13 \x03(\t\x12\x14\n\x0ctoken_weight\x18\x14 \x03(\x02\"c\n\x05\x42\x61tch\x12\r\n\x05token\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x18\n\x04item\x18\x03 \x03(\x0b\x32\n.artm.Item\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\"\x93\x01\n\x06Stream\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x11.artm.Stream.Type:\x06Global\x12\x15\n\x04name\x18\x02 \x01(\t:\x07@global\x12\x0f\n\x07modulus\x18\x03 \x01(\x05\x12\x11\n\tresiduals\x18\x04 \x03(\x05\"%\n\x04Type\x12\n\n\x06Global\x10\x00\x12\x11\n\rItemIdModulus\x10\x01\"\xd0\x02\n\x15MasterComponentConfig\x12\x11\n\tdisk_path\x18\x02 \x01(\t\x12\x1c\n\x06stream\x18\x03 \x03(\x0b\x32\x0c.artm.Stream\x12\x1d\n\x0f\x63ompact_batches\x18\x04 \x01(\x08:\x04true\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10processors_count\x18\x06 \x01(\x05\x12$\n\x18processor_queue_max_size\x18\x07 \x01(\x05:\x02\x31\x30\x12!\n\x15merger_queue_max_size\x18\x08 \x01(\x05:\x02\x31\x30\x12\'\n\x0cscore_config\x18\t \x03(\x0b\x32\x11.artm.ScoreConfig\x12&\n\x17online_batch_processing\x18\r \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x64isk_cache_path\x18\x0f \x01(\t\"d\n\x13RegularizerSettings\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03tau\x18\x02 \x01(\x01\x12#\n\x1buse_relative_regularization\x18\x03 \x01(\x08\x12\r\n\x05gamma\x18\x04 \x01(\x01\"\xa1\x04\n\x0bModelConfig\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x18\n\x0ctopics_count\x18\x02 \x01(\x05:\x02\x33\x32\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x15\n\x07\x65nabled\x18\x04 \x01(\x08:\x04true\x12\"\n\x16inner_iterations_count\x18\x05 \x01(\x05:\x02\x31\x30\x12\x19\n\nfield_name\x18\x06 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x07 \x01(\t:\x07@global\x12\x12\n\nscore_name\x18\x08 \x03(\t\x12\x1a\n\x0breuse_theta\x18\t \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10regularizer_name\x18\n \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x0b \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x0c \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\r \x03(\x02\x12\x1c\n\x0euse_sparse_bow\x18\x0e \x01(\x08:\x04true\x12\x1f\n\x10use_random_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\x12\x1c\n\x0euse_new_tokens\x18\x10 \x01(\x08:\x04true\x12\x19\n\x0bopt_for_avx\x18\x11 \x01(\x08:\x04true\x12\x37\n\x14regularizer_settings\x18\x12 \x03(\x0b\x32\x19.artm.RegularizerSettings\x12\x1e\n\x0fuse_ptdw_matrix\x18\x13 \x01(\x08:\x05\x66\x61lse\"\x8a\x02\n\x11RegularizerConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\x04type\x18\x02 \x01(\x0e\x32\x1c.artm.RegularizerConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\xaa\x01\n\x04Type\x12\x15\n\x11SmoothSparseTheta\x10\x00\x12\x13\n\x0fSmoothSparsePhi\x10\x01\x12\x13\n\x0f\x44\x65\x63orrelatorPhi\x10\x02\x12\x14\n\x10MultiLanguagePhi\x10\x03\x12\x1a\n\x16LabelRegularizationPhi\x10\x04\x12\x16\n\x12SpecifiedSparsePhi\x10\x05\x12\x17\n\x13ImproveCoherencePhi\x10\x06\"A\n\x17SmoothSparseThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x12\n\nalpha_iter\x18\x02 \x03(\x02\"V\n\x15SmoothSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"=\n\x15\x44\x65\x63orrelatorPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\"\x18\n\x16MultiLanguagePhiConfig\"]\n\x1cLabelRegularizationPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x82\x02\n\x18SpecifiedSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x1e\n\x12max_elements_count\x18\x03 \x01(\x05:\x02\x32\x30\x12#\n\x15probability_threshold\x18\x04 \x01(\x02:\x04\x30.99\x12?\n\x04mode\x18\x05 \x01(\x0e\x32#.artm.SpecifiedSparsePhiConfig.Mode:\x0cSparseTopics\"*\n\x04Mode\x12\x10\n\x0cSparseTopics\x10\x00\x12\x10\n\x0cSparseTokens\x10\x01\"Z\n\x19ImproveCoherencePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x87\x01\n\x18RegularizerInternalState\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.artm.RegularizerInternalState.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x1c\n\x04Type\x12\x14\n\x10MultiLanguagePhi\x10\x03\"C\n\x1dMultiLanguagePhiInternalState\x12\"\n\x17no_regularization_calls\x18\x01 \x01(\x05:\x01\x30\"\xd1\x01\n\x10\x44ictionaryConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x05\x65ntry\x18\x02 \x03(\x0b\x32\x15.artm.DictionaryEntry\x12\x19\n\x11total_token_count\x18\x03 \x01(\x05\x12\x19\n\x11total_items_count\x18\x04 \x01(\x05\x12\x37\n\x0c\x63ooc_entries\x18\x05 \x01(\x0b\x32!.artm.DictionaryCoocurenceEntries\x12\x1a\n\x12total_token_weight\x18\x06 \x01(\x02\"\xbd\x01\n\x0f\x44ictionaryEntry\x12\x11\n\tkey_token\x18\x01 \x01(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x02\x12\x14\n\x0cvalue_tokens\x18\x04 \x03(\t\x12 \n\x06values\x18\x05 \x01(\x0b\x32\x10.artm.FloatArray\x12\x13\n\x0btoken_count\x18\x06 \x01(\x05\x12\x13\n\x0bitems_count\x18\x07 \x01(\x05\x12\x14\n\x0ctoken_weight\x18\x08 \x01(\x02\"}\n\x1b\x44ictionaryCoocurenceEntries\x12\x13\n\x0b\x66irst_index\x18\x01 \x03(\x05\x12\x14\n\x0csecond_index\x18\x02 \x03(\x05\x12\r\n\x05value\x18\x03 \x03(\x02\x12$\n\x15symmetric_cooc_values\x18\x04 \x01(\x08:\x05\x66\x61lse\"\xe6\x01\n\x0bScoreConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x04type\x18\x02 \x01(\x0e\x32\x16.artm.ScoreConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xe0\x01\n\tScoreData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x04type\x18\x02 \x01(\x0e\x32\x14.artm.ScoreData.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xcc\x02\n\x15PerplexityScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12J\n\nmodel_type\x18\x03 \x01(\x0e\x32 .artm.PerplexityScoreConfig.Type:\x14UnigramDocumentModel\x12\x17\n\x0f\x64ictionary_name\x18\x04 \x01(\t\x12\"\n\x12theta_sparsity_eps\x18\x05 \x01(\x02:\x06\x31\x65-037\x12!\n\x19theta_sparsity_topic_name\x18\x06 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x07 \x03(\t\"<\n\x04Type\x12\x18\n\x14UnigramDocumentModel\x10\x00\x12\x1a\n\x16UnigramCollectionModel\x10\x01\"\xbc\x01\n\x0fPerplexityScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x0b\n\x03raw\x18\x02 \x01(\x01\x12\x12\n\nnormalizer\x18\x03 \x01(\x01\x12\x12\n\nzero_words\x18\x04 \x01(\x05\x12\x1c\n\x14theta_sparsity_value\x18\x05 \x01(\x01\x12\"\n\x1atheta_sparsity_zero_topics\x18\x06 \x01(\x05\x12#\n\x1btheta_sparsity_total_topics\x18\x07 \x01(\x05\"|\n\x18SparsityThetaScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x03\x65ps\x18\x03 \x01(\x02:\x06\x31\x65-037\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"N\n\x12SparsityThetaScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_topics\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_topics\x18\x03 \x01(\x05\"c\n\x16SparsityPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"L\n\x10SparsityPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_tokens\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x05\"T\n\x19ItemsProcessedScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\"$\n\x13ItemsProcessedScore\x12\r\n\x05value\x18\x01 \x01(\x05\"\x8a\x01\n\x14TopTokensScoreConfig\x12\x16\n\nnum_tokens\x18\x01 \x01(\x05:\x02\x31\x30\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x04 \x01(\t\"\xad\x01\n\x0eTopTokensScore\x12\x13\n\x0bnum_entries\x18\x01 \x01(\x05\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_index\x18\x03 \x03(\x05\x12\r\n\x05token\x18\x04 \x03(\t\x12\x0e\n\x06weight\x18\x05 \x03(\x02\x12#\n\tcoherence\x18\x06 \x01(\x0b\x32\x10.artm.FloatArray\x12\x19\n\x11\x61verage_coherence\x18\x07 \x01(\x02\"\x7f\n\x17ThetaSnippetScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x07item_id\x18\x03 \x03(\x05\x42\x02\x10\x01\x12\x16\n\nitem_count\x18\x04 \x01(\x05:\x02\x31\x30\"F\n\x11ThetaSnippetScore\x12\x0f\n\x07item_id\x18\x01 \x03(\x05\x12 \n\x06values\x18\x02 \x03(\x0b\x32\x10.artm.FloatArray\"\xb2\x01\n\x16TopicKernelScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\'\n\x1aprobability_mass_threshold\x18\x04 \x01(\x01:\x03\x30.1\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x05 \x01(\t\"\xff\x02\n\x10TopicKernelScore\x12&\n\x0bkernel_size\x18\x01 \x01(\x0b\x32\x11.artm.DoubleArray\x12(\n\rkernel_purity\x18\x02 \x01(\x0b\x32\x11.artm.DoubleArray\x12*\n\x0fkernel_contrast\x18\x03 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x1b\n\x13\x61verage_kernel_size\x18\x04 \x01(\x01\x12\x1d\n\x15\x61verage_kernel_purity\x18\x05 \x01(\x01\x12\x1f\n\x17\x61verage_kernel_contrast\x18\x06 \x01(\x01\x12$\n\tcoherence\x18\x07 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x19\n\x11\x61verage_coherence\x18\x08 \x01(\x02\x12(\n\rkernel_tokens\x18\t \x03(\x0b\x32\x11.artm.StringArray\x12%\n\ntopic_name\x18\n \x01(\x0b\x32\x11.artm.StringArray\"d\n\x17TopicMassPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"_\n\x11TopicMassPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_ratio\x18\x03 \x03(\x01\x12\x12\n\ntopic_mass\x18\x04 \x03(\x01\"\x94\x03\n\nTopicModel\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x14\n\x0ctopics_count\x18\x02 \x01(\x05\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\r\n\x05token\x18\x04 \x03(\t\x12\'\n\rtoken_weights\x18\x05 \x03(\x0b\x32\x10.artm.FloatArray\x12\x10\n\x08\x63lass_id\x18\x06 \x03(\t\x12\x11\n\tinternals\x18\x07 \x01(\x0c\x12#\n\x0btopic_index\x18\x08 \x03(\x0b\x32\x0e.artm.IntArray\x12\x36\n\x0eoperation_type\x18\t \x03(\x0e\x32\x1e.artm.TopicModel.OperationType\x1a\x35\n\x13TopicModelInternals\x12\x1e\n\x04n_wt\x18\x01 \x03(\x0b\x32\x10.artm.FloatArray\"U\n\rOperationType\x12\x0e\n\nInitialize\x10\x00\x12\r\n\tIncrement\x10\x01\x12\r\n\tOverwrite\x10\x02\x12\n\n\x06Remove\x10\x03\x12\n\n\x06Ignore\x10\x04\"\xc5\x01\n\x0bThetaMatrix\x12\x1a\n\nmodel_name\x18\x01 \x01(\t:\x06@model\x12\x0f\n\x07item_id\x18\x02 \x03(\x05\x12&\n\x0citem_weights\x18\x03 \x03(\x0b\x32\x10.artm.FloatArray\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x14\n\x0ctopics_count\x18\x05 \x01(\x05\x12\x12\n\nitem_title\x18\x06 \x03(\t\x12#\n\x0btopic_index\x18\x07 \x03(\x0b\x32\x0e.artm.IntArray\"\xe3\x03\n\x16\x43ollectionParserConfig\x12\x42\n\x06\x66ormat\x18\x01 \x01(\x0e\x32#.artm.CollectionParserConfig.Format:\rBagOfWordsUci\x12\x19\n\x11\x64ocword_file_path\x18\x02 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x03 \x01(\t\x12\x15\n\rtarget_folder\x18\x04 \x01(\t\x12\x1c\n\x14\x64ictionary_file_name\x18\x05 \x01(\t\x12!\n\x13num_items_per_batch\x18\x06 \x01(\x05:\x04\x31\x30\x30\x30\x12\x1a\n\x12\x63ooccurrence_token\x18\x07 \x03(\t\x12%\n\x17use_unity_based_indices\x18\x08 \x01(\x08:\x04true\x12\x1a\n\x0bgather_cooc\x18\t \x01(\x08:\x05\x66\x61lse\x12\x1d\n\x15\x63ooccurrence_class_id\x18\n \x03(\t\x12(\n\x19use_symmetric_cooc_values\x18\x0b \x01(\x08:\x05\x66\x61lse\"Q\n\x06\x46ormat\x12\x11\n\rBagOfWordsUci\x10\x00\x12\x10\n\x0cMatrixMarket\x10\x01\x12\x10\n\x0cVowpalWabbit\x10\x02\x12\x10\n\x0c\x43ooccurrence\x10\x03\"\x7f\n\x14SynchronizeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0c\x64\x65\x63\x61y_weight\x18\x02 \x01(\x02:\x01\x30\x12!\n\x13invoke_regularizers\x18\x03 \x01(\x08:\x04true\x12\x17\n\x0c\x61pply_weight\x18\x04 \x01(\x02:\x01\x31\"\xe3\x03\n\x13InitializeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\x12\x45\n\x0bsource_type\x18\x03 \x01(\x0e\x32$.artm.InitializeModelArgs.SourceType:\nDictionary\x12\x11\n\tdisk_path\x18\x04 \x01(\t\x12\x30\n\x06\x66ilter\x18\x05 \x03(\x0b\x32 .artm.InitializeModelArgs.Filter\x12\x14\n\x0ctopics_count\x18\x06 \x01(\x05\x12\x12\n\ntopic_name\x18\x07 \x03(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x08 \x03(\t\x1a\xa5\x01\n\x06\x46ilter\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\t\x12\x16\n\x0emin_percentage\x18\x02 \x01(\x02\x12\x16\n\x0emax_percentage\x18\x03 \x01(\x02\x12\x11\n\tmin_items\x18\x04 \x01(\x05\x12\x11\n\tmax_items\x18\x05 \x01(\x05\x12\x17\n\x0fmin_total_count\x18\x06 \x01(\x05\x12\x1a\n\x12min_one_item_count\x18\x07 \x01(\x05\")\n\nSourceType\x12\x0e\n\nDictionary\x10\x00\x12\x0b\n\x07\x42\x61tches\x10\x01\"\xf4\x02\n\x11GetTopicModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\r\n\x05token\x18\x03 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x03(\t\x12\x19\n\x11use_sparse_format\x18\x05 \x01(\x08\x12\x13\n\x03\x65ps\x18\x06 \x01(\x02:\x06\x31\x65-037\x12>\n\x0crequest_type\x18\x07 \x01(\x0e\x32#.artm.GetTopicModelArgs.RequestType:\x03Pwt\x12\x42\n\rmatrix_layout\x18\x08 \x01(\x0e\x32$.artm.GetTopicModelArgs.MatrixLayout:\x05\x44\x65nse\";\n\x0bRequestType\x12\x07\n\x03Pwt\x10\x00\x12\x07\n\x03Nwt\x10\x01\x12\x0e\n\nTopicNames\x10\x02\x12\n\n\x06Tokens\x10\x03\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"\xa5\x02\n\x12GetThetaMatrixArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x02 \x01(\x0b\x32\x0b.artm.Batch\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x13\n\x0btopic_index\x18\x04 \x03(\x05\x12\x1a\n\x0b\x63lean_cache\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11use_sparse_format\x18\x06 \x01(\x08\x12\x13\n\x03\x65ps\x18\x07 \x01(\x02:\x06\x31\x65-037\x12\x43\n\rmatrix_layout\x18\x08 \x01(\x0e\x32%.artm.GetThetaMatrixArgs.MatrixLayout:\x05\x44\x65nse\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"W\n\x11GetScoreValueArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\nscore_name\x18\x02 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x01(\x0b\x32\x0b.artm.Batch\"\x82\x01\n\x0c\x41\x64\x64\x42\x61tchArgs\x12\x1a\n\x05\x62\x61tch\x18\x01 \x01(\x0b\x32\x0b.artm.Batch\x12 \n\x14timeout_milliseconds\x18\x02 \x01(\x05:\x02-1\x12\x1b\n\x0creset_scores\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x62\x61tch_file_name\x18\x04 \x01(\t\"a\n\x13InvokeIterationArgs\x12\x1b\n\x10iterations_count\x18\x01 \x01(\x05:\x01\x31\x12\x1a\n\x0creset_scores\x18\x02 \x01(\x08:\x04true\x12\x11\n\tdisk_path\x18\x03 \x01(\t\"0\n\x0cWaitIdleArgs\x12 \n\x14timeout_milliseconds\x18\x01 \x01(\x05:\x02-1\"8\n\x0f\x45xportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"8\n\x0fImportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"%\n\x0f\x41ttachModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\"\xad\x04\n\x12ProcessBatchesArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12\x17\n\x0fpwt_source_name\x18\x03 \x01(\t\x12\"\n\x16inner_iterations_count\x18\x04 \x01(\x05:\x02\x31\x30\x12\x1c\n\x0bstream_name\x18\x05 \x01(\t:\x07@global\x12\x18\n\x10regularizer_name\x18\x06 \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x07 \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x08 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\t \x03(\x02\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12\x1a\n\x0creset_scores\x18\r \x01(\x08:\x04true\x12J\n\x11theta_matrix_type\x18\x0e \x01(\x0e\x32(.artm.ProcessBatchesArgs.ThetaMatrixType:\x05\x43\x61\x63he\x12\x14\n\x0c\x62\x61tch_weight\x18\x0f \x03(\x02\x12\x1e\n\x0fuse_ptdw_matrix\x18\x10 \x01(\x08:\x05\x66\x61lse\"=\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\"d\n\x14ProcessBatchesResult\x12#\n\nscore_data\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\x12\'\n\x0ctheta_matrix\x18\x02 \x01(\x0b\x32\x11.artm.ThetaMatrix\"m\n\x0eMergeModelArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x03(\t\x12\x15\n\rsource_weight\x18\x03 \x03(\x02\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"\x99\x01\n\x13RegularizeModelArgs\x12\x17\n\x0frwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fpwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x03 \x01(\t\x12\x37\n\x14regularizer_settings\x18\x04 \x03(\x0b\x32\x19.artm.RegularizerSettings\"_\n\x12NormalizeModelArgs\x12\x17\n\x0fpwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0frwt_source_name\x18\x03 \x01(\t\"B\n\x14ImportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"\xc1\x01\n\x15\x43opyRequestResultArgs\x12Q\n\x0crequest_type\x18\x01 \x01(\x0e\x32\'.artm.CopyRequestResultArgs.RequestType:\x12\x44\x65\x66\x61ultRequestType\"U\n\x0bRequestType\x12\x16\n\x12\x44\x65\x66\x61ultRequestType\x10\x00\x12\x16\n\x12GetThetaSecondPass\x10\x01\x12\x16\n\x12GetModelSecondPass\x10\x02\"\x1e\n\x1c\x44uplicateMasterComponentArgs\"\x1c\n\x1aGetMasterComponentInfoArgs\"\xc1\x06\n\x13MasterComponentInfo\x12\x11\n\tmaster_id\x18\x01 \x01(\x05\x12+\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x1b.artm.MasterComponentConfig\x12>\n\x0bregularizer\x18\x03 \x03(\x0b\x32).artm.MasterComponentInfo.RegularizerInfo\x12\x32\n\x05score\x18\x04 \x03(\x0b\x32#.artm.MasterComponentInfo.ScoreInfo\x12<\n\ndictionary\x18\x05 \x03(\x0b\x32(.artm.MasterComponentInfo.DictionaryInfo\x12\x32\n\x05model\x18\x06 \x03(\x0b\x32#.artm.MasterComponentInfo.ModelInfo\x12=\n\x0b\x63\x61\x63he_entry\x18\x07 \x03(\x0b\x32(.artm.MasterComponentInfo.CacheEntryInfo\x12\x19\n\x11merger_queue_size\x18\x08 \x01(\x05\x12\x1c\n\x14processor_queue_size\x18\t \x01(\x05\x12\x32\n\x05\x62\x61tch\x18\n \x03(\x0b\x32#.artm.MasterComponentInfo.BatchInfo\x1a-\n\x0fRegularizerInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\'\n\tScoreInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\x35\n\x0e\x44ictionaryInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rentries_count\x18\x02 \x01(\x03\x1a\x43\n\tBatchInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0bitems_count\x18\x02 \x01(\x05\x12\x13\n\x0btoken_count\x18\x03 \x01(\x05\x1aR\n\tModelInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x13\n\x0btoken_count\x18\x04 \x01(\x05\x1a\x30\n\x0e\x43\x61\x63heEntryInfo\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tbyte_size\x18\x02 \x01(\x05\"C\n\x11ImportBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x03(\x0b\x32\x0b.artm.Batch\"(\n\x12\x44isposeBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t')
 
 
 
@@ -307,8 +307,8 @@ _INITIALIZEMODELARGS_SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=7891,
-  serialized_end=7932,
+  serialized_start=7915,
+  serialized_end=7956,
 )
 
 _GETTOPICMODELARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
@@ -336,8 +336,8 @@ _GETTOPICMODELARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8209,
-  serialized_end=8268,
+  serialized_start=8233,
+  serialized_end=8292,
 )
 
 _GETTOPICMODELARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
@@ -357,8 +357,8 @@ _GETTOPICMODELARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8270,
-  serialized_end=8307,
+  serialized_start=8294,
+  serialized_end=8331,
 )
 
 _GETTHETAMATRIXARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
@@ -378,8 +378,8 @@ _GETTHETAMATRIXARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8270,
-  serialized_end=8307,
+  serialized_start=8294,
+  serialized_end=8331,
 )
 
 _PROCESSBATCHESARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
@@ -407,8 +407,8 @@ _PROCESSBATCHESARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9628,
-  serialized_end=9689,
+  serialized_start=9652,
+  serialized_end=9713,
 )
 
 _COPYREQUESTRESULTARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
@@ -432,8 +432,8 @@ _COPYREQUESTRESULTARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10334,
-  serialized_end=10419,
+  serialized_start=10358,
+  serialized_end=10443,
 )
 
 
@@ -3009,8 +3009,8 @@ _INITIALIZEMODELARGS_FILTER = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7724,
-  serialized_end=7889,
+  serialized_start=7748,
+  serialized_end=7913,
 )
 
 _INITIALIZEMODELARGS = _descriptor.Descriptor(
@@ -3069,6 +3069,13 @@ _INITIALIZEMODELARGS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='batch_filename', full_name='artm.InitializeModelArgs.batch_filename', index=7,
+      number=8, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -3080,7 +3087,7 @@ _INITIALIZEMODELARGS = _descriptor.Descriptor(
   is_extendable=False,
   extension_ranges=[],
   serialized_start=7473,
-  serialized_end=7932,
+  serialized_end=7956,
 )
 
 
@@ -3158,8 +3165,8 @@ _GETTOPICMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7935,
-  serialized_end=8307,
+  serialized_start=7959,
+  serialized_end=8331,
 )
 
 
@@ -3236,8 +3243,8 @@ _GETTHETAMATRIXARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8310,
-  serialized_end=8603,
+  serialized_start=8334,
+  serialized_end=8627,
 )
 
 
@@ -3278,8 +3285,8 @@ _GETSCOREVALUEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8605,
-  serialized_end=8692,
+  serialized_start=8629,
+  serialized_end=8716,
 )
 
 
@@ -3327,8 +3334,8 @@ _ADDBATCHARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8695,
-  serialized_end=8825,
+  serialized_start=8719,
+  serialized_end=8849,
 )
 
 
@@ -3369,8 +3376,8 @@ _INVOKEITERATIONARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8827,
-  serialized_end=8924,
+  serialized_start=8851,
+  serialized_end=8948,
 )
 
 
@@ -3397,8 +3404,8 @@ _WAITIDLEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8926,
-  serialized_end=8974,
+  serialized_start=8950,
+  serialized_end=8998,
 )
 
 
@@ -3432,8 +3439,8 @@ _EXPORTMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8976,
-  serialized_end=9032,
+  serialized_start=9000,
+  serialized_end=9056,
 )
 
 
@@ -3467,8 +3474,8 @@ _IMPORTMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9034,
-  serialized_end=9090,
+  serialized_start=9058,
+  serialized_end=9114,
 )
 
 
@@ -3495,8 +3502,8 @@ _ATTACHMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9092,
-  serialized_end=9129,
+  serialized_start=9116,
+  serialized_end=9153,
 )
 
 
@@ -3629,8 +3636,8 @@ _PROCESSBATCHESARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9132,
-  serialized_end=9689,
+  serialized_start=9156,
+  serialized_end=9713,
 )
 
 
@@ -3664,8 +3671,8 @@ _PROCESSBATCHESRESULT = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9691,
-  serialized_end=9791,
+  serialized_start=9715,
+  serialized_end=9815,
 )
 
 
@@ -3713,8 +3720,8 @@ _MERGEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9793,
-  serialized_end=9902,
+  serialized_start=9817,
+  serialized_end=9926,
 )
 
 
@@ -3762,8 +3769,8 @@ _REGULARIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9905,
-  serialized_end=10058,
+  serialized_start=9929,
+  serialized_end=10082,
 )
 
 
@@ -3804,8 +3811,8 @@ _NORMALIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10060,
-  serialized_end=10155,
+  serialized_start=10084,
+  serialized_end=10179,
 )
 
 
@@ -3839,8 +3846,8 @@ _IMPORTDICTIONARYARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10157,
-  serialized_end=10223,
+  serialized_start=10181,
+  serialized_end=10247,
 )
 
 
@@ -3868,8 +3875,8 @@ _COPYREQUESTRESULTARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10226,
-  serialized_end=10419,
+  serialized_start=10250,
+  serialized_end=10443,
 )
 
 
@@ -3889,8 +3896,8 @@ _DUPLICATEMASTERCOMPONENTARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10421,
-  serialized_end=10451,
+  serialized_start=10445,
+  serialized_end=10475,
 )
 
 
@@ -3910,8 +3917,8 @@ _GETMASTERCOMPONENTINFOARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10453,
-  serialized_end=10481,
+  serialized_start=10477,
+  serialized_end=10505,
 )
 
 
@@ -3945,8 +3952,8 @@ _MASTERCOMPONENTINFO_REGULARIZERINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10921,
-  serialized_end=10966,
+  serialized_start=10997,
+  serialized_end=11042,
 )
 
 _MASTERCOMPONENTINFO_SCOREINFO = _descriptor.Descriptor(
@@ -3979,8 +3986,8 @@ _MASTERCOMPONENTINFO_SCOREINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10968,
-  serialized_end=11007,
+  serialized_start=11044,
+  serialized_end=11083,
 )
 
 _MASTERCOMPONENTINFO_DICTIONARYINFO = _descriptor.Descriptor(
@@ -4013,8 +4020,49 @@ _MASTERCOMPONENTINFO_DICTIONARYINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11009,
-  serialized_end=11062,
+  serialized_start=11085,
+  serialized_end=11138,
+)
+
+_MASTERCOMPONENTINFO_BATCHINFO = _descriptor.Descriptor(
+  name='BatchInfo',
+  full_name='artm.MasterComponentInfo.BatchInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='artm.MasterComponentInfo.BatchInfo.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=unicode("", "utf-8"),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='items_count', full_name='artm.MasterComponentInfo.BatchInfo.items_count', index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='token_count', full_name='artm.MasterComponentInfo.BatchInfo.token_count', index=2,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=11140,
+  serialized_end=11207,
 )
 
 _MASTERCOMPONENTINFO_MODELINFO = _descriptor.Descriptor(
@@ -4061,8 +4109,8 @@ _MASTERCOMPONENTINFO_MODELINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11064,
-  serialized_end=11146,
+  serialized_start=11209,
+  serialized_end=11291,
 )
 
 _MASTERCOMPONENTINFO_CACHEENTRYINFO = _descriptor.Descriptor(
@@ -4095,8 +4143,8 @@ _MASTERCOMPONENTINFO_CACHEENTRYINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11148,
-  serialized_end=11196,
+  serialized_start=11293,
+  serialized_end=11341,
 )
 
 _MASTERCOMPONENTINFO = _descriptor.Descriptor(
@@ -4169,17 +4217,87 @@ _MASTERCOMPONENTINFO = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='batch', full_name='artm.MasterComponentInfo.batch', index=9,
+      number=10, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
-  nested_types=[_MASTERCOMPONENTINFO_REGULARIZERINFO, _MASTERCOMPONENTINFO_SCOREINFO, _MASTERCOMPONENTINFO_DICTIONARYINFO, _MASTERCOMPONENTINFO_MODELINFO, _MASTERCOMPONENTINFO_CACHEENTRYINFO, ],
+  nested_types=[_MASTERCOMPONENTINFO_REGULARIZERINFO, _MASTERCOMPONENTINFO_SCOREINFO, _MASTERCOMPONENTINFO_DICTIONARYINFO, _MASTERCOMPONENTINFO_BATCHINFO, _MASTERCOMPONENTINFO_MODELINFO, _MASTERCOMPONENTINFO_CACHEENTRYINFO, ],
   enum_types=[
   ],
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10484,
-  serialized_end=11196,
+  serialized_start=10508,
+  serialized_end=11341,
+)
+
+
+_IMPORTBATCHESARGS = _descriptor.Descriptor(
+  name='ImportBatchesArgs',
+  full_name='artm.ImportBatchesArgs',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='batch_name', full_name='artm.ImportBatchesArgs.batch_name', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='batch', full_name='artm.ImportBatchesArgs.batch', index=1,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=11343,
+  serialized_end=11410,
+)
+
+
+_DISPOSEBATCHESARGS = _descriptor.Descriptor(
+  name='DisposeBatchesArgs',
+  full_name='artm.DisposeBatchesArgs',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='batch_name', full_name='artm.DisposeBatchesArgs.batch_name', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=11412,
+  serialized_end=11452,
 )
 
 _ITEM.fields_by_name['field'].message_type = _FIELD
@@ -4245,6 +4363,7 @@ _COPYREQUESTRESULTARGS_REQUESTTYPE.containing_type = _COPYREQUESTRESULTARGS;
 _MASTERCOMPONENTINFO_REGULARIZERINFO.containing_type = _MASTERCOMPONENTINFO;
 _MASTERCOMPONENTINFO_SCOREINFO.containing_type = _MASTERCOMPONENTINFO;
 _MASTERCOMPONENTINFO_DICTIONARYINFO.containing_type = _MASTERCOMPONENTINFO;
+_MASTERCOMPONENTINFO_BATCHINFO.containing_type = _MASTERCOMPONENTINFO;
 _MASTERCOMPONENTINFO_MODELINFO.containing_type = _MASTERCOMPONENTINFO;
 _MASTERCOMPONENTINFO_CACHEENTRYINFO.containing_type = _MASTERCOMPONENTINFO;
 _MASTERCOMPONENTINFO.fields_by_name['config'].message_type = _MASTERCOMPONENTCONFIG
@@ -4253,6 +4372,8 @@ _MASTERCOMPONENTINFO.fields_by_name['score'].message_type = _MASTERCOMPONENTINFO
 _MASTERCOMPONENTINFO.fields_by_name['dictionary'].message_type = _MASTERCOMPONENTINFO_DICTIONARYINFO
 _MASTERCOMPONENTINFO.fields_by_name['model'].message_type = _MASTERCOMPONENTINFO_MODELINFO
 _MASTERCOMPONENTINFO.fields_by_name['cache_entry'].message_type = _MASTERCOMPONENTINFO_CACHEENTRYINFO
+_MASTERCOMPONENTINFO.fields_by_name['batch'].message_type = _MASTERCOMPONENTINFO_BATCHINFO
+_IMPORTBATCHESARGS.fields_by_name['batch'].message_type = _BATCH
 DESCRIPTOR.message_types_by_name['DoubleArray'] = _DOUBLEARRAY
 DESCRIPTOR.message_types_by_name['FloatArray'] = _FLOATARRAY
 DESCRIPTOR.message_types_by_name['BoolArray'] = _BOOLARRAY
@@ -4320,6 +4441,8 @@ DESCRIPTOR.message_types_by_name['CopyRequestResultArgs'] = _COPYREQUESTRESULTAR
 DESCRIPTOR.message_types_by_name['DuplicateMasterComponentArgs'] = _DUPLICATEMASTERCOMPONENTARGS
 DESCRIPTOR.message_types_by_name['GetMasterComponentInfoArgs'] = _GETMASTERCOMPONENTINFOARGS
 DESCRIPTOR.message_types_by_name['MasterComponentInfo'] = _MASTERCOMPONENTINFO
+DESCRIPTOR.message_types_by_name['ImportBatchesArgs'] = _IMPORTBATCHESARGS
+DESCRIPTOR.message_types_by_name['DisposeBatchesArgs'] = _DISPOSEBATCHESARGS
 
 class DoubleArray(_message.Message):
   __metaclass__ = _reflection.GeneratedProtocolMessageType
@@ -4750,6 +4873,12 @@ class MasterComponentInfo(_message.Message):
 
     # @@protoc_insertion_point(class_scope:artm.MasterComponentInfo.DictionaryInfo)
 
+  class BatchInfo(_message.Message):
+    __metaclass__ = _reflection.GeneratedProtocolMessageType
+    DESCRIPTOR = _MASTERCOMPONENTINFO_BATCHINFO
+
+    # @@protoc_insertion_point(class_scope:artm.MasterComponentInfo.BatchInfo)
+
   class ModelInfo(_message.Message):
     __metaclass__ = _reflection.GeneratedProtocolMessageType
     DESCRIPTOR = _MASTERCOMPONENTINFO_MODELINFO
@@ -4764,6 +4893,18 @@ class MasterComponentInfo(_message.Message):
   DESCRIPTOR = _MASTERCOMPONENTINFO
 
   # @@protoc_insertion_point(class_scope:artm.MasterComponentInfo)
+
+class ImportBatchesArgs(_message.Message):
+  __metaclass__ = _reflection.GeneratedProtocolMessageType
+  DESCRIPTOR = _IMPORTBATCHESARGS
+
+  # @@protoc_insertion_point(class_scope:artm.ImportBatchesArgs)
+
+class DisposeBatchesArgs(_message.Message):
+  __metaclass__ = _reflection.GeneratedProtocolMessageType
+  DESCRIPTOR = _DISPOSEBATCHESARGS
+
+  # @@protoc_insertion_point(class_scope:artm.DisposeBatchesArgs)
 
 
 _DOUBLEARRAY.fields_by_name['value'].has_options = True

--- a/python/artm/wrapper/messages_pb2.py
+++ b/python/artm/wrapper/messages_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import descriptor_pb2
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='artm/messages.proto',
   package='artm',
-  serialized_pb='\n\x13\x61rtm/messages.proto\x12\x04\x61rtm\" \n\x0b\x44oubleArray\x12\x11\n\x05value\x18\x01 \x03(\x01\x42\x02\x10\x01\"\x1f\n\nFloatArray\x12\x11\n\x05value\x18\x01 \x03(\x02\x42\x02\x10\x01\"\x1e\n\tBoolArray\x12\x11\n\x05value\x18\x01 \x03(\x08\x42\x02\x10\x01\"\x1d\n\x08IntArray\x12\x11\n\x05value\x18\x01 \x03(\x05\x42\x02\x10\x01\"\x1c\n\x0bStringArray\x12\r\n\x05value\x18\x01 \x03(\t\"=\n\x04Item\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x05\x66ield\x18\x02 \x03(\x0b\x32\x0b.artm.Field\x12\r\n\x05title\x18\x03 \x01(\t\"\x95\x02\n\x05\x46ield\x12\x13\n\x04name\x18\x01 \x01(\t:\x05@body\x12\x10\n\x08token_id\x18\x02 \x03(\x05\x12\x13\n\x0btoken_count\x18\x03 \x03(\x05\x12\x14\n\x0ctoken_offset\x18\x04 \x03(\x05\x12\x14\n\x0cstring_value\x18\x05 \x01(\t\x12\x11\n\tint_value\x18\x06 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x07 \x01(\x01\x12\x12\n\ndate_value\x18\x08 \x01(\t\x12\x14\n\x0cstring_array\x18\x10 \x03(\t\x12\x11\n\tint_array\x18\x11 \x03(\x03\x12\x14\n\x0c\x64ouble_array\x18\x12 \x03(\x01\x12\x12\n\ndate_array\x18\x13 \x03(\t\x12\x14\n\x0ctoken_weight\x18\x14 \x03(\x02\"c\n\x05\x42\x61tch\x12\r\n\x05token\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x18\n\x04item\x18\x03 \x03(\x0b\x32\n.artm.Item\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\"\x93\x01\n\x06Stream\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x11.artm.Stream.Type:\x06Global\x12\x15\n\x04name\x18\x02 \x01(\t:\x07@global\x12\x0f\n\x07modulus\x18\x03 \x01(\x05\x12\x11\n\tresiduals\x18\x04 \x03(\x05\"%\n\x04Type\x12\n\n\x06Global\x10\x00\x12\x11\n\rItemIdModulus\x10\x01\"\xd0\x02\n\x15MasterComponentConfig\x12\x11\n\tdisk_path\x18\x02 \x01(\t\x12\x1c\n\x06stream\x18\x03 \x03(\x0b\x32\x0c.artm.Stream\x12\x1d\n\x0f\x63ompact_batches\x18\x04 \x01(\x08:\x04true\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10processors_count\x18\x06 \x01(\x05\x12$\n\x18processor_queue_max_size\x18\x07 \x01(\x05:\x02\x31\x30\x12!\n\x15merger_queue_max_size\x18\x08 \x01(\x05:\x02\x31\x30\x12\'\n\x0cscore_config\x18\t \x03(\x0b\x32\x11.artm.ScoreConfig\x12&\n\x17online_batch_processing\x18\r \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x64isk_cache_path\x18\x0f \x01(\t\"d\n\x13RegularizerSettings\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03tau\x18\x02 \x01(\x01\x12#\n\x1buse_relative_regularization\x18\x03 \x01(\x08\x12\r\n\x05gamma\x18\x04 \x01(\x01\"\xa1\x04\n\x0bModelConfig\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x18\n\x0ctopics_count\x18\x02 \x01(\x05:\x02\x33\x32\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x15\n\x07\x65nabled\x18\x04 \x01(\x08:\x04true\x12\"\n\x16inner_iterations_count\x18\x05 \x01(\x05:\x02\x31\x30\x12\x19\n\nfield_name\x18\x06 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x07 \x01(\t:\x07@global\x12\x12\n\nscore_name\x18\x08 \x03(\t\x12\x1a\n\x0breuse_theta\x18\t \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10regularizer_name\x18\n \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x0b \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x0c \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\r \x03(\x02\x12\x1c\n\x0euse_sparse_bow\x18\x0e \x01(\x08:\x04true\x12\x1f\n\x10use_random_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\x12\x1c\n\x0euse_new_tokens\x18\x10 \x01(\x08:\x04true\x12\x19\n\x0bopt_for_avx\x18\x11 \x01(\x08:\x04true\x12\x37\n\x14regularizer_settings\x18\x12 \x03(\x0b\x32\x19.artm.RegularizerSettings\x12\x1e\n\x0fuse_ptdw_matrix\x18\x13 \x01(\x08:\x05\x66\x61lse\"\x8a\x02\n\x11RegularizerConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\x04type\x18\x02 \x01(\x0e\x32\x1c.artm.RegularizerConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\xaa\x01\n\x04Type\x12\x15\n\x11SmoothSparseTheta\x10\x00\x12\x13\n\x0fSmoothSparsePhi\x10\x01\x12\x13\n\x0f\x44\x65\x63orrelatorPhi\x10\x02\x12\x14\n\x10MultiLanguagePhi\x10\x03\x12\x1a\n\x16LabelRegularizationPhi\x10\x04\x12\x16\n\x12SpecifiedSparsePhi\x10\x05\x12\x17\n\x13ImproveCoherencePhi\x10\x06\"A\n\x17SmoothSparseThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x12\n\nalpha_iter\x18\x02 \x03(\x02\"V\n\x15SmoothSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"=\n\x15\x44\x65\x63orrelatorPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\"\x18\n\x16MultiLanguagePhiConfig\"]\n\x1cLabelRegularizationPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x82\x02\n\x18SpecifiedSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x1e\n\x12max_elements_count\x18\x03 \x01(\x05:\x02\x32\x30\x12#\n\x15probability_threshold\x18\x04 \x01(\x02:\x04\x30.99\x12?\n\x04mode\x18\x05 \x01(\x0e\x32#.artm.SpecifiedSparsePhiConfig.Mode:\x0cSparseTopics\"*\n\x04Mode\x12\x10\n\x0cSparseTopics\x10\x00\x12\x10\n\x0cSparseTokens\x10\x01\"Z\n\x19ImproveCoherencePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x87\x01\n\x18RegularizerInternalState\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.artm.RegularizerInternalState.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x1c\n\x04Type\x12\x14\n\x10MultiLanguagePhi\x10\x03\"C\n\x1dMultiLanguagePhiInternalState\x12\"\n\x17no_regularization_calls\x18\x01 \x01(\x05:\x01\x30\"\xd1\x01\n\x10\x44ictionaryConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x05\x65ntry\x18\x02 \x03(\x0b\x32\x15.artm.DictionaryEntry\x12\x19\n\x11total_token_count\x18\x03 \x01(\x05\x12\x19\n\x11total_items_count\x18\x04 \x01(\x05\x12\x37\n\x0c\x63ooc_entries\x18\x05 \x01(\x0b\x32!.artm.DictionaryCoocurenceEntries\x12\x1a\n\x12total_token_weight\x18\x06 \x01(\x02\"\xbd\x01\n\x0f\x44ictionaryEntry\x12\x11\n\tkey_token\x18\x01 \x01(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x02\x12\x14\n\x0cvalue_tokens\x18\x04 \x03(\t\x12 \n\x06values\x18\x05 \x01(\x0b\x32\x10.artm.FloatArray\x12\x13\n\x0btoken_count\x18\x06 \x01(\x05\x12\x13\n\x0bitems_count\x18\x07 \x01(\x05\x12\x14\n\x0ctoken_weight\x18\x08 \x01(\x02\"}\n\x1b\x44ictionaryCoocurenceEntries\x12\x13\n\x0b\x66irst_index\x18\x01 \x03(\x05\x12\x14\n\x0csecond_index\x18\x02 \x03(\x05\x12\r\n\x05value\x18\x03 \x03(\x02\x12$\n\x15symmetric_cooc_values\x18\x04 \x01(\x08:\x05\x66\x61lse\"\xe6\x01\n\x0bScoreConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x04type\x18\x02 \x01(\x0e\x32\x16.artm.ScoreConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xe0\x01\n\tScoreData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x04type\x18\x02 \x01(\x0e\x32\x14.artm.ScoreData.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xcc\x02\n\x15PerplexityScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12J\n\nmodel_type\x18\x03 \x01(\x0e\x32 .artm.PerplexityScoreConfig.Type:\x14UnigramDocumentModel\x12\x17\n\x0f\x64ictionary_name\x18\x04 \x01(\t\x12\"\n\x12theta_sparsity_eps\x18\x05 \x01(\x02:\x06\x31\x65-037\x12!\n\x19theta_sparsity_topic_name\x18\x06 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x07 \x03(\t\"<\n\x04Type\x12\x18\n\x14UnigramDocumentModel\x10\x00\x12\x1a\n\x16UnigramCollectionModel\x10\x01\"\xbc\x01\n\x0fPerplexityScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x0b\n\x03raw\x18\x02 \x01(\x01\x12\x12\n\nnormalizer\x18\x03 \x01(\x01\x12\x12\n\nzero_words\x18\x04 \x01(\x05\x12\x1c\n\x14theta_sparsity_value\x18\x05 \x01(\x01\x12\"\n\x1atheta_sparsity_zero_topics\x18\x06 \x01(\x05\x12#\n\x1btheta_sparsity_total_topics\x18\x07 \x01(\x05\"|\n\x18SparsityThetaScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x03\x65ps\x18\x03 \x01(\x02:\x06\x31\x65-037\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"N\n\x12SparsityThetaScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_topics\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_topics\x18\x03 \x01(\x05\"c\n\x16SparsityPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"L\n\x10SparsityPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_tokens\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x05\"T\n\x19ItemsProcessedScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\"$\n\x13ItemsProcessedScore\x12\r\n\x05value\x18\x01 \x01(\x05\"\x8a\x01\n\x14TopTokensScoreConfig\x12\x16\n\nnum_tokens\x18\x01 \x01(\x05:\x02\x31\x30\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x04 \x01(\t\"\xad\x01\n\x0eTopTokensScore\x12\x13\n\x0bnum_entries\x18\x01 \x01(\x05\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_index\x18\x03 \x03(\x05\x12\r\n\x05token\x18\x04 \x03(\t\x12\x0e\n\x06weight\x18\x05 \x03(\x02\x12#\n\tcoherence\x18\x06 \x01(\x0b\x32\x10.artm.FloatArray\x12\x19\n\x11\x61verage_coherence\x18\x07 \x01(\x02\"\x7f\n\x17ThetaSnippetScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x07item_id\x18\x03 \x03(\x05\x42\x02\x10\x01\x12\x16\n\nitem_count\x18\x04 \x01(\x05:\x02\x31\x30\"F\n\x11ThetaSnippetScore\x12\x0f\n\x07item_id\x18\x01 \x03(\x05\x12 \n\x06values\x18\x02 \x03(\x0b\x32\x10.artm.FloatArray\"\xb2\x01\n\x16TopicKernelScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\'\n\x1aprobability_mass_threshold\x18\x04 \x01(\x01:\x03\x30.1\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x05 \x01(\t\"\xff\x02\n\x10TopicKernelScore\x12&\n\x0bkernel_size\x18\x01 \x01(\x0b\x32\x11.artm.DoubleArray\x12(\n\rkernel_purity\x18\x02 \x01(\x0b\x32\x11.artm.DoubleArray\x12*\n\x0fkernel_contrast\x18\x03 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x1b\n\x13\x61verage_kernel_size\x18\x04 \x01(\x01\x12\x1d\n\x15\x61verage_kernel_purity\x18\x05 \x01(\x01\x12\x1f\n\x17\x61verage_kernel_contrast\x18\x06 \x01(\x01\x12$\n\tcoherence\x18\x07 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x19\n\x11\x61verage_coherence\x18\x08 \x01(\x02\x12(\n\rkernel_tokens\x18\t \x03(\x0b\x32\x11.artm.StringArray\x12%\n\ntopic_name\x18\n \x01(\x0b\x32\x11.artm.StringArray\"d\n\x17TopicMassPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"_\n\x11TopicMassPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_ratio\x18\x03 \x03(\x01\x12\x12\n\ntopic_mass\x18\x04 \x03(\x01\"\x94\x03\n\nTopicModel\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x14\n\x0ctopics_count\x18\x02 \x01(\x05\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\r\n\x05token\x18\x04 \x03(\t\x12\'\n\rtoken_weights\x18\x05 \x03(\x0b\x32\x10.artm.FloatArray\x12\x10\n\x08\x63lass_id\x18\x06 \x03(\t\x12\x11\n\tinternals\x18\x07 \x01(\x0c\x12#\n\x0btopic_index\x18\x08 \x03(\x0b\x32\x0e.artm.IntArray\x12\x36\n\x0eoperation_type\x18\t \x03(\x0e\x32\x1e.artm.TopicModel.OperationType\x1a\x35\n\x13TopicModelInternals\x12\x1e\n\x04n_wt\x18\x01 \x03(\x0b\x32\x10.artm.FloatArray\"U\n\rOperationType\x12\x0e\n\nInitialize\x10\x00\x12\r\n\tIncrement\x10\x01\x12\r\n\tOverwrite\x10\x02\x12\n\n\x06Remove\x10\x03\x12\n\n\x06Ignore\x10\x04\"\xc5\x01\n\x0bThetaMatrix\x12\x1a\n\nmodel_name\x18\x01 \x01(\t:\x06@model\x12\x0f\n\x07item_id\x18\x02 \x03(\x05\x12&\n\x0citem_weights\x18\x03 \x03(\x0b\x32\x10.artm.FloatArray\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x14\n\x0ctopics_count\x18\x05 \x01(\x05\x12\x12\n\nitem_title\x18\x06 \x03(\t\x12#\n\x0btopic_index\x18\x07 \x03(\x0b\x32\x0e.artm.IntArray\"\xe3\x03\n\x16\x43ollectionParserConfig\x12\x42\n\x06\x66ormat\x18\x01 \x01(\x0e\x32#.artm.CollectionParserConfig.Format:\rBagOfWordsUci\x12\x19\n\x11\x64ocword_file_path\x18\x02 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x03 \x01(\t\x12\x15\n\rtarget_folder\x18\x04 \x01(\t\x12\x1c\n\x14\x64ictionary_file_name\x18\x05 \x01(\t\x12!\n\x13num_items_per_batch\x18\x06 \x01(\x05:\x04\x31\x30\x30\x30\x12\x1a\n\x12\x63ooccurrence_token\x18\x07 \x03(\t\x12%\n\x17use_unity_based_indices\x18\x08 \x01(\x08:\x04true\x12\x1a\n\x0bgather_cooc\x18\t \x01(\x08:\x05\x66\x61lse\x12\x1d\n\x15\x63ooccurrence_class_id\x18\n \x03(\t\x12(\n\x19use_symmetric_cooc_values\x18\x0b \x01(\x08:\x05\x66\x61lse\"Q\n\x06\x46ormat\x12\x11\n\rBagOfWordsUci\x10\x00\x12\x10\n\x0cMatrixMarket\x10\x01\x12\x10\n\x0cVowpalWabbit\x10\x02\x12\x10\n\x0c\x43ooccurrence\x10\x03\"\x7f\n\x14SynchronizeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0c\x64\x65\x63\x61y_weight\x18\x02 \x01(\x02:\x01\x30\x12!\n\x13invoke_regularizers\x18\x03 \x01(\x08:\x04true\x12\x17\n\x0c\x61pply_weight\x18\x04 \x01(\x02:\x01\x31\"\xcb\x03\n\x13InitializeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\x12\x45\n\x0bsource_type\x18\x03 \x01(\x0e\x32$.artm.InitializeModelArgs.SourceType:\nDictionary\x12\x11\n\tdisk_path\x18\x04 \x01(\t\x12\x30\n\x06\x66ilter\x18\x05 \x03(\x0b\x32 .artm.InitializeModelArgs.Filter\x12\x14\n\x0ctopics_count\x18\x06 \x01(\x05\x12\x12\n\ntopic_name\x18\x07 \x03(\t\x1a\xa5\x01\n\x06\x46ilter\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\t\x12\x16\n\x0emin_percentage\x18\x02 \x01(\x02\x12\x16\n\x0emax_percentage\x18\x03 \x01(\x02\x12\x11\n\tmin_items\x18\x04 \x01(\x05\x12\x11\n\tmax_items\x18\x05 \x01(\x05\x12\x17\n\x0fmin_total_count\x18\x06 \x01(\x05\x12\x1a\n\x12min_one_item_count\x18\x07 \x01(\x05\")\n\nSourceType\x12\x0e\n\nDictionary\x10\x00\x12\x0b\n\x07\x42\x61tches\x10\x01\"\xf4\x02\n\x11GetTopicModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\r\n\x05token\x18\x03 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x03(\t\x12\x19\n\x11use_sparse_format\x18\x05 \x01(\x08\x12\x13\n\x03\x65ps\x18\x06 \x01(\x02:\x06\x31\x65-037\x12>\n\x0crequest_type\x18\x07 \x01(\x0e\x32#.artm.GetTopicModelArgs.RequestType:\x03Pwt\x12\x42\n\rmatrix_layout\x18\x08 \x01(\x0e\x32$.artm.GetTopicModelArgs.MatrixLayout:\x05\x44\x65nse\";\n\x0bRequestType\x12\x07\n\x03Pwt\x10\x00\x12\x07\n\x03Nwt\x10\x01\x12\x0e\n\nTopicNames\x10\x02\x12\n\n\x06Tokens\x10\x03\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"\xa5\x02\n\x12GetThetaMatrixArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x02 \x01(\x0b\x32\x0b.artm.Batch\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x13\n\x0btopic_index\x18\x04 \x03(\x05\x12\x1a\n\x0b\x63lean_cache\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11use_sparse_format\x18\x06 \x01(\x08\x12\x13\n\x03\x65ps\x18\x07 \x01(\x02:\x06\x31\x65-037\x12\x43\n\rmatrix_layout\x18\x08 \x01(\x0e\x32%.artm.GetThetaMatrixArgs.MatrixLayout:\x05\x44\x65nse\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"W\n\x11GetScoreValueArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\nscore_name\x18\x02 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x01(\x0b\x32\x0b.artm.Batch\"\x82\x01\n\x0c\x41\x64\x64\x42\x61tchArgs\x12\x1a\n\x05\x62\x61tch\x18\x01 \x01(\x0b\x32\x0b.artm.Batch\x12 \n\x14timeout_milliseconds\x18\x02 \x01(\x05:\x02-1\x12\x1b\n\x0creset_scores\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x62\x61tch_file_name\x18\x04 \x01(\t\"a\n\x13InvokeIterationArgs\x12\x1b\n\x10iterations_count\x18\x01 \x01(\x05:\x01\x31\x12\x1a\n\x0creset_scores\x18\x02 \x01(\x08:\x04true\x12\x11\n\tdisk_path\x18\x03 \x01(\t\"0\n\x0cWaitIdleArgs\x12 \n\x14timeout_milliseconds\x18\x01 \x01(\x05:\x02-1\"8\n\x0f\x45xportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"8\n\x0fImportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"%\n\x0f\x41ttachModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\"\xad\x04\n\x12ProcessBatchesArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12\x17\n\x0fpwt_source_name\x18\x03 \x01(\t\x12\"\n\x16inner_iterations_count\x18\x04 \x01(\x05:\x02\x31\x30\x12\x1c\n\x0bstream_name\x18\x05 \x01(\t:\x07@global\x12\x18\n\x10regularizer_name\x18\x06 \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x07 \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x08 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\t \x03(\x02\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12\x1a\n\x0creset_scores\x18\r \x01(\x08:\x04true\x12J\n\x11theta_matrix_type\x18\x0e \x01(\x0e\x32(.artm.ProcessBatchesArgs.ThetaMatrixType:\x05\x43\x61\x63he\x12\x14\n\x0c\x62\x61tch_weight\x18\x0f \x03(\x02\x12\x1e\n\x0fuse_ptdw_matrix\x18\x10 \x01(\x08:\x05\x66\x61lse\"=\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\"d\n\x14ProcessBatchesResult\x12#\n\nscore_data\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\x12\'\n\x0ctheta_matrix\x18\x02 \x01(\x0b\x32\x11.artm.ThetaMatrix\"m\n\x0eMergeModelArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x03(\t\x12\x15\n\rsource_weight\x18\x03 \x03(\x02\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"\x99\x01\n\x13RegularizeModelArgs\x12\x17\n\x0frwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fpwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x03 \x01(\t\x12\x37\n\x14regularizer_settings\x18\x04 \x03(\x0b\x32\x19.artm.RegularizerSettings\"_\n\x12NormalizeModelArgs\x12\x17\n\x0fpwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0frwt_source_name\x18\x03 \x01(\t\"B\n\x14ImportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"\xc1\x01\n\x15\x43opyRequestResultArgs\x12Q\n\x0crequest_type\x18\x01 \x01(\x0e\x32\'.artm.CopyRequestResultArgs.RequestType:\x12\x44\x65\x66\x61ultRequestType\"U\n\x0bRequestType\x12\x16\n\x12\x44\x65\x66\x61ultRequestType\x10\x00\x12\x16\n\x12GetThetaSecondPass\x10\x01\x12\x16\n\x12GetModelSecondPass\x10\x02\"\x1e\n\x1c\x44uplicateMasterComponentArgs\"\x1c\n\x1aGetMasterComponentInfoArgs\"\xc8\x05\n\x13MasterComponentInfo\x12\x11\n\tmaster_id\x18\x01 \x01(\x05\x12+\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x1b.artm.MasterComponentConfig\x12>\n\x0bregularizer\x18\x03 \x03(\x0b\x32).artm.MasterComponentInfo.RegularizerInfo\x12\x32\n\x05score\x18\x04 \x03(\x0b\x32#.artm.MasterComponentInfo.ScoreInfo\x12<\n\ndictionary\x18\x05 \x03(\x0b\x32(.artm.MasterComponentInfo.DictionaryInfo\x12\x32\n\x05model\x18\x06 \x03(\x0b\x32#.artm.MasterComponentInfo.ModelInfo\x12=\n\x0b\x63\x61\x63he_entry\x18\x07 \x03(\x0b\x32(.artm.MasterComponentInfo.CacheEntryInfo\x12\x19\n\x11merger_queue_size\x18\x08 \x01(\x05\x12\x1c\n\x14processor_queue_size\x18\t \x01(\x05\x1a-\n\x0fRegularizerInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\'\n\tScoreInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\x35\n\x0e\x44ictionaryInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rentries_count\x18\x02 \x01(\x03\x1aR\n\tModelInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x13\n\x0btoken_count\x18\x04 \x01(\x05\x1a\x30\n\x0e\x43\x61\x63heEntryInfo\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tbyte_size\x18\x02 \x01(\x05')
+  serialized_pb='\n\x13\x61rtm/messages.proto\x12\x04\x61rtm\" \n\x0b\x44oubleArray\x12\x11\n\x05value\x18\x01 \x03(\x01\x42\x02\x10\x01\"\x1f\n\nFloatArray\x12\x11\n\x05value\x18\x01 \x03(\x02\x42\x02\x10\x01\"\x1e\n\tBoolArray\x12\x11\n\x05value\x18\x01 \x03(\x08\x42\x02\x10\x01\"\x1d\n\x08IntArray\x12\x11\n\x05value\x18\x01 \x03(\x05\x42\x02\x10\x01\"\x1c\n\x0bStringArray\x12\r\n\x05value\x18\x01 \x03(\t\"=\n\x04Item\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x05\x66ield\x18\x02 \x03(\x0b\x32\x0b.artm.Field\x12\r\n\x05title\x18\x03 \x01(\t\"\x95\x02\n\x05\x46ield\x12\x13\n\x04name\x18\x01 \x01(\t:\x05@body\x12\x10\n\x08token_id\x18\x02 \x03(\x05\x12\x13\n\x0btoken_count\x18\x03 \x03(\x05\x12\x14\n\x0ctoken_offset\x18\x04 \x03(\x05\x12\x14\n\x0cstring_value\x18\x05 \x01(\t\x12\x11\n\tint_value\x18\x06 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x07 \x01(\x01\x12\x12\n\ndate_value\x18\x08 \x01(\t\x12\x14\n\x0cstring_array\x18\x10 \x03(\t\x12\x11\n\tint_array\x18\x11 \x03(\x03\x12\x14\n\x0c\x64ouble_array\x18\x12 \x03(\x01\x12\x12\n\ndate_array\x18\x13 \x03(\t\x12\x14\n\x0ctoken_weight\x18\x14 \x03(\x02\"c\n\x05\x42\x61tch\x12\r\n\x05token\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x18\n\x04item\x18\x03 \x03(\x0b\x32\n.artm.Item\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\"\x93\x01\n\x06Stream\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x11.artm.Stream.Type:\x06Global\x12\x15\n\x04name\x18\x02 \x01(\t:\x07@global\x12\x0f\n\x07modulus\x18\x03 \x01(\x05\x12\x11\n\tresiduals\x18\x04 \x03(\x05\"%\n\x04Type\x12\n\n\x06Global\x10\x00\x12\x11\n\rItemIdModulus\x10\x01\"\xd0\x02\n\x15MasterComponentConfig\x12\x11\n\tdisk_path\x18\x02 \x01(\t\x12\x1c\n\x06stream\x18\x03 \x03(\x0b\x32\x0c.artm.Stream\x12\x1d\n\x0f\x63ompact_batches\x18\x04 \x01(\x08:\x04true\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10processors_count\x18\x06 \x01(\x05\x12$\n\x18processor_queue_max_size\x18\x07 \x01(\x05:\x02\x31\x30\x12!\n\x15merger_queue_max_size\x18\x08 \x01(\x05:\x02\x31\x30\x12\'\n\x0cscore_config\x18\t \x03(\x0b\x32\x11.artm.ScoreConfig\x12&\n\x17online_batch_processing\x18\r \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x64isk_cache_path\x18\x0f \x01(\t\"d\n\x13RegularizerSettings\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03tau\x18\x02 \x01(\x01\x12#\n\x1buse_relative_regularization\x18\x03 \x01(\x08\x12\r\n\x05gamma\x18\x04 \x01(\x01\"\xa1\x04\n\x0bModelConfig\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x18\n\x0ctopics_count\x18\x02 \x01(\x05:\x02\x33\x32\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x15\n\x07\x65nabled\x18\x04 \x01(\x08:\x04true\x12\"\n\x16inner_iterations_count\x18\x05 \x01(\x05:\x02\x31\x30\x12\x19\n\nfield_name\x18\x06 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x07 \x01(\t:\x07@global\x12\x12\n\nscore_name\x18\x08 \x03(\t\x12\x1a\n\x0breuse_theta\x18\t \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10regularizer_name\x18\n \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x0b \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x0c \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\r \x03(\x02\x12\x1c\n\x0euse_sparse_bow\x18\x0e \x01(\x08:\x04true\x12\x1f\n\x10use_random_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\x12\x1c\n\x0euse_new_tokens\x18\x10 \x01(\x08:\x04true\x12\x19\n\x0bopt_for_avx\x18\x11 \x01(\x08:\x04true\x12\x37\n\x14regularizer_settings\x18\x12 \x03(\x0b\x32\x19.artm.RegularizerSettings\x12\x1e\n\x0fuse_ptdw_matrix\x18\x13 \x01(\x08:\x05\x66\x61lse\"\x8a\x02\n\x11RegularizerConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\x04type\x18\x02 \x01(\x0e\x32\x1c.artm.RegularizerConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\xaa\x01\n\x04Type\x12\x15\n\x11SmoothSparseTheta\x10\x00\x12\x13\n\x0fSmoothSparsePhi\x10\x01\x12\x13\n\x0f\x44\x65\x63orrelatorPhi\x10\x02\x12\x14\n\x10MultiLanguagePhi\x10\x03\x12\x1a\n\x16LabelRegularizationPhi\x10\x04\x12\x16\n\x12SpecifiedSparsePhi\x10\x05\x12\x17\n\x13ImproveCoherencePhi\x10\x06\"A\n\x17SmoothSparseThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x12\n\nalpha_iter\x18\x02 \x03(\x02\"V\n\x15SmoothSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"=\n\x15\x44\x65\x63orrelatorPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\"\x18\n\x16MultiLanguagePhiConfig\"]\n\x1cLabelRegularizationPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x82\x02\n\x18SpecifiedSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x1e\n\x12max_elements_count\x18\x03 \x01(\x05:\x02\x32\x30\x12#\n\x15probability_threshold\x18\x04 \x01(\x02:\x04\x30.99\x12?\n\x04mode\x18\x05 \x01(\x0e\x32#.artm.SpecifiedSparsePhiConfig.Mode:\x0cSparseTopics\"*\n\x04Mode\x12\x10\n\x0cSparseTopics\x10\x00\x12\x10\n\x0cSparseTokens\x10\x01\"Z\n\x19ImproveCoherencePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x87\x01\n\x18RegularizerInternalState\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.artm.RegularizerInternalState.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x1c\n\x04Type\x12\x14\n\x10MultiLanguagePhi\x10\x03\"C\n\x1dMultiLanguagePhiInternalState\x12\"\n\x17no_regularization_calls\x18\x01 \x01(\x05:\x01\x30\"\xd1\x01\n\x10\x44ictionaryConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x05\x65ntry\x18\x02 \x03(\x0b\x32\x15.artm.DictionaryEntry\x12\x19\n\x11total_token_count\x18\x03 \x01(\x05\x12\x19\n\x11total_items_count\x18\x04 \x01(\x05\x12\x37\n\x0c\x63ooc_entries\x18\x05 \x01(\x0b\x32!.artm.DictionaryCoocurenceEntries\x12\x1a\n\x12total_token_weight\x18\x06 \x01(\x02\"\xbd\x01\n\x0f\x44ictionaryEntry\x12\x11\n\tkey_token\x18\x01 \x01(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x02\x12\x14\n\x0cvalue_tokens\x18\x04 \x03(\t\x12 \n\x06values\x18\x05 \x01(\x0b\x32\x10.artm.FloatArray\x12\x13\n\x0btoken_count\x18\x06 \x01(\x05\x12\x13\n\x0bitems_count\x18\x07 \x01(\x05\x12\x14\n\x0ctoken_weight\x18\x08 \x01(\x02\"}\n\x1b\x44ictionaryCoocurenceEntries\x12\x13\n\x0b\x66irst_index\x18\x01 \x03(\x05\x12\x14\n\x0csecond_index\x18\x02 \x03(\x05\x12\r\n\x05value\x18\x03 \x03(\x02\x12$\n\x15symmetric_cooc_values\x18\x04 \x01(\x08:\x05\x66\x61lse\"\xe6\x01\n\x0bScoreConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x04type\x18\x02 \x01(\x0e\x32\x16.artm.ScoreConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xe0\x01\n\tScoreData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x04type\x18\x02 \x01(\x0e\x32\x14.artm.ScoreData.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xcc\x02\n\x15PerplexityScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12J\n\nmodel_type\x18\x03 \x01(\x0e\x32 .artm.PerplexityScoreConfig.Type:\x14UnigramDocumentModel\x12\x17\n\x0f\x64ictionary_name\x18\x04 \x01(\t\x12\"\n\x12theta_sparsity_eps\x18\x05 \x01(\x02:\x06\x31\x65-037\x12!\n\x19theta_sparsity_topic_name\x18\x06 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x07 \x03(\t\"<\n\x04Type\x12\x18\n\x14UnigramDocumentModel\x10\x00\x12\x1a\n\x16UnigramCollectionModel\x10\x01\"\xbc\x01\n\x0fPerplexityScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x0b\n\x03raw\x18\x02 \x01(\x01\x12\x12\n\nnormalizer\x18\x03 \x01(\x01\x12\x12\n\nzero_words\x18\x04 \x01(\x05\x12\x1c\n\x14theta_sparsity_value\x18\x05 \x01(\x01\x12\"\n\x1atheta_sparsity_zero_topics\x18\x06 \x01(\x05\x12#\n\x1btheta_sparsity_total_topics\x18\x07 \x01(\x05\"|\n\x18SparsityThetaScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x03\x65ps\x18\x03 \x01(\x02:\x06\x31\x65-037\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"N\n\x12SparsityThetaScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_topics\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_topics\x18\x03 \x01(\x05\"c\n\x16SparsityPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"L\n\x10SparsityPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_tokens\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x05\"T\n\x19ItemsProcessedScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\"$\n\x13ItemsProcessedScore\x12\r\n\x05value\x18\x01 \x01(\x05\"\x8a\x01\n\x14TopTokensScoreConfig\x12\x16\n\nnum_tokens\x18\x01 \x01(\x05:\x02\x31\x30\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x04 \x01(\t\"\xad\x01\n\x0eTopTokensScore\x12\x13\n\x0bnum_entries\x18\x01 \x01(\x05\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_index\x18\x03 \x03(\x05\x12\r\n\x05token\x18\x04 \x03(\t\x12\x0e\n\x06weight\x18\x05 \x03(\x02\x12#\n\tcoherence\x18\x06 \x01(\x0b\x32\x10.artm.FloatArray\x12\x19\n\x11\x61verage_coherence\x18\x07 \x01(\x02\"\x7f\n\x17ThetaSnippetScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x07item_id\x18\x03 \x03(\x05\x42\x02\x10\x01\x12\x16\n\nitem_count\x18\x04 \x01(\x05:\x02\x31\x30\"F\n\x11ThetaSnippetScore\x12\x0f\n\x07item_id\x18\x01 \x03(\x05\x12 \n\x06values\x18\x02 \x03(\x0b\x32\x10.artm.FloatArray\"\xb2\x01\n\x16TopicKernelScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\'\n\x1aprobability_mass_threshold\x18\x04 \x01(\x01:\x03\x30.1\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x05 \x01(\t\"\xff\x02\n\x10TopicKernelScore\x12&\n\x0bkernel_size\x18\x01 \x01(\x0b\x32\x11.artm.DoubleArray\x12(\n\rkernel_purity\x18\x02 \x01(\x0b\x32\x11.artm.DoubleArray\x12*\n\x0fkernel_contrast\x18\x03 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x1b\n\x13\x61verage_kernel_size\x18\x04 \x01(\x01\x12\x1d\n\x15\x61verage_kernel_purity\x18\x05 \x01(\x01\x12\x1f\n\x17\x61verage_kernel_contrast\x18\x06 \x01(\x01\x12$\n\tcoherence\x18\x07 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x19\n\x11\x61verage_coherence\x18\x08 \x01(\x02\x12(\n\rkernel_tokens\x18\t \x03(\x0b\x32\x11.artm.StringArray\x12%\n\ntopic_name\x18\n \x01(\x0b\x32\x11.artm.StringArray\"d\n\x17TopicMassPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"_\n\x11TopicMassPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_ratio\x18\x03 \x03(\x01\x12\x12\n\ntopic_mass\x18\x04 \x03(\x01\"\x94\x03\n\nTopicModel\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x14\n\x0ctopics_count\x18\x02 \x01(\x05\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\r\n\x05token\x18\x04 \x03(\t\x12\'\n\rtoken_weights\x18\x05 \x03(\x0b\x32\x10.artm.FloatArray\x12\x10\n\x08\x63lass_id\x18\x06 \x03(\t\x12\x11\n\tinternals\x18\x07 \x01(\x0c\x12#\n\x0btopic_index\x18\x08 \x03(\x0b\x32\x0e.artm.IntArray\x12\x36\n\x0eoperation_type\x18\t \x03(\x0e\x32\x1e.artm.TopicModel.OperationType\x1a\x35\n\x13TopicModelInternals\x12\x1e\n\x04n_wt\x18\x01 \x03(\x0b\x32\x10.artm.FloatArray\"U\n\rOperationType\x12\x0e\n\nInitialize\x10\x00\x12\r\n\tIncrement\x10\x01\x12\r\n\tOverwrite\x10\x02\x12\n\n\x06Remove\x10\x03\x12\n\n\x06Ignore\x10\x04\"\xc5\x01\n\x0bThetaMatrix\x12\x1a\n\nmodel_name\x18\x01 \x01(\t:\x06@model\x12\x0f\n\x07item_id\x18\x02 \x03(\x05\x12&\n\x0citem_weights\x18\x03 \x03(\x0b\x32\x10.artm.FloatArray\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x14\n\x0ctopics_count\x18\x05 \x01(\x05\x12\x12\n\nitem_title\x18\x06 \x03(\t\x12#\n\x0btopic_index\x18\x07 \x03(\x0b\x32\x0e.artm.IntArray\"\xe3\x03\n\x16\x43ollectionParserConfig\x12\x42\n\x06\x66ormat\x18\x01 \x01(\x0e\x32#.artm.CollectionParserConfig.Format:\rBagOfWordsUci\x12\x19\n\x11\x64ocword_file_path\x18\x02 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x03 \x01(\t\x12\x15\n\rtarget_folder\x18\x04 \x01(\t\x12\x1c\n\x14\x64ictionary_file_name\x18\x05 \x01(\t\x12!\n\x13num_items_per_batch\x18\x06 \x01(\x05:\x04\x31\x30\x30\x30\x12\x1a\n\x12\x63ooccurrence_token\x18\x07 \x03(\t\x12%\n\x17use_unity_based_indices\x18\x08 \x01(\x08:\x04true\x12\x1a\n\x0bgather_cooc\x18\t \x01(\x08:\x05\x66\x61lse\x12\x1d\n\x15\x63ooccurrence_class_id\x18\n \x03(\t\x12(\n\x19use_symmetric_cooc_values\x18\x0b \x01(\x08:\x05\x66\x61lse\"Q\n\x06\x46ormat\x12\x11\n\rBagOfWordsUci\x10\x00\x12\x10\n\x0cMatrixMarket\x10\x01\x12\x10\n\x0cVowpalWabbit\x10\x02\x12\x10\n\x0c\x43ooccurrence\x10\x03\"\x7f\n\x14SynchronizeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0c\x64\x65\x63\x61y_weight\x18\x02 \x01(\x02:\x01\x30\x12!\n\x13invoke_regularizers\x18\x03 \x01(\x08:\x04true\x12\x17\n\x0c\x61pply_weight\x18\x04 \x01(\x02:\x01\x31\"\xe3\x03\n\x13InitializeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\x12\x45\n\x0bsource_type\x18\x03 \x01(\x0e\x32$.artm.InitializeModelArgs.SourceType:\nDictionary\x12\x11\n\tdisk_path\x18\x04 \x01(\t\x12\x30\n\x06\x66ilter\x18\x05 \x03(\x0b\x32 .artm.InitializeModelArgs.Filter\x12\x14\n\x0ctopics_count\x18\x06 \x01(\x05\x12\x12\n\ntopic_name\x18\x07 \x03(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x08 \x03(\t\x1a\xa5\x01\n\x06\x46ilter\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\t\x12\x16\n\x0emin_percentage\x18\x02 \x01(\x02\x12\x16\n\x0emax_percentage\x18\x03 \x01(\x02\x12\x11\n\tmin_items\x18\x04 \x01(\x05\x12\x11\n\tmax_items\x18\x05 \x01(\x05\x12\x17\n\x0fmin_total_count\x18\x06 \x01(\x05\x12\x1a\n\x12min_one_item_count\x18\x07 \x01(\x05\")\n\nSourceType\x12\x0e\n\nDictionary\x10\x00\x12\x0b\n\x07\x42\x61tches\x10\x01\"\xf4\x02\n\x11GetTopicModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\r\n\x05token\x18\x03 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x03(\t\x12\x19\n\x11use_sparse_format\x18\x05 \x01(\x08\x12\x13\n\x03\x65ps\x18\x06 \x01(\x02:\x06\x31\x65-037\x12>\n\x0crequest_type\x18\x07 \x01(\x0e\x32#.artm.GetTopicModelArgs.RequestType:\x03Pwt\x12\x42\n\rmatrix_layout\x18\x08 \x01(\x0e\x32$.artm.GetTopicModelArgs.MatrixLayout:\x05\x44\x65nse\";\n\x0bRequestType\x12\x07\n\x03Pwt\x10\x00\x12\x07\n\x03Nwt\x10\x01\x12\x0e\n\nTopicNames\x10\x02\x12\n\n\x06Tokens\x10\x03\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"\xa5\x02\n\x12GetThetaMatrixArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x02 \x01(\x0b\x32\x0b.artm.Batch\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x13\n\x0btopic_index\x18\x04 \x03(\x05\x12\x1a\n\x0b\x63lean_cache\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11use_sparse_format\x18\x06 \x01(\x08\x12\x13\n\x03\x65ps\x18\x07 \x01(\x02:\x06\x31\x65-037\x12\x43\n\rmatrix_layout\x18\x08 \x01(\x0e\x32%.artm.GetThetaMatrixArgs.MatrixLayout:\x05\x44\x65nse\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"W\n\x11GetScoreValueArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\nscore_name\x18\x02 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x01(\x0b\x32\x0b.artm.Batch\"\x82\x01\n\x0c\x41\x64\x64\x42\x61tchArgs\x12\x1a\n\x05\x62\x61tch\x18\x01 \x01(\x0b\x32\x0b.artm.Batch\x12 \n\x14timeout_milliseconds\x18\x02 \x01(\x05:\x02-1\x12\x1b\n\x0creset_scores\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x62\x61tch_file_name\x18\x04 \x01(\t\"a\n\x13InvokeIterationArgs\x12\x1b\n\x10iterations_count\x18\x01 \x01(\x05:\x01\x31\x12\x1a\n\x0creset_scores\x18\x02 \x01(\x08:\x04true\x12\x11\n\tdisk_path\x18\x03 \x01(\t\"0\n\x0cWaitIdleArgs\x12 \n\x14timeout_milliseconds\x18\x01 \x01(\x05:\x02-1\"8\n\x0f\x45xportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"8\n\x0fImportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"%\n\x0f\x41ttachModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\"\xad\x04\n\x12ProcessBatchesArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12\x17\n\x0fpwt_source_name\x18\x03 \x01(\t\x12\"\n\x16inner_iterations_count\x18\x04 \x01(\x05:\x02\x31\x30\x12\x1c\n\x0bstream_name\x18\x05 \x01(\t:\x07@global\x12\x18\n\x10regularizer_name\x18\x06 \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x07 \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x08 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\t \x03(\x02\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12\x1a\n\x0creset_scores\x18\r \x01(\x08:\x04true\x12J\n\x11theta_matrix_type\x18\x0e \x01(\x0e\x32(.artm.ProcessBatchesArgs.ThetaMatrixType:\x05\x43\x61\x63he\x12\x14\n\x0c\x62\x61tch_weight\x18\x0f \x03(\x02\x12\x1e\n\x0fuse_ptdw_matrix\x18\x10 \x01(\x08:\x05\x66\x61lse\"=\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\"d\n\x14ProcessBatchesResult\x12#\n\nscore_data\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\x12\'\n\x0ctheta_matrix\x18\x02 \x01(\x0b\x32\x11.artm.ThetaMatrix\"m\n\x0eMergeModelArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x03(\t\x12\x15\n\rsource_weight\x18\x03 \x03(\x02\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"\x99\x01\n\x13RegularizeModelArgs\x12\x17\n\x0frwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fpwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x03 \x01(\t\x12\x37\n\x14regularizer_settings\x18\x04 \x03(\x0b\x32\x19.artm.RegularizerSettings\"_\n\x12NormalizeModelArgs\x12\x17\n\x0fpwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0frwt_source_name\x18\x03 \x01(\t\"B\n\x14ImportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"\xc1\x01\n\x15\x43opyRequestResultArgs\x12Q\n\x0crequest_type\x18\x01 \x01(\x0e\x32\'.artm.CopyRequestResultArgs.RequestType:\x12\x44\x65\x66\x61ultRequestType\"U\n\x0bRequestType\x12\x16\n\x12\x44\x65\x66\x61ultRequestType\x10\x00\x12\x16\n\x12GetThetaSecondPass\x10\x01\x12\x16\n\x12GetModelSecondPass\x10\x02\"\x1e\n\x1c\x44uplicateMasterComponentArgs\"\x1c\n\x1aGetMasterComponentInfoArgs\"\xc1\x06\n\x13MasterComponentInfo\x12\x11\n\tmaster_id\x18\x01 \x01(\x05\x12+\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x1b.artm.MasterComponentConfig\x12>\n\x0bregularizer\x18\x03 \x03(\x0b\x32).artm.MasterComponentInfo.RegularizerInfo\x12\x32\n\x05score\x18\x04 \x03(\x0b\x32#.artm.MasterComponentInfo.ScoreInfo\x12<\n\ndictionary\x18\x05 \x03(\x0b\x32(.artm.MasterComponentInfo.DictionaryInfo\x12\x32\n\x05model\x18\x06 \x03(\x0b\x32#.artm.MasterComponentInfo.ModelInfo\x12=\n\x0b\x63\x61\x63he_entry\x18\x07 \x03(\x0b\x32(.artm.MasterComponentInfo.CacheEntryInfo\x12\x19\n\x11merger_queue_size\x18\x08 \x01(\x05\x12\x1c\n\x14processor_queue_size\x18\t \x01(\x05\x12\x32\n\x05\x62\x61tch\x18\n \x03(\x0b\x32#.artm.MasterComponentInfo.BatchInfo\x1a-\n\x0fRegularizerInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\'\n\tScoreInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\x35\n\x0e\x44ictionaryInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rentries_count\x18\x02 \x01(\x03\x1a\x43\n\tBatchInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0bitems_count\x18\x02 \x01(\x05\x12\x13\n\x0btoken_count\x18\x03 \x01(\x05\x1aR\n\tModelInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x13\n\x0btoken_count\x18\x04 \x01(\x05\x1a\x30\n\x0e\x43\x61\x63heEntryInfo\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tbyte_size\x18\x02 \x01(\x05\"C\n\x11ImportBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x03(\x0b\x32\x0b.artm.Batch\"(\n\x12\x44isposeBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t')
 
 
 
@@ -307,8 +307,8 @@ _INITIALIZEMODELARGS_SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=7891,
-  serialized_end=7932,
+  serialized_start=7915,
+  serialized_end=7956,
 )
 
 _GETTOPICMODELARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
@@ -336,8 +336,8 @@ _GETTOPICMODELARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8209,
-  serialized_end=8268,
+  serialized_start=8233,
+  serialized_end=8292,
 )
 
 _GETTOPICMODELARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
@@ -357,8 +357,8 @@ _GETTOPICMODELARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8270,
-  serialized_end=8307,
+  serialized_start=8294,
+  serialized_end=8331,
 )
 
 _GETTHETAMATRIXARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
@@ -378,8 +378,8 @@ _GETTHETAMATRIXARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8270,
-  serialized_end=8307,
+  serialized_start=8294,
+  serialized_end=8331,
 )
 
 _PROCESSBATCHESARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
@@ -407,8 +407,8 @@ _PROCESSBATCHESARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9628,
-  serialized_end=9689,
+  serialized_start=9652,
+  serialized_end=9713,
 )
 
 _COPYREQUESTRESULTARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
@@ -432,8 +432,8 @@ _COPYREQUESTRESULTARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10334,
-  serialized_end=10419,
+  serialized_start=10358,
+  serialized_end=10443,
 )
 
 
@@ -3009,8 +3009,8 @@ _INITIALIZEMODELARGS_FILTER = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7724,
-  serialized_end=7889,
+  serialized_start=7748,
+  serialized_end=7913,
 )
 
 _INITIALIZEMODELARGS = _descriptor.Descriptor(
@@ -3069,6 +3069,13 @@ _INITIALIZEMODELARGS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='batch_filename', full_name='artm.InitializeModelArgs.batch_filename', index=7,
+      number=8, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -3080,7 +3087,7 @@ _INITIALIZEMODELARGS = _descriptor.Descriptor(
   is_extendable=False,
   extension_ranges=[],
   serialized_start=7473,
-  serialized_end=7932,
+  serialized_end=7956,
 )
 
 
@@ -3158,8 +3165,8 @@ _GETTOPICMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7935,
-  serialized_end=8307,
+  serialized_start=7959,
+  serialized_end=8331,
 )
 
 
@@ -3236,8 +3243,8 @@ _GETTHETAMATRIXARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8310,
-  serialized_end=8603,
+  serialized_start=8334,
+  serialized_end=8627,
 )
 
 
@@ -3278,8 +3285,8 @@ _GETSCOREVALUEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8605,
-  serialized_end=8692,
+  serialized_start=8629,
+  serialized_end=8716,
 )
 
 
@@ -3327,8 +3334,8 @@ _ADDBATCHARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8695,
-  serialized_end=8825,
+  serialized_start=8719,
+  serialized_end=8849,
 )
 
 
@@ -3369,8 +3376,8 @@ _INVOKEITERATIONARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8827,
-  serialized_end=8924,
+  serialized_start=8851,
+  serialized_end=8948,
 )
 
 
@@ -3397,8 +3404,8 @@ _WAITIDLEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8926,
-  serialized_end=8974,
+  serialized_start=8950,
+  serialized_end=8998,
 )
 
 
@@ -3432,8 +3439,8 @@ _EXPORTMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8976,
-  serialized_end=9032,
+  serialized_start=9000,
+  serialized_end=9056,
 )
 
 
@@ -3467,8 +3474,8 @@ _IMPORTMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9034,
-  serialized_end=9090,
+  serialized_start=9058,
+  serialized_end=9114,
 )
 
 
@@ -3495,8 +3502,8 @@ _ATTACHMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9092,
-  serialized_end=9129,
+  serialized_start=9116,
+  serialized_end=9153,
 )
 
 
@@ -3629,8 +3636,8 @@ _PROCESSBATCHESARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9132,
-  serialized_end=9689,
+  serialized_start=9156,
+  serialized_end=9713,
 )
 
 
@@ -3664,8 +3671,8 @@ _PROCESSBATCHESRESULT = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9691,
-  serialized_end=9791,
+  serialized_start=9715,
+  serialized_end=9815,
 )
 
 
@@ -3713,8 +3720,8 @@ _MERGEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9793,
-  serialized_end=9902,
+  serialized_start=9817,
+  serialized_end=9926,
 )
 
 
@@ -3762,8 +3769,8 @@ _REGULARIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9905,
-  serialized_end=10058,
+  serialized_start=9929,
+  serialized_end=10082,
 )
 
 
@@ -3804,8 +3811,8 @@ _NORMALIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10060,
-  serialized_end=10155,
+  serialized_start=10084,
+  serialized_end=10179,
 )
 
 
@@ -3839,8 +3846,8 @@ _IMPORTDICTIONARYARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10157,
-  serialized_end=10223,
+  serialized_start=10181,
+  serialized_end=10247,
 )
 
 
@@ -3868,8 +3875,8 @@ _COPYREQUESTRESULTARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10226,
-  serialized_end=10419,
+  serialized_start=10250,
+  serialized_end=10443,
 )
 
 
@@ -3889,8 +3896,8 @@ _DUPLICATEMASTERCOMPONENTARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10421,
-  serialized_end=10451,
+  serialized_start=10445,
+  serialized_end=10475,
 )
 
 
@@ -3910,8 +3917,8 @@ _GETMASTERCOMPONENTINFOARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10453,
-  serialized_end=10481,
+  serialized_start=10477,
+  serialized_end=10505,
 )
 
 
@@ -3945,8 +3952,8 @@ _MASTERCOMPONENTINFO_REGULARIZERINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10921,
-  serialized_end=10966,
+  serialized_start=10997,
+  serialized_end=11042,
 )
 
 _MASTERCOMPONENTINFO_SCOREINFO = _descriptor.Descriptor(
@@ -3979,8 +3986,8 @@ _MASTERCOMPONENTINFO_SCOREINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10968,
-  serialized_end=11007,
+  serialized_start=11044,
+  serialized_end=11083,
 )
 
 _MASTERCOMPONENTINFO_DICTIONARYINFO = _descriptor.Descriptor(
@@ -4013,8 +4020,49 @@ _MASTERCOMPONENTINFO_DICTIONARYINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11009,
-  serialized_end=11062,
+  serialized_start=11085,
+  serialized_end=11138,
+)
+
+_MASTERCOMPONENTINFO_BATCHINFO = _descriptor.Descriptor(
+  name='BatchInfo',
+  full_name='artm.MasterComponentInfo.BatchInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='artm.MasterComponentInfo.BatchInfo.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=unicode("", "utf-8"),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='items_count', full_name='artm.MasterComponentInfo.BatchInfo.items_count', index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='token_count', full_name='artm.MasterComponentInfo.BatchInfo.token_count', index=2,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=11140,
+  serialized_end=11207,
 )
 
 _MASTERCOMPONENTINFO_MODELINFO = _descriptor.Descriptor(
@@ -4061,8 +4109,8 @@ _MASTERCOMPONENTINFO_MODELINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11064,
-  serialized_end=11146,
+  serialized_start=11209,
+  serialized_end=11291,
 )
 
 _MASTERCOMPONENTINFO_CACHEENTRYINFO = _descriptor.Descriptor(
@@ -4095,8 +4143,8 @@ _MASTERCOMPONENTINFO_CACHEENTRYINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11148,
-  serialized_end=11196,
+  serialized_start=11293,
+  serialized_end=11341,
 )
 
 _MASTERCOMPONENTINFO = _descriptor.Descriptor(
@@ -4169,17 +4217,87 @@ _MASTERCOMPONENTINFO = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='batch', full_name='artm.MasterComponentInfo.batch', index=9,
+      number=10, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
-  nested_types=[_MASTERCOMPONENTINFO_REGULARIZERINFO, _MASTERCOMPONENTINFO_SCOREINFO, _MASTERCOMPONENTINFO_DICTIONARYINFO, _MASTERCOMPONENTINFO_MODELINFO, _MASTERCOMPONENTINFO_CACHEENTRYINFO, ],
+  nested_types=[_MASTERCOMPONENTINFO_REGULARIZERINFO, _MASTERCOMPONENTINFO_SCOREINFO, _MASTERCOMPONENTINFO_DICTIONARYINFO, _MASTERCOMPONENTINFO_BATCHINFO, _MASTERCOMPONENTINFO_MODELINFO, _MASTERCOMPONENTINFO_CACHEENTRYINFO, ],
   enum_types=[
   ],
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10484,
-  serialized_end=11196,
+  serialized_start=10508,
+  serialized_end=11341,
+)
+
+
+_IMPORTBATCHESARGS = _descriptor.Descriptor(
+  name='ImportBatchesArgs',
+  full_name='artm.ImportBatchesArgs',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='batch_name', full_name='artm.ImportBatchesArgs.batch_name', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='batch', full_name='artm.ImportBatchesArgs.batch', index=1,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=11343,
+  serialized_end=11410,
+)
+
+
+_DISPOSEBATCHESARGS = _descriptor.Descriptor(
+  name='DisposeBatchesArgs',
+  full_name='artm.DisposeBatchesArgs',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='batch_name', full_name='artm.DisposeBatchesArgs.batch_name', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=11412,
+  serialized_end=11452,
 )
 
 _ITEM.fields_by_name['field'].message_type = _FIELD
@@ -4245,6 +4363,7 @@ _COPYREQUESTRESULTARGS_REQUESTTYPE.containing_type = _COPYREQUESTRESULTARGS;
 _MASTERCOMPONENTINFO_REGULARIZERINFO.containing_type = _MASTERCOMPONENTINFO;
 _MASTERCOMPONENTINFO_SCOREINFO.containing_type = _MASTERCOMPONENTINFO;
 _MASTERCOMPONENTINFO_DICTIONARYINFO.containing_type = _MASTERCOMPONENTINFO;
+_MASTERCOMPONENTINFO_BATCHINFO.containing_type = _MASTERCOMPONENTINFO;
 _MASTERCOMPONENTINFO_MODELINFO.containing_type = _MASTERCOMPONENTINFO;
 _MASTERCOMPONENTINFO_CACHEENTRYINFO.containing_type = _MASTERCOMPONENTINFO;
 _MASTERCOMPONENTINFO.fields_by_name['config'].message_type = _MASTERCOMPONENTCONFIG
@@ -4253,6 +4372,8 @@ _MASTERCOMPONENTINFO.fields_by_name['score'].message_type = _MASTERCOMPONENTINFO
 _MASTERCOMPONENTINFO.fields_by_name['dictionary'].message_type = _MASTERCOMPONENTINFO_DICTIONARYINFO
 _MASTERCOMPONENTINFO.fields_by_name['model'].message_type = _MASTERCOMPONENTINFO_MODELINFO
 _MASTERCOMPONENTINFO.fields_by_name['cache_entry'].message_type = _MASTERCOMPONENTINFO_CACHEENTRYINFO
+_MASTERCOMPONENTINFO.fields_by_name['batch'].message_type = _MASTERCOMPONENTINFO_BATCHINFO
+_IMPORTBATCHESARGS.fields_by_name['batch'].message_type = _BATCH
 DESCRIPTOR.message_types_by_name['DoubleArray'] = _DOUBLEARRAY
 DESCRIPTOR.message_types_by_name['FloatArray'] = _FLOATARRAY
 DESCRIPTOR.message_types_by_name['BoolArray'] = _BOOLARRAY
@@ -4320,6 +4441,8 @@ DESCRIPTOR.message_types_by_name['CopyRequestResultArgs'] = _COPYREQUESTRESULTAR
 DESCRIPTOR.message_types_by_name['DuplicateMasterComponentArgs'] = _DUPLICATEMASTERCOMPONENTARGS
 DESCRIPTOR.message_types_by_name['GetMasterComponentInfoArgs'] = _GETMASTERCOMPONENTINFOARGS
 DESCRIPTOR.message_types_by_name['MasterComponentInfo'] = _MASTERCOMPONENTINFO
+DESCRIPTOR.message_types_by_name['ImportBatchesArgs'] = _IMPORTBATCHESARGS
+DESCRIPTOR.message_types_by_name['DisposeBatchesArgs'] = _DISPOSEBATCHESARGS
 
 class DoubleArray(_message.Message):
   __metaclass__ = _reflection.GeneratedProtocolMessageType
@@ -4750,6 +4873,12 @@ class MasterComponentInfo(_message.Message):
 
     # @@protoc_insertion_point(class_scope:artm.MasterComponentInfo.DictionaryInfo)
 
+  class BatchInfo(_message.Message):
+    __metaclass__ = _reflection.GeneratedProtocolMessageType
+    DESCRIPTOR = _MASTERCOMPONENTINFO_BATCHINFO
+
+    # @@protoc_insertion_point(class_scope:artm.MasterComponentInfo.BatchInfo)
+
   class ModelInfo(_message.Message):
     __metaclass__ = _reflection.GeneratedProtocolMessageType
     DESCRIPTOR = _MASTERCOMPONENTINFO_MODELINFO
@@ -4764,6 +4893,18 @@ class MasterComponentInfo(_message.Message):
   DESCRIPTOR = _MASTERCOMPONENTINFO
 
   # @@protoc_insertion_point(class_scope:artm.MasterComponentInfo)
+
+class ImportBatchesArgs(_message.Message):
+  __metaclass__ = _reflection.GeneratedProtocolMessageType
+  DESCRIPTOR = _IMPORTBATCHESARGS
+
+  # @@protoc_insertion_point(class_scope:artm.ImportBatchesArgs)
+
+class DisposeBatchesArgs(_message.Message):
+  __metaclass__ = _reflection.GeneratedProtocolMessageType
+  DESCRIPTOR = _DISPOSEBATCHESARGS
+
+  # @@protoc_insertion_point(class_scope:artm.DisposeBatchesArgs)
 
 
 _DOUBLEARRAY.fields_by_name['value'].has_options = True

--- a/python/artm/wrapper/spec.py
+++ b/python/artm/wrapper/spec.py
@@ -90,6 +90,14 @@ ARTM_API = [
         'ArtmParseCollection',
         [('config', messages.CollectionParserConfig)],
     ),
+    CallSpec(
+        'ArtmImportBatches',
+        [('master_id', int), ('args', messages.ImportBatchesArgs)],
+    ),
+    CallSpec(
+        'ArtmDisposeBatches',
+        [('master_id', int), ('args', messages.DisposeBatchesArgs)],
+    ),
 
     ## deprecated
     #CallSpec(

--- a/src/artm/c_interface.cc
+++ b/src/artm/c_interface.cc
@@ -544,6 +544,24 @@ int ArtmImportDictionary(int master_id, int length, const char* dictionary_args)
   } CATCH_EXCEPTIONS;
 }
 
+int ArtmImportBatches(int master_id, int length, const char* import_batches_args) {
+  try {
+    artm::ImportBatchesArgs args;
+    ParseFromArray(import_batches_args, length, &args);
+    master_component(master_id)->ImportBatches(args);
+    return ARTM_SUCCESS;
+  } CATCH_EXCEPTIONS;
+}
+
+int ArtmDisposeBatches(int master_id, int length, const char* dispose_batches_args) {
+  try {
+    artm::DisposeBatchesArgs args;
+    ParseFromArray(dispose_batches_args, length, &args);
+    master_component(master_id)->DisposeBatches(args);
+    return ARTM_SUCCESS;
+  } CATCH_EXCEPTIONS;
+}
+
 int ArtmRequestParseCollection(int length, const char* collection_parser_config) {
   try {
     EnableLogging();

--- a/src/artm/c_interface.h
+++ b/src/artm/c_interface.h
@@ -36,6 +36,9 @@ extern "C" {
   DLL_PUBLIC int ArtmImportDictionary(int master_id, int length, const char* import_dictionary_args);
   DLL_PUBLIC int ArtmParseCollection(int length, const char* collection_parser_config);
 
+  DLL_PUBLIC int ArtmImportBatches(int master_id, int length, const char* import_batches_args);
+  DLL_PUBLIC int ArtmDisposeBatches(int master_id, int length, const char* dispose_batches_args);
+
   DLL_PUBLIC int ArtmAddBatch(int master_id, int length, const char* add_batch_args);
   DLL_PUBLIC int ArtmInvokeIteration(int master_id, int length, const char* invoke_iteration_args);
   DLL_PUBLIC int ArtmWaitIdle(int master_id, int length, const char* wait_idle_args);

--- a/src/artm/core/helpers.cc
+++ b/src/artm/core/helpers.cc
@@ -554,7 +554,9 @@ bool Helpers::Validate(const ::artm::InitializeModelArgs& message, bool throw_er
   }
 
   if (message.source_type() == InitializeModelArgs_SourceType_Batches) {
-    if (!message.has_disk_path() || message.disk_path().empty()) {
+    const bool has_disk_path = message.has_disk_path() && !message.disk_path().empty();
+    const bool has_batch_filename = message.batch_filename_size() > 0;
+    if (!has_disk_path && !has_batch_filename) {
       ss << "InitializeModelArgs.disk_path is required together with SourceType.Batches; ";
     }
   }

--- a/src/artm/core/instance.h
+++ b/src/artm/core/instance.h
@@ -32,6 +32,7 @@ class Merger;
 class InstanceSchema;
 class Dictionary;
 typedef ThreadSafeCollectionHolder<std::string, Dictionary> ThreadSafeDictionaryCollection;
+typedef ThreadSafeCollectionHolder<std::string, Batch> ThreadSafeBatchCollection;
 typedef ThreadSafeQueue<std::shared_ptr<ProcessorInput>> ProcessorQueue;
 typedef ThreadSafeQueue<std::shared_ptr<ModelIncrement>> MergerQueue;
 
@@ -48,6 +49,7 @@ class Instance {
   std::shared_ptr<InstanceSchema> schema() const { return schema_.get(); }
   ProcessorQueue* processor_queue() { return &processor_queue_; }
   MergerQueue* merger_queue() { return &merger_queue_; }
+  ThreadSafeBatchCollection* batches() { return &batches_; }
 
   DataLoader* data_loader();
   BatchManager* batch_manager();
@@ -77,6 +79,7 @@ class Instance {
 
   ThreadSafeHolder<InstanceSchema> schema_;
   ThreadSafeDictionaryCollection dictionaries_;
+  ThreadSafeBatchCollection batches_;
 
   ProcessorQueue processor_queue_;
 

--- a/src/artm/core/master_component.cc
+++ b/src/artm/core/master_component.cc
@@ -94,6 +94,23 @@ void MasterComponent::ImportDictionary(const ImportDictionaryArgs& args) {
   LOG(INFO) << "Dictionary import completed";
 }
 
+void MasterComponent::ImportBatches(const ImportBatchesArgs& args) {
+  if (args.batch_name_size() != args.batch_size())
+    BOOST_THROW_EXCEPTION(InvalidOperation("ImportBatchesArgs: batch_name_size() != batch_size()"));
+
+  for (int i = 0; i < args.batch_name_size(); ++i) {
+    std::shared_ptr<Batch> batch = std::make_shared<Batch>(args.batch(i));
+    Helpers::FixAndValidate(batch.get(), /* throw_error =*/ true);
+    instance_->batches()->set(args.batch_name(i), batch);
+  }
+}
+
+void MasterComponent::DisposeBatches(const DisposeBatchesArgs& args) {
+  for (auto& batch_name : args.batch_name())
+    instance_->batches()->erase(batch_name);
+}
+
+
 void MasterComponent::SynchronizeModel(const SynchronizeModelArgs& args) {
   instance_->merger()->ForceSynchronizeModel(args);
 }

--- a/src/artm/core/master_component.h
+++ b/src/artm/core/master_component.h
@@ -68,6 +68,9 @@ class MasterComponent : boost::noncopyable {
   void DisposeDictionary(const std::string& name);
   void ImportDictionary(const ImportDictionaryArgs& args);
 
+  void ImportBatches(const ImportBatchesArgs& args);
+  void DisposeBatches(const DisposeBatchesArgs& args);
+
   // Returns false if BigARTM is still processing the collection, otherwise true.
   bool WaitIdle(const WaitIdleArgs& args);
   void InvokeIteration(const InvokeIterationArgs& args);

--- a/src/artm/core/merger.h
+++ b/src/artm/core/merger.h
@@ -31,11 +31,13 @@ namespace core {
 class TopicModel;
 class InstanceSchema;
 class Dictionary;
+typedef ThreadSafeCollectionHolder<std::string, Batch> ThreadSafeBatchCollection;
 
 class Merger : boost::noncopyable {
  public:
   Merger(ThreadSafeQueue<std::shared_ptr<ModelIncrement> >* merger_queue,
          ThreadSafeHolder<InstanceSchema>* schema,
+         const ::artm::core::ThreadSafeBatchCollection* batches,
          const ::artm::core::ThreadSafeDictionaryCollection* dictionaries);
 
   ~Merger();
@@ -99,6 +101,7 @@ class Merger : boost::noncopyable {
   ThreadSafeQueue<std::shared_ptr<ModelIncrement> >* merger_queue_;
   ThreadSafeQueue<MergerTask> internal_task_queue_;
 
+  const ::artm::core::ThreadSafeBatchCollection* batches_;
   const ::artm::core::ThreadSafeDictionaryCollection* dictionaries_;
 
   mutable std::atomic<bool> is_stopping;

--- a/src/artm/core/processor.h
+++ b/src/artm/core/processor.h
@@ -34,6 +34,7 @@ class Processor : boost::noncopyable {
  public:
   Processor(ThreadSafeQueue<std::shared_ptr<ProcessorInput> >* processor_queue,
             ThreadSafeQueue<std::shared_ptr<ModelIncrement> >* merger_queue,
+            const ThreadSafeCollectionHolder<std::string, Batch>& batches,
             const Merger& merger,
             const ThreadSafeHolder<InstanceSchema>& schema);
 
@@ -47,6 +48,7 @@ class Processor : boost::noncopyable {
   ThreadSafeQueue<std::shared_ptr<ProcessorInput> >* processor_queue_;
   ThreadSafeQueue<std::shared_ptr<ModelIncrement> >* merger_queue_;
   const Merger& merger_;
+  const ThreadSafeCollectionHolder<std::string, Batch>& batches_;
   const ThreadSafeHolder<InstanceSchema>& schema_;
 
   mutable std::atomic<bool> is_stopping;

--- a/src/artm/cpp_interface.cc
+++ b/src/artm/cpp_interface.cc
@@ -584,4 +584,16 @@ void MasterComponent::InitializeModel(const InitializeModelArgs& args) {
   HandleErrorCode(ArtmInitializeModel(id(), blob.size(), blob.c_str()));
 }
 
+void MasterComponent::ImportBatches(const ImportBatchesArgs& args) {
+  std::string blob;
+  args.SerializeToString(&blob);
+  HandleErrorCode(ArtmImportBatches(id(), blob.size(), blob.c_str()));
+}
+
+void MasterComponent::DisposeBatches(const DisposeBatchesArgs& args) {
+  std::string blob;
+  args.SerializeToString(&blob);
+  HandleErrorCode(ArtmDisposeBatches(id(), blob.size(), blob.c_str()));
+}
+
 }  // namespace artm

--- a/src/artm/cpp_interface.h
+++ b/src/artm/cpp_interface.h
@@ -140,6 +140,9 @@ class MasterComponent {
   void ImportModel(const ImportModelArgs& args);
   void DisposeModel(const std::string& model_name);
 
+  void ImportBatches(const ImportBatchesArgs& args);
+  void DisposeBatches(const DisposeBatchesArgs &args);
+
   void ImportDictionary(const ImportDictionaryArgs& args);
 
   void Reconfigure(const MasterComponentConfig& config);

--- a/src/artm/messages.pb.cc
+++ b/src/artm/messages.pb.cc
@@ -251,12 +251,21 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* MasterComponentInfo_DictionaryInfo_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   MasterComponentInfo_DictionaryInfo_reflection_ = NULL;
+const ::google::protobuf::Descriptor* MasterComponentInfo_BatchInfo_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  MasterComponentInfo_BatchInfo_reflection_ = NULL;
 const ::google::protobuf::Descriptor* MasterComponentInfo_ModelInfo_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   MasterComponentInfo_ModelInfo_reflection_ = NULL;
 const ::google::protobuf::Descriptor* MasterComponentInfo_CacheEntryInfo_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   MasterComponentInfo_CacheEntryInfo_reflection_ = NULL;
+const ::google::protobuf::Descriptor* ImportBatchesArgs_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  ImportBatchesArgs_reflection_ = NULL;
+const ::google::protobuf::Descriptor* DisposeBatchesArgs_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  DisposeBatchesArgs_reflection_ = NULL;
 
 }  // namespace
 
@@ -1162,7 +1171,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SynchronizeModelArgs));
   InitializeModelArgs_descriptor_ = file->message_type(47);
-  static const int InitializeModelArgs_offsets_[7] = {
+  static const int InitializeModelArgs_offsets_[8] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, model_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, dictionary_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, source_type_),
@@ -1170,6 +1179,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, filter_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, topics_count_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, topic_name_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, batch_filename_),
   };
   InitializeModelArgs_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -1526,7 +1536,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GetMasterComponentInfoArgs));
   MasterComponentInfo_descriptor_ = file->message_type(66);
-  static const int MasterComponentInfo_offsets_[9] = {
+  static const int MasterComponentInfo_offsets_[10] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, master_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, config_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, regularizer_),
@@ -1536,6 +1546,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, cache_entry_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, merger_queue_size_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, processor_queue_size_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, batch_),
   };
   MasterComponentInfo_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -1596,7 +1607,24 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(MasterComponentInfo_DictionaryInfo));
-  MasterComponentInfo_ModelInfo_descriptor_ = MasterComponentInfo_descriptor_->nested_type(3);
+  MasterComponentInfo_BatchInfo_descriptor_ = MasterComponentInfo_descriptor_->nested_type(3);
+  static const int MasterComponentInfo_BatchInfo_offsets_[3] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo_BatchInfo, name_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo_BatchInfo, items_count_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo_BatchInfo, token_count_),
+  };
+  MasterComponentInfo_BatchInfo_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      MasterComponentInfo_BatchInfo_descriptor_,
+      MasterComponentInfo_BatchInfo::default_instance_,
+      MasterComponentInfo_BatchInfo_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo_BatchInfo, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo_BatchInfo, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(MasterComponentInfo_BatchInfo));
+  MasterComponentInfo_ModelInfo_descriptor_ = MasterComponentInfo_descriptor_->nested_type(4);
   static const int MasterComponentInfo_ModelInfo_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo_ModelInfo, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo_ModelInfo, type_),
@@ -1614,7 +1642,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(MasterComponentInfo_ModelInfo));
-  MasterComponentInfo_CacheEntryInfo_descriptor_ = MasterComponentInfo_descriptor_->nested_type(4);
+  MasterComponentInfo_CacheEntryInfo_descriptor_ = MasterComponentInfo_descriptor_->nested_type(5);
   static const int MasterComponentInfo_CacheEntryInfo_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo_CacheEntryInfo, key_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo_CacheEntryInfo, byte_size_),
@@ -1630,6 +1658,37 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(MasterComponentInfo_CacheEntryInfo));
+  ImportBatchesArgs_descriptor_ = file->message_type(67);
+  static const int ImportBatchesArgs_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportBatchesArgs, batch_name_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportBatchesArgs, batch_),
+  };
+  ImportBatchesArgs_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      ImportBatchesArgs_descriptor_,
+      ImportBatchesArgs::default_instance_,
+      ImportBatchesArgs_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportBatchesArgs, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportBatchesArgs, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(ImportBatchesArgs));
+  DisposeBatchesArgs_descriptor_ = file->message_type(68);
+  static const int DisposeBatchesArgs_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DisposeBatchesArgs, batch_name_),
+  };
+  DisposeBatchesArgs_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      DisposeBatchesArgs_descriptor_,
+      DisposeBatchesArgs::default_instance_,
+      DisposeBatchesArgs_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DisposeBatchesArgs, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DisposeBatchesArgs, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(DisposeBatchesArgs));
 }
 
 namespace {
@@ -1787,9 +1846,15 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     MasterComponentInfo_DictionaryInfo_descriptor_, &MasterComponentInfo_DictionaryInfo::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    MasterComponentInfo_BatchInfo_descriptor_, &MasterComponentInfo_BatchInfo::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     MasterComponentInfo_ModelInfo_descriptor_, &MasterComponentInfo_ModelInfo::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     MasterComponentInfo_CacheEntryInfo_descriptor_, &MasterComponentInfo_CacheEntryInfo::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    ImportBatchesArgs_descriptor_, &ImportBatchesArgs::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    DisposeBatchesArgs_descriptor_, &DisposeBatchesArgs::default_instance());
 }
 
 }  // namespace
@@ -1960,10 +2025,16 @@ void protobuf_ShutdownFile_artm_2fmessages_2eproto() {
   delete MasterComponentInfo_ScoreInfo_reflection_;
   delete MasterComponentInfo_DictionaryInfo::default_instance_;
   delete MasterComponentInfo_DictionaryInfo_reflection_;
+  delete MasterComponentInfo_BatchInfo::default_instance_;
+  delete MasterComponentInfo_BatchInfo_reflection_;
   delete MasterComponentInfo_ModelInfo::default_instance_;
   delete MasterComponentInfo_ModelInfo_reflection_;
   delete MasterComponentInfo_CacheEntryInfo::default_instance_;
   delete MasterComponentInfo_CacheEntryInfo_reflection_;
+  delete ImportBatchesArgs::default_instance_;
+  delete ImportBatchesArgs_reflection_;
+  delete DisposeBatchesArgs::default_instance_;
+  delete DisposeBatchesArgs_reflection_;
 }
 
 void protobuf_AddDesc_artm_2fmessages_2eproto() {
@@ -2159,100 +2230,107 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
     "t\020\002\022\020\n\014Cooccurrence\020\003\"\177\n\024SynchronizeMode"
     "lArgs\022\022\n\nmodel_name\030\001 \001(\t\022\027\n\014decay_weigh"
     "t\030\002 \001(\002:\0010\022!\n\023invoke_regularizers\030\003 \001(\010:"
-    "\004true\022\027\n\014apply_weight\030\004 \001(\002:\0011\"\313\003\n\023Initi"
+    "\004true\022\027\n\014apply_weight\030\004 \001(\002:\0011\"\343\003\n\023Initi"
     "alizeModelArgs\022\022\n\nmodel_name\030\001 \001(\t\022\027\n\017di"
     "ctionary_name\030\002 \001(\t\022E\n\013source_type\030\003 \001(\016"
     "2$.artm.InitializeModelArgs.SourceType:\n"
     "Dictionary\022\021\n\tdisk_path\030\004 \001(\t\0220\n\006filter\030"
     "\005 \003(\0132 .artm.InitializeModelArgs.Filter\022"
     "\024\n\014topics_count\030\006 \001(\005\022\022\n\ntopic_name\030\007 \003("
-    "\t\032\245\001\n\006Filter\022\020\n\010class_id\030\001 \001(\t\022\026\n\016min_pe"
-    "rcentage\030\002 \001(\002\022\026\n\016max_percentage\030\003 \001(\002\022\021"
-    "\n\tmin_items\030\004 \001(\005\022\021\n\tmax_items\030\005 \001(\005\022\027\n\017"
-    "min_total_count\030\006 \001(\005\022\032\n\022min_one_item_co"
-    "unt\030\007 \001(\005\")\n\nSourceType\022\016\n\nDictionary\020\000\022"
-    "\013\n\007Batches\020\001\"\364\002\n\021GetTopicModelArgs\022\022\n\nmo"
-    "del_name\030\001 \001(\t\022\022\n\ntopic_name\030\002 \003(\t\022\r\n\005to"
-    "ken\030\003 \003(\t\022\020\n\010class_id\030\004 \003(\t\022\031\n\021use_spars"
-    "e_format\030\005 \001(\010\022\023\n\003eps\030\006 \001(\002:\0061e-037\022>\n\014r"
-    "equest_type\030\007 \001(\0162#.artm.GetTopicModelAr"
-    "gs.RequestType:\003Pwt\022B\n\rmatrix_layout\030\010 \001"
-    "(\0162$.artm.GetTopicModelArgs.MatrixLayout"
-    ":\005Dense\";\n\013RequestType\022\007\n\003Pwt\020\000\022\007\n\003Nwt\020\001"
-    "\022\016\n\nTopicNames\020\002\022\n\n\006Tokens\020\003\"%\n\014MatrixLa"
-    "yout\022\t\n\005Dense\020\000\022\n\n\006Sparse\020\001\"\245\002\n\022GetTheta"
-    "MatrixArgs\022\022\n\nmodel_name\030\001 \001(\t\022\032\n\005batch\030"
-    "\002 \001(\0132\013.artm.Batch\022\022\n\ntopic_name\030\003 \003(\t\022\023"
-    "\n\013topic_index\030\004 \003(\005\022\032\n\013clean_cache\030\005 \001(\010"
-    ":\005false\022\031\n\021use_sparse_format\030\006 \001(\010\022\023\n\003ep"
-    "s\030\007 \001(\002:\0061e-037\022C\n\rmatrix_layout\030\010 \001(\0162%"
-    ".artm.GetThetaMatrixArgs.MatrixLayout:\005D"
-    "ense\"%\n\014MatrixLayout\022\t\n\005Dense\020\000\022\n\n\006Spars"
-    "e\020\001\"W\n\021GetScoreValueArgs\022\022\n\nmodel_name\030\001"
-    " \001(\t\022\022\n\nscore_name\030\002 \001(\t\022\032\n\005batch\030\003 \001(\0132"
-    "\013.artm.Batch\"\202\001\n\014AddBatchArgs\022\032\n\005batch\030\001"
-    " \001(\0132\013.artm.Batch\022 \n\024timeout_millisecond"
-    "s\030\002 \001(\005:\002-1\022\033\n\014reset_scores\030\003 \001(\010:\005false"
-    "\022\027\n\017batch_file_name\030\004 \001(\t\"a\n\023InvokeItera"
-    "tionArgs\022\033\n\020iterations_count\030\001 \001(\005:\0011\022\032\n"
-    "\014reset_scores\030\002 \001(\010:\004true\022\021\n\tdisk_path\030\003"
-    " \001(\t\"0\n\014WaitIdleArgs\022 \n\024timeout_millisec"
-    "onds\030\001 \001(\005:\002-1\"8\n\017ExportModelArgs\022\021\n\tfil"
-    "e_name\030\001 \001(\t\022\022\n\nmodel_name\030\002 \001(\t\"8\n\017Impo"
-    "rtModelArgs\022\021\n\tfile_name\030\001 \001(\t\022\022\n\nmodel_"
-    "name\030\002 \001(\t\"%\n\017AttachModelArgs\022\022\n\nmodel_n"
-    "ame\030\001 \001(\t\"\255\004\n\022ProcessBatchesArgs\022\027\n\017nwt_"
-    "target_name\030\001 \001(\t\022\026\n\016batch_filename\030\002 \003("
-    "\t\022\027\n\017pwt_source_name\030\003 \001(\t\022\"\n\026inner_iter"
-    "ations_count\030\004 \001(\005:\00210\022\034\n\013stream_name\030\005 "
-    "\001(\t:\007@global\022\030\n\020regularizer_name\030\006 \003(\t\022\027"
-    "\n\017regularizer_tau\030\007 \003(\001\022\020\n\010class_id\030\010 \003("
-    "\t\022\024\n\014class_weight\030\t \003(\002\022\032\n\013reuse_theta\030\n"
-    " \001(\010:\005false\022\031\n\013opt_for_avx\030\013 \001(\010:\004true\022\034"
-    "\n\016use_sparse_bow\030\014 \001(\010:\004true\022\032\n\014reset_sc"
-    "ores\030\r \001(\010:\004true\022J\n\021theta_matrix_type\030\016 "
-    "\001(\0162(.artm.ProcessBatchesArgs.ThetaMatri"
-    "xType:\005Cache\022\024\n\014batch_weight\030\017 \003(\002\022\036\n\017us"
-    "e_ptdw_matrix\030\020 \001(\010:\005false\"=\n\017ThetaMatri"
-    "xType\022\010\n\004None\020\000\022\t\n\005Dense\020\001\022\n\n\006Sparse\020\002\022\t"
-    "\n\005Cache\020\003\"d\n\024ProcessBatchesResult\022#\n\nsco"
-    "re_data\030\001 \003(\0132\017.artm.ScoreData\022\'\n\014theta_"
-    "matrix\030\002 \001(\0132\021.artm.ThetaMatrix\"m\n\016Merge"
-    "ModelArgs\022\027\n\017nwt_target_name\030\001 \001(\t\022\027\n\017nw"
-    "t_source_name\030\002 \003(\t\022\025\n\rsource_weight\030\003 \003"
-    "(\002\022\022\n\ntopic_name\030\004 \003(\t\"\231\001\n\023RegularizeMod"
-    "elArgs\022\027\n\017rwt_target_name\030\001 \001(\t\022\027\n\017pwt_s"
-    "ource_name\030\002 \001(\t\022\027\n\017nwt_source_name\030\003 \001("
-    "\t\0227\n\024regularizer_settings\030\004 \003(\0132\031.artm.R"
-    "egularizerSettings\"_\n\022NormalizeModelArgs"
-    "\022\027\n\017pwt_target_name\030\001 \001(\t\022\027\n\017nwt_source_"
-    "name\030\002 \001(\t\022\027\n\017rwt_source_name\030\003 \001(\t\"B\n\024I"
-    "mportDictionaryArgs\022\021\n\tfile_name\030\001 \001(\t\022\027"
-    "\n\017dictionary_name\030\002 \001(\t\"\301\001\n\025CopyRequestR"
-    "esultArgs\022Q\n\014request_type\030\001 \001(\0162\'.artm.C"
-    "opyRequestResultArgs.RequestType:\022Defaul"
-    "tRequestType\"U\n\013RequestType\022\026\n\022DefaultRe"
-    "questType\020\000\022\026\n\022GetThetaSecondPass\020\001\022\026\n\022G"
-    "etModelSecondPass\020\002\"\036\n\034DuplicateMasterCo"
-    "mponentArgs\"\034\n\032GetMasterComponentInfoArg"
-    "s\"\310\005\n\023MasterComponentInfo\022\021\n\tmaster_id\030\001"
-    " \001(\005\022+\n\006config\030\002 \001(\0132\033.artm.MasterCompon"
-    "entConfig\022>\n\013regularizer\030\003 \003(\0132).artm.Ma"
-    "sterComponentInfo.RegularizerInfo\0222\n\005sco"
-    "re\030\004 \003(\0132#.artm.MasterComponentInfo.Scor"
-    "eInfo\022<\n\ndictionary\030\005 \003(\0132(.artm.MasterC"
-    "omponentInfo.DictionaryInfo\0222\n\005model\030\006 \003"
-    "(\0132#.artm.MasterComponentInfo.ModelInfo\022"
-    "=\n\013cache_entry\030\007 \003(\0132(.artm.MasterCompon"
-    "entInfo.CacheEntryInfo\022\031\n\021merger_queue_s"
-    "ize\030\010 \001(\005\022\034\n\024processor_queue_size\030\t \001(\005\032"
-    "-\n\017RegularizerInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004type"
-    "\030\002 \001(\t\032\'\n\tScoreInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004typ"
-    "e\030\002 \001(\t\0325\n\016DictionaryInfo\022\014\n\004name\030\001 \001(\t\022"
-    "\025\n\rentries_count\030\002 \001(\003\032R\n\tModelInfo\022\014\n\004n"
-    "ame\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\024\n\014topics_count\030"
-    "\003 \001(\005\022\023\n\013token_count\030\004 \001(\005\0320\n\016CacheEntry"
-    "Info\022\013\n\003key\030\001 \001(\t\022\021\n\tbyte_size\030\002 \001(\005", 11196);
+    "\t\022\026\n\016batch_filename\030\010 \003(\t\032\245\001\n\006Filter\022\020\n\010"
+    "class_id\030\001 \001(\t\022\026\n\016min_percentage\030\002 \001(\002\022\026"
+    "\n\016max_percentage\030\003 \001(\002\022\021\n\tmin_items\030\004 \001("
+    "\005\022\021\n\tmax_items\030\005 \001(\005\022\027\n\017min_total_count\030"
+    "\006 \001(\005\022\032\n\022min_one_item_count\030\007 \001(\005\")\n\nSou"
+    "rceType\022\016\n\nDictionary\020\000\022\013\n\007Batches\020\001\"\364\002\n"
+    "\021GetTopicModelArgs\022\022\n\nmodel_name\030\001 \001(\t\022\022"
+    "\n\ntopic_name\030\002 \003(\t\022\r\n\005token\030\003 \003(\t\022\020\n\010cla"
+    "ss_id\030\004 \003(\t\022\031\n\021use_sparse_format\030\005 \001(\010\022\023"
+    "\n\003eps\030\006 \001(\002:\0061e-037\022>\n\014request_type\030\007 \001("
+    "\0162#.artm.GetTopicModelArgs.RequestType:\003"
+    "Pwt\022B\n\rmatrix_layout\030\010 \001(\0162$.artm.GetTop"
+    "icModelArgs.MatrixLayout:\005Dense\";\n\013Reque"
+    "stType\022\007\n\003Pwt\020\000\022\007\n\003Nwt\020\001\022\016\n\nTopicNames\020\002"
+    "\022\n\n\006Tokens\020\003\"%\n\014MatrixLayout\022\t\n\005Dense\020\000\022"
+    "\n\n\006Sparse\020\001\"\245\002\n\022GetThetaMatrixArgs\022\022\n\nmo"
+    "del_name\030\001 \001(\t\022\032\n\005batch\030\002 \001(\0132\013.artm.Bat"
+    "ch\022\022\n\ntopic_name\030\003 \003(\t\022\023\n\013topic_index\030\004 "
+    "\003(\005\022\032\n\013clean_cache\030\005 \001(\010:\005false\022\031\n\021use_s"
+    "parse_format\030\006 \001(\010\022\023\n\003eps\030\007 \001(\002:\0061e-037\022"
+    "C\n\rmatrix_layout\030\010 \001(\0162%.artm.GetThetaMa"
+    "trixArgs.MatrixLayout:\005Dense\"%\n\014MatrixLa"
+    "yout\022\t\n\005Dense\020\000\022\n\n\006Sparse\020\001\"W\n\021GetScoreV"
+    "alueArgs\022\022\n\nmodel_name\030\001 \001(\t\022\022\n\nscore_na"
+    "me\030\002 \001(\t\022\032\n\005batch\030\003 \001(\0132\013.artm.Batch\"\202\001\n"
+    "\014AddBatchArgs\022\032\n\005batch\030\001 \001(\0132\013.artm.Batc"
+    "h\022 \n\024timeout_milliseconds\030\002 \001(\005:\002-1\022\033\n\014r"
+    "eset_scores\030\003 \001(\010:\005false\022\027\n\017batch_file_n"
+    "ame\030\004 \001(\t\"a\n\023InvokeIterationArgs\022\033\n\020iter"
+    "ations_count\030\001 \001(\005:\0011\022\032\n\014reset_scores\030\002 "
+    "\001(\010:\004true\022\021\n\tdisk_path\030\003 \001(\t\"0\n\014WaitIdle"
+    "Args\022 \n\024timeout_milliseconds\030\001 \001(\005:\002-1\"8"
+    "\n\017ExportModelArgs\022\021\n\tfile_name\030\001 \001(\t\022\022\n\n"
+    "model_name\030\002 \001(\t\"8\n\017ImportModelArgs\022\021\n\tf"
+    "ile_name\030\001 \001(\t\022\022\n\nmodel_name\030\002 \001(\t\"%\n\017At"
+    "tachModelArgs\022\022\n\nmodel_name\030\001 \001(\t\"\255\004\n\022Pr"
+    "ocessBatchesArgs\022\027\n\017nwt_target_name\030\001 \001("
+    "\t\022\026\n\016batch_filename\030\002 \003(\t\022\027\n\017pwt_source_"
+    "name\030\003 \001(\t\022\"\n\026inner_iterations_count\030\004 \001"
+    "(\005:\00210\022\034\n\013stream_name\030\005 \001(\t:\007@global\022\030\n\020"
+    "regularizer_name\030\006 \003(\t\022\027\n\017regularizer_ta"
+    "u\030\007 \003(\001\022\020\n\010class_id\030\010 \003(\t\022\024\n\014class_weigh"
+    "t\030\t \003(\002\022\032\n\013reuse_theta\030\n \001(\010:\005false\022\031\n\013o"
+    "pt_for_avx\030\013 \001(\010:\004true\022\034\n\016use_sparse_bow"
+    "\030\014 \001(\010:\004true\022\032\n\014reset_scores\030\r \001(\010:\004true"
+    "\022J\n\021theta_matrix_type\030\016 \001(\0162(.artm.Proce"
+    "ssBatchesArgs.ThetaMatrixType:\005Cache\022\024\n\014"
+    "batch_weight\030\017 \003(\002\022\036\n\017use_ptdw_matrix\030\020 "
+    "\001(\010:\005false\"=\n\017ThetaMatrixType\022\010\n\004None\020\000\022"
+    "\t\n\005Dense\020\001\022\n\n\006Sparse\020\002\022\t\n\005Cache\020\003\"d\n\024Pro"
+    "cessBatchesResult\022#\n\nscore_data\030\001 \003(\0132\017."
+    "artm.ScoreData\022\'\n\014theta_matrix\030\002 \001(\0132\021.a"
+    "rtm.ThetaMatrix\"m\n\016MergeModelArgs\022\027\n\017nwt"
+    "_target_name\030\001 \001(\t\022\027\n\017nwt_source_name\030\002 "
+    "\003(\t\022\025\n\rsource_weight\030\003 \003(\002\022\022\n\ntopic_name"
+    "\030\004 \003(\t\"\231\001\n\023RegularizeModelArgs\022\027\n\017rwt_ta"
+    "rget_name\030\001 \001(\t\022\027\n\017pwt_source_name\030\002 \001(\t"
+    "\022\027\n\017nwt_source_name\030\003 \001(\t\0227\n\024regularizer"
+    "_settings\030\004 \003(\0132\031.artm.RegularizerSettin"
+    "gs\"_\n\022NormalizeModelArgs\022\027\n\017pwt_target_n"
+    "ame\030\001 \001(\t\022\027\n\017nwt_source_name\030\002 \001(\t\022\027\n\017rw"
+    "t_source_name\030\003 \001(\t\"B\n\024ImportDictionaryA"
+    "rgs\022\021\n\tfile_name\030\001 \001(\t\022\027\n\017dictionary_nam"
+    "e\030\002 \001(\t\"\301\001\n\025CopyRequestResultArgs\022Q\n\014req"
+    "uest_type\030\001 \001(\0162\'.artm.CopyRequestResult"
+    "Args.RequestType:\022DefaultRequestType\"U\n\013"
+    "RequestType\022\026\n\022DefaultRequestType\020\000\022\026\n\022G"
+    "etThetaSecondPass\020\001\022\026\n\022GetModelSecondPas"
+    "s\020\002\"\036\n\034DuplicateMasterComponentArgs\"\034\n\032G"
+    "etMasterComponentInfoArgs\"\301\006\n\023MasterComp"
+    "onentInfo\022\021\n\tmaster_id\030\001 \001(\005\022+\n\006config\030\002"
+    " \001(\0132\033.artm.MasterComponentConfig\022>\n\013reg"
+    "ularizer\030\003 \003(\0132).artm.MasterComponentInf"
+    "o.RegularizerInfo\0222\n\005score\030\004 \003(\0132#.artm."
+    "MasterComponentInfo.ScoreInfo\022<\n\ndiction"
+    "ary\030\005 \003(\0132(.artm.MasterComponentInfo.Dic"
+    "tionaryInfo\0222\n\005model\030\006 \003(\0132#.artm.Master"
+    "ComponentInfo.ModelInfo\022=\n\013cache_entry\030\007"
+    " \003(\0132(.artm.MasterComponentInfo.CacheEnt"
+    "ryInfo\022\031\n\021merger_queue_size\030\010 \001(\005\022\034\n\024pro"
+    "cessor_queue_size\030\t \001(\005\0222\n\005batch\030\n \003(\0132#"
+    ".artm.MasterComponentInfo.BatchInfo\032-\n\017R"
+    "egularizerInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001"
+    "(\t\032\'\n\tScoreInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 "
+    "\001(\t\0325\n\016DictionaryInfo\022\014\n\004name\030\001 \001(\t\022\025\n\re"
+    "ntries_count\030\002 \001(\003\032C\n\tBatchInfo\022\014\n\004name\030"
+    "\001 \001(\t\022\023\n\013items_count\030\002 \001(\005\022\023\n\013token_coun"
+    "t\030\003 \001(\005\032R\n\tModelInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004ty"
+    "pe\030\002 \001(\t\022\024\n\014topics_count\030\003 \001(\005\022\023\n\013token_"
+    "count\030\004 \001(\005\0320\n\016CacheEntryInfo\022\013\n\003key\030\001 \001"
+    "(\t\022\021\n\tbyte_size\030\002 \001(\005\"C\n\021ImportBatchesAr"
+    "gs\022\022\n\nbatch_name\030\001 \003(\t\022\032\n\005batch\030\003 \003(\0132\013."
+    "artm.Batch\"(\n\022DisposeBatchesArgs\022\022\n\nbatc"
+    "h_name\030\001 \003(\t", 11452);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "artm/messages.proto", &protobuf_RegisterTypes);
   DoubleArray::default_instance_ = new DoubleArray();
@@ -2369,8 +2447,11 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
   MasterComponentInfo_RegularizerInfo::default_instance_ = new MasterComponentInfo_RegularizerInfo();
   MasterComponentInfo_ScoreInfo::default_instance_ = new MasterComponentInfo_ScoreInfo();
   MasterComponentInfo_DictionaryInfo::default_instance_ = new MasterComponentInfo_DictionaryInfo();
+  MasterComponentInfo_BatchInfo::default_instance_ = new MasterComponentInfo_BatchInfo();
   MasterComponentInfo_ModelInfo::default_instance_ = new MasterComponentInfo_ModelInfo();
   MasterComponentInfo_CacheEntryInfo::default_instance_ = new MasterComponentInfo_CacheEntryInfo();
+  ImportBatchesArgs::default_instance_ = new ImportBatchesArgs();
+  DisposeBatchesArgs::default_instance_ = new DisposeBatchesArgs();
   DoubleArray::default_instance_->InitAsDefaultInstance();
   FloatArray::default_instance_->InitAsDefaultInstance();
   BoolArray::default_instance_->InitAsDefaultInstance();
@@ -2443,8 +2524,11 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
   MasterComponentInfo_RegularizerInfo::default_instance_->InitAsDefaultInstance();
   MasterComponentInfo_ScoreInfo::default_instance_->InitAsDefaultInstance();
   MasterComponentInfo_DictionaryInfo::default_instance_->InitAsDefaultInstance();
+  MasterComponentInfo_BatchInfo::default_instance_->InitAsDefaultInstance();
   MasterComponentInfo_ModelInfo::default_instance_->InitAsDefaultInstance();
   MasterComponentInfo_CacheEntryInfo::default_instance_->InitAsDefaultInstance();
+  ImportBatchesArgs::default_instance_->InitAsDefaultInstance();
+  DisposeBatchesArgs::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_artm_2fmessages_2eproto);
 }
 
@@ -21138,6 +21222,7 @@ const int InitializeModelArgs::kDiskPathFieldNumber;
 const int InitializeModelArgs::kFilterFieldNumber;
 const int InitializeModelArgs::kTopicsCountFieldNumber;
 const int InitializeModelArgs::kTopicNameFieldNumber;
+const int InitializeModelArgs::kBatchFilenameFieldNumber;
 #endif  // !_MSC_VER
 
 InitializeModelArgs::InitializeModelArgs()
@@ -21225,6 +21310,7 @@ void InitializeModelArgs::Clear() {
   }
   filter_.Clear();
   topic_name_.Clear();
+  batch_filename_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -21352,6 +21438,25 @@ bool InitializeModelArgs::MergePartialFromCodedStream(
           goto handle_uninterpreted;
         }
         if (input->ExpectTag(58)) goto parse_topic_name;
+        if (input->ExpectTag(66)) goto parse_batch_filename;
+        break;
+      }
+
+      // repeated string batch_filename = 8;
+      case 8: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+         parse_batch_filename:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->add_batch_filename()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+            this->batch_filename(this->batch_filename_size() - 1).data(),
+            this->batch_filename(this->batch_filename_size() - 1).length(),
+            ::google::protobuf::internal::WireFormat::PARSE);
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(66)) goto parse_batch_filename;
         if (input->ExpectAtEnd()) return true;
         break;
       }
@@ -21427,6 +21532,15 @@ void InitializeModelArgs::SerializeWithCachedSizes(
       7, this->topic_name(i), output);
   }
 
+  // repeated string batch_filename = 8;
+  for (int i = 0; i < this->batch_filename_size(); i++) {
+  ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+    this->batch_filename(i).data(), this->batch_filename(i).length(),
+    ::google::protobuf::internal::WireFormat::SERIALIZE);
+    ::google::protobuf::internal::WireFormatLite::WriteString(
+      8, this->batch_filename(i), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -21492,6 +21606,15 @@ void InitializeModelArgs::SerializeWithCachedSizes(
       WriteStringToArray(7, this->topic_name(i), target);
   }
 
+  // repeated string batch_filename = 8;
+  for (int i = 0; i < this->batch_filename_size(); i++) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+      this->batch_filename(i).data(), this->batch_filename(i).length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE);
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteStringToArray(8, this->batch_filename(i), target);
+  }
+
   if (!unknown_fields().empty()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -21553,6 +21676,13 @@ int InitializeModelArgs::ByteSize() const {
       this->topic_name(i));
   }
 
+  // repeated string batch_filename = 8;
+  total_size += 1 * this->batch_filename_size();
+  for (int i = 0; i < this->batch_filename_size(); i++) {
+    total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
+      this->batch_filename(i));
+  }
+
   if (!unknown_fields().empty()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -21580,6 +21710,7 @@ void InitializeModelArgs::MergeFrom(const InitializeModelArgs& from) {
   GOOGLE_CHECK_NE(&from, this);
   filter_.MergeFrom(from.filter_);
   topic_name_.MergeFrom(from.topic_name_);
+  batch_filename_.MergeFrom(from.batch_filename_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_model_name()) {
       set_model_name(from.model_name());
@@ -21626,6 +21757,7 @@ void InitializeModelArgs::Swap(InitializeModelArgs* other) {
     filter_.Swap(&other->filter_);
     std::swap(topics_count_, other->topics_count_);
     topic_name_.Swap(&other->topic_name_);
+    batch_filename_.Swap(&other->batch_filename_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);
@@ -28673,6 +28805,311 @@ void MasterComponentInfo_DictionaryInfo::Swap(MasterComponentInfo_DictionaryInfo
 // -------------------------------------------------------------------
 
 #ifndef _MSC_VER
+const int MasterComponentInfo_BatchInfo::kNameFieldNumber;
+const int MasterComponentInfo_BatchInfo::kItemsCountFieldNumber;
+const int MasterComponentInfo_BatchInfo::kTokenCountFieldNumber;
+#endif  // !_MSC_VER
+
+MasterComponentInfo_BatchInfo::MasterComponentInfo_BatchInfo()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+}
+
+void MasterComponentInfo_BatchInfo::InitAsDefaultInstance() {
+}
+
+MasterComponentInfo_BatchInfo::MasterComponentInfo_BatchInfo(const MasterComponentInfo_BatchInfo& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+}
+
+void MasterComponentInfo_BatchInfo::SharedCtor() {
+  _cached_size_ = 0;
+  name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyString());
+  items_count_ = 0;
+  token_count_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+MasterComponentInfo_BatchInfo::~MasterComponentInfo_BatchInfo() {
+  SharedDtor();
+}
+
+void MasterComponentInfo_BatchInfo::SharedDtor() {
+  if (name_ != &::google::protobuf::internal::GetEmptyString()) {
+    delete name_;
+  }
+  if (this != default_instance_) {
+  }
+}
+
+void MasterComponentInfo_BatchInfo::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* MasterComponentInfo_BatchInfo::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return MasterComponentInfo_BatchInfo_descriptor_;
+}
+
+const MasterComponentInfo_BatchInfo& MasterComponentInfo_BatchInfo::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_artm_2fmessages_2eproto();
+  return *default_instance_;
+}
+
+MasterComponentInfo_BatchInfo* MasterComponentInfo_BatchInfo::default_instance_ = NULL;
+
+MasterComponentInfo_BatchInfo* MasterComponentInfo_BatchInfo::New() const {
+  return new MasterComponentInfo_BatchInfo;
+}
+
+void MasterComponentInfo_BatchInfo::Clear() {
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (has_name()) {
+      if (name_ != &::google::protobuf::internal::GetEmptyString()) {
+        name_->clear();
+      }
+    }
+    items_count_ = 0;
+    token_count_ = 0;
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool MasterComponentInfo_BatchInfo::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) return false
+  ::google::protobuf::uint32 tag;
+  while ((tag = input->ReadTag()) != 0) {
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional string name = 1;
+      case 1: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_name()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+            this->name().data(), this->name().length(),
+            ::google::protobuf::internal::WireFormat::PARSE);
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(16)) goto parse_items_count;
+        break;
+      }
+
+      // optional int32 items_count = 2;
+      case 2: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
+         parse_items_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &items_count_)));
+          set_has_items_count();
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(24)) goto parse_token_count;
+        break;
+      }
+
+      // optional int32 token_count = 3;
+      case 3: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
+         parse_token_count:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &token_count_)));
+          set_has_token_count();
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectAtEnd()) return true;
+        break;
+      }
+
+      default: {
+      handle_uninterpreted:
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          return true;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+  return true;
+#undef DO_
+}
+
+void MasterComponentInfo_BatchInfo::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // optional string name = 1;
+  if (has_name()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+      this->name().data(), this->name().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE);
+    ::google::protobuf::internal::WireFormatLite::WriteString(
+      1, this->name(), output);
+  }
+
+  // optional int32 items_count = 2;
+  if (has_items_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(2, this->items_count(), output);
+  }
+
+  // optional int32 token_count = 3;
+  if (has_token_count()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(3, this->token_count(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+}
+
+::google::protobuf::uint8* MasterComponentInfo_BatchInfo::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // optional string name = 1;
+  if (has_name()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+      this->name().data(), this->name().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE);
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->name(), target);
+  }
+
+  // optional int32 items_count = 2;
+  if (has_items_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(2, this->items_count(), target);
+  }
+
+  // optional int32 token_count = 3;
+  if (has_token_count()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(3, this->token_count(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  return target;
+}
+
+int MasterComponentInfo_BatchInfo::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional string name = 1;
+    if (has_name()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::StringSize(
+          this->name());
+    }
+
+    // optional int32 items_count = 2;
+    if (has_items_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->items_count());
+    }
+
+    // optional int32 token_count = 3;
+    if (has_token_count()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->token_count());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void MasterComponentInfo_BatchInfo::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const MasterComponentInfo_BatchInfo* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const MasterComponentInfo_BatchInfo*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void MasterComponentInfo_BatchInfo::MergeFrom(const MasterComponentInfo_BatchInfo& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_name()) {
+      set_name(from.name());
+    }
+    if (from.has_items_count()) {
+      set_items_count(from.items_count());
+    }
+    if (from.has_token_count()) {
+      set_token_count(from.token_count());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void MasterComponentInfo_BatchInfo::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void MasterComponentInfo_BatchInfo::CopyFrom(const MasterComponentInfo_BatchInfo& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool MasterComponentInfo_BatchInfo::IsInitialized() const {
+
+  return true;
+}
+
+void MasterComponentInfo_BatchInfo::Swap(MasterComponentInfo_BatchInfo* other) {
+  if (other != this) {
+    std::swap(name_, other->name_);
+    std::swap(items_count_, other->items_count_);
+    std::swap(token_count_, other->token_count_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata MasterComponentInfo_BatchInfo::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = MasterComponentInfo_BatchInfo_descriptor_;
+  metadata.reflection = MasterComponentInfo_BatchInfo_reflection_;
+  return metadata;
+}
+
+
+// -------------------------------------------------------------------
+
+#ifndef _MSC_VER
 const int MasterComponentInfo_ModelInfo::kNameFieldNumber;
 const int MasterComponentInfo_ModelInfo::kTypeFieldNumber;
 const int MasterComponentInfo_ModelInfo::kTopicsCountFieldNumber;
@@ -29309,6 +29746,7 @@ const int MasterComponentInfo::kModelFieldNumber;
 const int MasterComponentInfo::kCacheEntryFieldNumber;
 const int MasterComponentInfo::kMergerQueueSizeFieldNumber;
 const int MasterComponentInfo::kProcessorQueueSizeFieldNumber;
+const int MasterComponentInfo::kBatchFieldNumber;
 #endif  // !_MSC_VER
 
 MasterComponentInfo::MasterComponentInfo()
@@ -29382,6 +29820,7 @@ void MasterComponentInfo::Clear() {
   dictionary_.Clear();
   model_.Clear();
   cache_entry_.Clear();
+  batch_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -29524,6 +29963,21 @@ bool MasterComponentInfo::MergePartialFromCodedStream(
         } else {
           goto handle_uninterpreted;
         }
+        if (input->ExpectTag(82)) goto parse_batch;
+        break;
+      }
+
+      // repeated .artm.MasterComponentInfo.BatchInfo batch = 10;
+      case 10: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+         parse_batch:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+                input, add_batch()));
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(82)) goto parse_batch;
         if (input->ExpectAtEnd()) return true;
         break;
       }
@@ -29597,6 +30051,12 @@ void MasterComponentInfo::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt32(9, this->processor_queue_size(), output);
   }
 
+  // repeated .artm.MasterComponentInfo.BatchInfo batch = 10;
+  for (int i = 0; i < this->batch_size(); i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      10, this->batch(i), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -29660,6 +30120,13 @@ void MasterComponentInfo::SerializeWithCachedSizes(
   // optional int32 processor_queue_size = 9;
   if (has_processor_queue_size()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(9, this->processor_queue_size(), target);
+  }
+
+  // repeated .artm.MasterComponentInfo.BatchInfo batch = 10;
+  for (int i = 0; i < this->batch_size(); i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        10, this->batch(i), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -29744,6 +30211,14 @@ int MasterComponentInfo::ByteSize() const {
         this->cache_entry(i));
   }
 
+  // repeated .artm.MasterComponentInfo.BatchInfo batch = 10;
+  total_size += 1 * this->batch_size();
+  for (int i = 0; i < this->batch_size(); i++) {
+    total_size +=
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        this->batch(i));
+  }
+
   if (!unknown_fields().empty()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -29774,6 +30249,7 @@ void MasterComponentInfo::MergeFrom(const MasterComponentInfo& from) {
   dictionary_.MergeFrom(from.dictionary_);
   model_.MergeFrom(from.model_);
   cache_entry_.MergeFrom(from.cache_entry_);
+  batch_.MergeFrom(from.batch_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_master_id()) {
       set_master_id(from.master_id());
@@ -29821,6 +30297,7 @@ void MasterComponentInfo::Swap(MasterComponentInfo* other) {
     cache_entry_.Swap(&other->cache_entry_);
     std::swap(merger_queue_size_, other->merger_queue_size_);
     std::swap(processor_queue_size_, other->processor_queue_size_);
+    batch_.Swap(&other->batch_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);
@@ -29832,6 +30309,468 @@ void MasterComponentInfo::Swap(MasterComponentInfo* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = MasterComponentInfo_descriptor_;
   metadata.reflection = MasterComponentInfo_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int ImportBatchesArgs::kBatchNameFieldNumber;
+const int ImportBatchesArgs::kBatchFieldNumber;
+#endif  // !_MSC_VER
+
+ImportBatchesArgs::ImportBatchesArgs()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+}
+
+void ImportBatchesArgs::InitAsDefaultInstance() {
+}
+
+ImportBatchesArgs::ImportBatchesArgs(const ImportBatchesArgs& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+}
+
+void ImportBatchesArgs::SharedCtor() {
+  _cached_size_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+ImportBatchesArgs::~ImportBatchesArgs() {
+  SharedDtor();
+}
+
+void ImportBatchesArgs::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void ImportBatchesArgs::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* ImportBatchesArgs::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return ImportBatchesArgs_descriptor_;
+}
+
+const ImportBatchesArgs& ImportBatchesArgs::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_artm_2fmessages_2eproto();
+  return *default_instance_;
+}
+
+ImportBatchesArgs* ImportBatchesArgs::default_instance_ = NULL;
+
+ImportBatchesArgs* ImportBatchesArgs::New() const {
+  return new ImportBatchesArgs;
+}
+
+void ImportBatchesArgs::Clear() {
+  batch_name_.Clear();
+  batch_.Clear();
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool ImportBatchesArgs::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) return false
+  ::google::protobuf::uint32 tag;
+  while ((tag = input->ReadTag()) != 0) {
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // repeated string batch_name = 1;
+      case 1: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+         parse_batch_name:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->add_batch_name()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+            this->batch_name(this->batch_name_size() - 1).data(),
+            this->batch_name(this->batch_name_size() - 1).length(),
+            ::google::protobuf::internal::WireFormat::PARSE);
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(10)) goto parse_batch_name;
+        if (input->ExpectTag(26)) goto parse_batch;
+        break;
+      }
+
+      // repeated .artm.Batch batch = 3;
+      case 3: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+         parse_batch:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+                input, add_batch()));
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(26)) goto parse_batch;
+        if (input->ExpectAtEnd()) return true;
+        break;
+      }
+
+      default: {
+      handle_uninterpreted:
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          return true;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+  return true;
+#undef DO_
+}
+
+void ImportBatchesArgs::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // repeated string batch_name = 1;
+  for (int i = 0; i < this->batch_name_size(); i++) {
+  ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+    this->batch_name(i).data(), this->batch_name(i).length(),
+    ::google::protobuf::internal::WireFormat::SERIALIZE);
+    ::google::protobuf::internal::WireFormatLite::WriteString(
+      1, this->batch_name(i), output);
+  }
+
+  // repeated .artm.Batch batch = 3;
+  for (int i = 0; i < this->batch_size(); i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      3, this->batch(i), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+}
+
+::google::protobuf::uint8* ImportBatchesArgs::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // repeated string batch_name = 1;
+  for (int i = 0; i < this->batch_name_size(); i++) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+      this->batch_name(i).data(), this->batch_name(i).length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE);
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteStringToArray(1, this->batch_name(i), target);
+  }
+
+  // repeated .artm.Batch batch = 3;
+  for (int i = 0; i < this->batch_size(); i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        3, this->batch(i), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  return target;
+}
+
+int ImportBatchesArgs::ByteSize() const {
+  int total_size = 0;
+
+  // repeated string batch_name = 1;
+  total_size += 1 * this->batch_name_size();
+  for (int i = 0; i < this->batch_name_size(); i++) {
+    total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
+      this->batch_name(i));
+  }
+
+  // repeated .artm.Batch batch = 3;
+  total_size += 1 * this->batch_size();
+  for (int i = 0; i < this->batch_size(); i++) {
+    total_size +=
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        this->batch(i));
+  }
+
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void ImportBatchesArgs::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const ImportBatchesArgs* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const ImportBatchesArgs*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void ImportBatchesArgs::MergeFrom(const ImportBatchesArgs& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  batch_name_.MergeFrom(from.batch_name_);
+  batch_.MergeFrom(from.batch_);
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void ImportBatchesArgs::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ImportBatchesArgs::CopyFrom(const ImportBatchesArgs& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ImportBatchesArgs::IsInitialized() const {
+
+  return true;
+}
+
+void ImportBatchesArgs::Swap(ImportBatchesArgs* other) {
+  if (other != this) {
+    batch_name_.Swap(&other->batch_name_);
+    batch_.Swap(&other->batch_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata ImportBatchesArgs::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = ImportBatchesArgs_descriptor_;
+  metadata.reflection = ImportBatchesArgs_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int DisposeBatchesArgs::kBatchNameFieldNumber;
+#endif  // !_MSC_VER
+
+DisposeBatchesArgs::DisposeBatchesArgs()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+}
+
+void DisposeBatchesArgs::InitAsDefaultInstance() {
+}
+
+DisposeBatchesArgs::DisposeBatchesArgs(const DisposeBatchesArgs& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+}
+
+void DisposeBatchesArgs::SharedCtor() {
+  _cached_size_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+DisposeBatchesArgs::~DisposeBatchesArgs() {
+  SharedDtor();
+}
+
+void DisposeBatchesArgs::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void DisposeBatchesArgs::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* DisposeBatchesArgs::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return DisposeBatchesArgs_descriptor_;
+}
+
+const DisposeBatchesArgs& DisposeBatchesArgs::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_artm_2fmessages_2eproto();
+  return *default_instance_;
+}
+
+DisposeBatchesArgs* DisposeBatchesArgs::default_instance_ = NULL;
+
+DisposeBatchesArgs* DisposeBatchesArgs::New() const {
+  return new DisposeBatchesArgs;
+}
+
+void DisposeBatchesArgs::Clear() {
+  batch_name_.Clear();
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool DisposeBatchesArgs::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) return false
+  ::google::protobuf::uint32 tag;
+  while ((tag = input->ReadTag()) != 0) {
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // repeated string batch_name = 1;
+      case 1: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+         parse_batch_name:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->add_batch_name()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+            this->batch_name(this->batch_name_size() - 1).data(),
+            this->batch_name(this->batch_name_size() - 1).length(),
+            ::google::protobuf::internal::WireFormat::PARSE);
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(10)) goto parse_batch_name;
+        if (input->ExpectAtEnd()) return true;
+        break;
+      }
+
+      default: {
+      handle_uninterpreted:
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          return true;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+  return true;
+#undef DO_
+}
+
+void DisposeBatchesArgs::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // repeated string batch_name = 1;
+  for (int i = 0; i < this->batch_name_size(); i++) {
+  ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+    this->batch_name(i).data(), this->batch_name(i).length(),
+    ::google::protobuf::internal::WireFormat::SERIALIZE);
+    ::google::protobuf::internal::WireFormatLite::WriteString(
+      1, this->batch_name(i), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+}
+
+::google::protobuf::uint8* DisposeBatchesArgs::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // repeated string batch_name = 1;
+  for (int i = 0; i < this->batch_name_size(); i++) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+      this->batch_name(i).data(), this->batch_name(i).length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE);
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteStringToArray(1, this->batch_name(i), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  return target;
+}
+
+int DisposeBatchesArgs::ByteSize() const {
+  int total_size = 0;
+
+  // repeated string batch_name = 1;
+  total_size += 1 * this->batch_name_size();
+  for (int i = 0; i < this->batch_name_size(); i++) {
+    total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
+      this->batch_name(i));
+  }
+
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void DisposeBatchesArgs::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const DisposeBatchesArgs* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const DisposeBatchesArgs*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void DisposeBatchesArgs::MergeFrom(const DisposeBatchesArgs& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  batch_name_.MergeFrom(from.batch_name_);
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void DisposeBatchesArgs::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void DisposeBatchesArgs::CopyFrom(const DisposeBatchesArgs& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool DisposeBatchesArgs::IsInitialized() const {
+
+  return true;
+}
+
+void DisposeBatchesArgs::Swap(DisposeBatchesArgs* other) {
+  if (other != this) {
+    batch_name_.Swap(&other->batch_name_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata DisposeBatchesArgs::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = DisposeBatchesArgs_descriptor_;
+  metadata.reflection = DisposeBatchesArgs_reflection_;
   return metadata;
 }
 

--- a/src/artm/messages.pb.h
+++ b/src/artm/messages.pb.h
@@ -106,8 +106,11 @@ class MasterComponentInfo;
 class MasterComponentInfo_RegularizerInfo;
 class MasterComponentInfo_ScoreInfo;
 class MasterComponentInfo_DictionaryInfo;
+class MasterComponentInfo_BatchInfo;
 class MasterComponentInfo_ModelInfo;
 class MasterComponentInfo_CacheEntryInfo;
+class ImportBatchesArgs;
+class DisposeBatchesArgs;
 
 enum Stream_Type {
   Stream_Type_Global = 0,
@@ -7219,6 +7222,22 @@ class InitializeModelArgs : public ::google::protobuf::Message {
   inline const ::google::protobuf::RepeatedPtrField< ::std::string>& topic_name() const;
   inline ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_topic_name();
 
+  // repeated string batch_filename = 8;
+  inline int batch_filename_size() const;
+  inline void clear_batch_filename();
+  static const int kBatchFilenameFieldNumber = 8;
+  inline const ::std::string& batch_filename(int index) const;
+  inline ::std::string* mutable_batch_filename(int index);
+  inline void set_batch_filename(int index, const ::std::string& value);
+  inline void set_batch_filename(int index, const char* value);
+  inline void set_batch_filename(int index, const char* value, size_t size);
+  inline ::std::string* add_batch_filename();
+  inline void add_batch_filename(const ::std::string& value);
+  inline void add_batch_filename(const char* value);
+  inline void add_batch_filename(const char* value, size_t size);
+  inline const ::google::protobuf::RepeatedPtrField< ::std::string>& batch_filename() const;
+  inline ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_batch_filename();
+
   // @@protoc_insertion_point(class_scope:artm.InitializeModelArgs)
  private:
   inline void set_has_model_name();
@@ -7241,9 +7260,10 @@ class InitializeModelArgs : public ::google::protobuf::Message {
   ::google::protobuf::int32 topics_count_;
   ::google::protobuf::RepeatedPtrField< ::artm::InitializeModelArgs_Filter > filter_;
   ::google::protobuf::RepeatedPtrField< ::std::string> topic_name_;
+  ::google::protobuf::RepeatedPtrField< ::std::string> batch_filename_;
 
   mutable int _cached_size_;
-  ::google::protobuf::uint32 _has_bits_[(7 + 31) / 32];
+  ::google::protobuf::uint32 _has_bits_[(8 + 31) / 32];
 
   friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
   friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
@@ -9824,6 +9844,113 @@ class MasterComponentInfo_DictionaryInfo : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
+class MasterComponentInfo_BatchInfo : public ::google::protobuf::Message {
+ public:
+  MasterComponentInfo_BatchInfo();
+  virtual ~MasterComponentInfo_BatchInfo();
+
+  MasterComponentInfo_BatchInfo(const MasterComponentInfo_BatchInfo& from);
+
+  inline MasterComponentInfo_BatchInfo& operator=(const MasterComponentInfo_BatchInfo& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const MasterComponentInfo_BatchInfo& default_instance();
+
+  void Swap(MasterComponentInfo_BatchInfo* other);
+
+  // implements Message ----------------------------------------------
+
+  MasterComponentInfo_BatchInfo* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const MasterComponentInfo_BatchInfo& from);
+  void MergeFrom(const MasterComponentInfo_BatchInfo& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional string name = 1;
+  inline bool has_name() const;
+  inline void clear_name();
+  static const int kNameFieldNumber = 1;
+  inline const ::std::string& name() const;
+  inline void set_name(const ::std::string& value);
+  inline void set_name(const char* value);
+  inline void set_name(const char* value, size_t size);
+  inline ::std::string* mutable_name();
+  inline ::std::string* release_name();
+  inline void set_allocated_name(::std::string* name);
+
+  // optional int32 items_count = 2;
+  inline bool has_items_count() const;
+  inline void clear_items_count();
+  static const int kItemsCountFieldNumber = 2;
+  inline ::google::protobuf::int32 items_count() const;
+  inline void set_items_count(::google::protobuf::int32 value);
+
+  // optional int32 token_count = 3;
+  inline bool has_token_count() const;
+  inline void clear_token_count();
+  static const int kTokenCountFieldNumber = 3;
+  inline ::google::protobuf::int32 token_count() const;
+  inline void set_token_count(::google::protobuf::int32 value);
+
+  // @@protoc_insertion_point(class_scope:artm.MasterComponentInfo.BatchInfo)
+ private:
+  inline void set_has_name();
+  inline void clear_has_name();
+  inline void set_has_items_count();
+  inline void clear_has_items_count();
+  inline void set_has_token_count();
+  inline void clear_has_token_count();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::std::string* name_;
+  ::google::protobuf::int32 items_count_;
+  ::google::protobuf::int32 token_count_;
+
+  mutable int _cached_size_;
+  ::google::protobuf::uint32 _has_bits_[(3 + 31) / 32];
+
+  friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
+  friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
+  friend void protobuf_ShutdownFile_artm_2fmessages_2eproto();
+
+  void InitAsDefaultInstance();
+  static MasterComponentInfo_BatchInfo* default_instance_;
+};
+// -------------------------------------------------------------------
+
 class MasterComponentInfo_ModelInfo : public ::google::protobuf::Message {
  public:
   MasterComponentInfo_ModelInfo();
@@ -10098,6 +10225,7 @@ class MasterComponentInfo : public ::google::protobuf::Message {
   typedef MasterComponentInfo_RegularizerInfo RegularizerInfo;
   typedef MasterComponentInfo_ScoreInfo ScoreInfo;
   typedef MasterComponentInfo_DictionaryInfo DictionaryInfo;
+  typedef MasterComponentInfo_BatchInfo BatchInfo;
   typedef MasterComponentInfo_ModelInfo ModelInfo;
   typedef MasterComponentInfo_CacheEntryInfo CacheEntryInfo;
 
@@ -10193,6 +10321,18 @@ class MasterComponentInfo : public ::google::protobuf::Message {
   inline ::google::protobuf::int32 processor_queue_size() const;
   inline void set_processor_queue_size(::google::protobuf::int32 value);
 
+  // repeated .artm.MasterComponentInfo.BatchInfo batch = 10;
+  inline int batch_size() const;
+  inline void clear_batch();
+  static const int kBatchFieldNumber = 10;
+  inline const ::artm::MasterComponentInfo_BatchInfo& batch(int index) const;
+  inline ::artm::MasterComponentInfo_BatchInfo* mutable_batch(int index);
+  inline ::artm::MasterComponentInfo_BatchInfo* add_batch();
+  inline const ::google::protobuf::RepeatedPtrField< ::artm::MasterComponentInfo_BatchInfo >&
+      batch() const;
+  inline ::google::protobuf::RepeatedPtrField< ::artm::MasterComponentInfo_BatchInfo >*
+      mutable_batch();
+
   // @@protoc_insertion_point(class_scope:artm.MasterComponentInfo)
  private:
   inline void set_has_master_id();
@@ -10214,10 +10354,11 @@ class MasterComponentInfo : public ::google::protobuf::Message {
   ::google::protobuf::RepeatedPtrField< ::artm::MasterComponentInfo_DictionaryInfo > dictionary_;
   ::google::protobuf::RepeatedPtrField< ::artm::MasterComponentInfo_ModelInfo > model_;
   ::google::protobuf::RepeatedPtrField< ::artm::MasterComponentInfo_CacheEntryInfo > cache_entry_;
+  ::google::protobuf::RepeatedPtrField< ::artm::MasterComponentInfo_BatchInfo > batch_;
   ::google::protobuf::int32 processor_queue_size_;
 
   mutable int _cached_size_;
-  ::google::protobuf::uint32 _has_bits_[(9 + 31) / 32];
+  ::google::protobuf::uint32 _has_bits_[(10 + 31) / 32];
 
   friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
   friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
@@ -10225,6 +10366,197 @@ class MasterComponentInfo : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static MasterComponentInfo* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class ImportBatchesArgs : public ::google::protobuf::Message {
+ public:
+  ImportBatchesArgs();
+  virtual ~ImportBatchesArgs();
+
+  ImportBatchesArgs(const ImportBatchesArgs& from);
+
+  inline ImportBatchesArgs& operator=(const ImportBatchesArgs& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ImportBatchesArgs& default_instance();
+
+  void Swap(ImportBatchesArgs* other);
+
+  // implements Message ----------------------------------------------
+
+  ImportBatchesArgs* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const ImportBatchesArgs& from);
+  void MergeFrom(const ImportBatchesArgs& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // repeated string batch_name = 1;
+  inline int batch_name_size() const;
+  inline void clear_batch_name();
+  static const int kBatchNameFieldNumber = 1;
+  inline const ::std::string& batch_name(int index) const;
+  inline ::std::string* mutable_batch_name(int index);
+  inline void set_batch_name(int index, const ::std::string& value);
+  inline void set_batch_name(int index, const char* value);
+  inline void set_batch_name(int index, const char* value, size_t size);
+  inline ::std::string* add_batch_name();
+  inline void add_batch_name(const ::std::string& value);
+  inline void add_batch_name(const char* value);
+  inline void add_batch_name(const char* value, size_t size);
+  inline const ::google::protobuf::RepeatedPtrField< ::std::string>& batch_name() const;
+  inline ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_batch_name();
+
+  // repeated .artm.Batch batch = 3;
+  inline int batch_size() const;
+  inline void clear_batch();
+  static const int kBatchFieldNumber = 3;
+  inline const ::artm::Batch& batch(int index) const;
+  inline ::artm::Batch* mutable_batch(int index);
+  inline ::artm::Batch* add_batch();
+  inline const ::google::protobuf::RepeatedPtrField< ::artm::Batch >&
+      batch() const;
+  inline ::google::protobuf::RepeatedPtrField< ::artm::Batch >*
+      mutable_batch();
+
+  // @@protoc_insertion_point(class_scope:artm.ImportBatchesArgs)
+ private:
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::RepeatedPtrField< ::std::string> batch_name_;
+  ::google::protobuf::RepeatedPtrField< ::artm::Batch > batch_;
+
+  mutable int _cached_size_;
+  ::google::protobuf::uint32 _has_bits_[(2 + 31) / 32];
+
+  friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
+  friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
+  friend void protobuf_ShutdownFile_artm_2fmessages_2eproto();
+
+  void InitAsDefaultInstance();
+  static ImportBatchesArgs* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class DisposeBatchesArgs : public ::google::protobuf::Message {
+ public:
+  DisposeBatchesArgs();
+  virtual ~DisposeBatchesArgs();
+
+  DisposeBatchesArgs(const DisposeBatchesArgs& from);
+
+  inline DisposeBatchesArgs& operator=(const DisposeBatchesArgs& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const DisposeBatchesArgs& default_instance();
+
+  void Swap(DisposeBatchesArgs* other);
+
+  // implements Message ----------------------------------------------
+
+  DisposeBatchesArgs* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const DisposeBatchesArgs& from);
+  void MergeFrom(const DisposeBatchesArgs& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // repeated string batch_name = 1;
+  inline int batch_name_size() const;
+  inline void clear_batch_name();
+  static const int kBatchNameFieldNumber = 1;
+  inline const ::std::string& batch_name(int index) const;
+  inline ::std::string* mutable_batch_name(int index);
+  inline void set_batch_name(int index, const ::std::string& value);
+  inline void set_batch_name(int index, const char* value);
+  inline void set_batch_name(int index, const char* value, size_t size);
+  inline ::std::string* add_batch_name();
+  inline void add_batch_name(const ::std::string& value);
+  inline void add_batch_name(const char* value);
+  inline void add_batch_name(const char* value, size_t size);
+  inline const ::google::protobuf::RepeatedPtrField< ::std::string>& batch_name() const;
+  inline ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_batch_name();
+
+  // @@protoc_insertion_point(class_scope:artm.DisposeBatchesArgs)
+ private:
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::RepeatedPtrField< ::std::string> batch_name_;
+
+  mutable int _cached_size_;
+  ::google::protobuf::uint32 _has_bits_[(1 + 31) / 32];
+
+  friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
+  friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
+  friend void protobuf_ShutdownFile_artm_2fmessages_2eproto();
+
+  void InitAsDefaultInstance();
+  static DisposeBatchesArgs* default_instance_;
 };
 // ===================================================================
 
@@ -19155,6 +19487,50 @@ InitializeModelArgs::mutable_topic_name() {
   return &topic_name_;
 }
 
+// repeated string batch_filename = 8;
+inline int InitializeModelArgs::batch_filename_size() const {
+  return batch_filename_.size();
+}
+inline void InitializeModelArgs::clear_batch_filename() {
+  batch_filename_.Clear();
+}
+inline const ::std::string& InitializeModelArgs::batch_filename(int index) const {
+  return batch_filename_.Get(index);
+}
+inline ::std::string* InitializeModelArgs::mutable_batch_filename(int index) {
+  return batch_filename_.Mutable(index);
+}
+inline void InitializeModelArgs::set_batch_filename(int index, const ::std::string& value) {
+  batch_filename_.Mutable(index)->assign(value);
+}
+inline void InitializeModelArgs::set_batch_filename(int index, const char* value) {
+  batch_filename_.Mutable(index)->assign(value);
+}
+inline void InitializeModelArgs::set_batch_filename(int index, const char* value, size_t size) {
+  batch_filename_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+}
+inline ::std::string* InitializeModelArgs::add_batch_filename() {
+  return batch_filename_.Add();
+}
+inline void InitializeModelArgs::add_batch_filename(const ::std::string& value) {
+  batch_filename_.Add()->assign(value);
+}
+inline void InitializeModelArgs::add_batch_filename(const char* value) {
+  batch_filename_.Add()->assign(value);
+}
+inline void InitializeModelArgs::add_batch_filename(const char* value, size_t size) {
+  batch_filename_.Add()->assign(reinterpret_cast<const char*>(value), size);
+}
+inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
+InitializeModelArgs::batch_filename() const {
+  return batch_filename_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::std::string>*
+InitializeModelArgs::mutable_batch_filename() {
+  return &batch_filename_;
+}
+
 // -------------------------------------------------------------------
 
 // GetTopicModelArgs
@@ -22413,6 +22789,124 @@ inline void MasterComponentInfo_DictionaryInfo::set_entries_count(::google::prot
 
 // -------------------------------------------------------------------
 
+// MasterComponentInfo_BatchInfo
+
+// optional string name = 1;
+inline bool MasterComponentInfo_BatchInfo::has_name() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void MasterComponentInfo_BatchInfo::set_has_name() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void MasterComponentInfo_BatchInfo::clear_has_name() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void MasterComponentInfo_BatchInfo::clear_name() {
+  if (name_ != &::google::protobuf::internal::GetEmptyString()) {
+    name_->clear();
+  }
+  clear_has_name();
+}
+inline const ::std::string& MasterComponentInfo_BatchInfo::name() const {
+  return *name_;
+}
+inline void MasterComponentInfo_BatchInfo::set_name(const ::std::string& value) {
+  set_has_name();
+  if (name_ == &::google::protobuf::internal::GetEmptyString()) {
+    name_ = new ::std::string;
+  }
+  name_->assign(value);
+}
+inline void MasterComponentInfo_BatchInfo::set_name(const char* value) {
+  set_has_name();
+  if (name_ == &::google::protobuf::internal::GetEmptyString()) {
+    name_ = new ::std::string;
+  }
+  name_->assign(value);
+}
+inline void MasterComponentInfo_BatchInfo::set_name(const char* value, size_t size) {
+  set_has_name();
+  if (name_ == &::google::protobuf::internal::GetEmptyString()) {
+    name_ = new ::std::string;
+  }
+  name_->assign(reinterpret_cast<const char*>(value), size);
+}
+inline ::std::string* MasterComponentInfo_BatchInfo::mutable_name() {
+  set_has_name();
+  if (name_ == &::google::protobuf::internal::GetEmptyString()) {
+    name_ = new ::std::string;
+  }
+  return name_;
+}
+inline ::std::string* MasterComponentInfo_BatchInfo::release_name() {
+  clear_has_name();
+  if (name_ == &::google::protobuf::internal::GetEmptyString()) {
+    return NULL;
+  } else {
+    ::std::string* temp = name_;
+    name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyString());
+    return temp;
+  }
+}
+inline void MasterComponentInfo_BatchInfo::set_allocated_name(::std::string* name) {
+  if (name_ != &::google::protobuf::internal::GetEmptyString()) {
+    delete name_;
+  }
+  if (name) {
+    set_has_name();
+    name_ = name;
+  } else {
+    clear_has_name();
+    name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyString());
+  }
+}
+
+// optional int32 items_count = 2;
+inline bool MasterComponentInfo_BatchInfo::has_items_count() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void MasterComponentInfo_BatchInfo::set_has_items_count() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void MasterComponentInfo_BatchInfo::clear_has_items_count() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void MasterComponentInfo_BatchInfo::clear_items_count() {
+  items_count_ = 0;
+  clear_has_items_count();
+}
+inline ::google::protobuf::int32 MasterComponentInfo_BatchInfo::items_count() const {
+  return items_count_;
+}
+inline void MasterComponentInfo_BatchInfo::set_items_count(::google::protobuf::int32 value) {
+  set_has_items_count();
+  items_count_ = value;
+}
+
+// optional int32 token_count = 3;
+inline bool MasterComponentInfo_BatchInfo::has_token_count() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void MasterComponentInfo_BatchInfo::set_has_token_count() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void MasterComponentInfo_BatchInfo::clear_has_token_count() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void MasterComponentInfo_BatchInfo::clear_token_count() {
+  token_count_ = 0;
+  clear_has_token_count();
+}
+inline ::google::protobuf::int32 MasterComponentInfo_BatchInfo::token_count() const {
+  return token_count_;
+}
+inline void MasterComponentInfo_BatchInfo::set_token_count(::google::protobuf::int32 value) {
+  set_has_token_count();
+  token_count_ = value;
+}
+
+// -------------------------------------------------------------------
+
 // MasterComponentInfo_ModelInfo
 
 // optional string name = 1;
@@ -22926,6 +23420,152 @@ inline ::google::protobuf::int32 MasterComponentInfo::processor_queue_size() con
 inline void MasterComponentInfo::set_processor_queue_size(::google::protobuf::int32 value) {
   set_has_processor_queue_size();
   processor_queue_size_ = value;
+}
+
+// repeated .artm.MasterComponentInfo.BatchInfo batch = 10;
+inline int MasterComponentInfo::batch_size() const {
+  return batch_.size();
+}
+inline void MasterComponentInfo::clear_batch() {
+  batch_.Clear();
+}
+inline const ::artm::MasterComponentInfo_BatchInfo& MasterComponentInfo::batch(int index) const {
+  return batch_.Get(index);
+}
+inline ::artm::MasterComponentInfo_BatchInfo* MasterComponentInfo::mutable_batch(int index) {
+  return batch_.Mutable(index);
+}
+inline ::artm::MasterComponentInfo_BatchInfo* MasterComponentInfo::add_batch() {
+  return batch_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::artm::MasterComponentInfo_BatchInfo >&
+MasterComponentInfo::batch() const {
+  return batch_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::artm::MasterComponentInfo_BatchInfo >*
+MasterComponentInfo::mutable_batch() {
+  return &batch_;
+}
+
+// -------------------------------------------------------------------
+
+// ImportBatchesArgs
+
+// repeated string batch_name = 1;
+inline int ImportBatchesArgs::batch_name_size() const {
+  return batch_name_.size();
+}
+inline void ImportBatchesArgs::clear_batch_name() {
+  batch_name_.Clear();
+}
+inline const ::std::string& ImportBatchesArgs::batch_name(int index) const {
+  return batch_name_.Get(index);
+}
+inline ::std::string* ImportBatchesArgs::mutable_batch_name(int index) {
+  return batch_name_.Mutable(index);
+}
+inline void ImportBatchesArgs::set_batch_name(int index, const ::std::string& value) {
+  batch_name_.Mutable(index)->assign(value);
+}
+inline void ImportBatchesArgs::set_batch_name(int index, const char* value) {
+  batch_name_.Mutable(index)->assign(value);
+}
+inline void ImportBatchesArgs::set_batch_name(int index, const char* value, size_t size) {
+  batch_name_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+}
+inline ::std::string* ImportBatchesArgs::add_batch_name() {
+  return batch_name_.Add();
+}
+inline void ImportBatchesArgs::add_batch_name(const ::std::string& value) {
+  batch_name_.Add()->assign(value);
+}
+inline void ImportBatchesArgs::add_batch_name(const char* value) {
+  batch_name_.Add()->assign(value);
+}
+inline void ImportBatchesArgs::add_batch_name(const char* value, size_t size) {
+  batch_name_.Add()->assign(reinterpret_cast<const char*>(value), size);
+}
+inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
+ImportBatchesArgs::batch_name() const {
+  return batch_name_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::std::string>*
+ImportBatchesArgs::mutable_batch_name() {
+  return &batch_name_;
+}
+
+// repeated .artm.Batch batch = 3;
+inline int ImportBatchesArgs::batch_size() const {
+  return batch_.size();
+}
+inline void ImportBatchesArgs::clear_batch() {
+  batch_.Clear();
+}
+inline const ::artm::Batch& ImportBatchesArgs::batch(int index) const {
+  return batch_.Get(index);
+}
+inline ::artm::Batch* ImportBatchesArgs::mutable_batch(int index) {
+  return batch_.Mutable(index);
+}
+inline ::artm::Batch* ImportBatchesArgs::add_batch() {
+  return batch_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::artm::Batch >&
+ImportBatchesArgs::batch() const {
+  return batch_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::artm::Batch >*
+ImportBatchesArgs::mutable_batch() {
+  return &batch_;
+}
+
+// -------------------------------------------------------------------
+
+// DisposeBatchesArgs
+
+// repeated string batch_name = 1;
+inline int DisposeBatchesArgs::batch_name_size() const {
+  return batch_name_.size();
+}
+inline void DisposeBatchesArgs::clear_batch_name() {
+  batch_name_.Clear();
+}
+inline const ::std::string& DisposeBatchesArgs::batch_name(int index) const {
+  return batch_name_.Get(index);
+}
+inline ::std::string* DisposeBatchesArgs::mutable_batch_name(int index) {
+  return batch_name_.Mutable(index);
+}
+inline void DisposeBatchesArgs::set_batch_name(int index, const ::std::string& value) {
+  batch_name_.Mutable(index)->assign(value);
+}
+inline void DisposeBatchesArgs::set_batch_name(int index, const char* value) {
+  batch_name_.Mutable(index)->assign(value);
+}
+inline void DisposeBatchesArgs::set_batch_name(int index, const char* value, size_t size) {
+  batch_name_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+}
+inline ::std::string* DisposeBatchesArgs::add_batch_name() {
+  return batch_name_.Add();
+}
+inline void DisposeBatchesArgs::add_batch_name(const ::std::string& value) {
+  batch_name_.Add()->assign(value);
+}
+inline void DisposeBatchesArgs::add_batch_name(const char* value) {
+  batch_name_.Add()->assign(value);
+}
+inline void DisposeBatchesArgs::add_batch_name(const char* value, size_t size) {
+  batch_name_.Add()->assign(reinterpret_cast<const char*>(value), size);
+}
+inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
+DisposeBatchesArgs::batch_name() const {
+  return batch_name_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::std::string>*
+DisposeBatchesArgs::mutable_batch_name() {
+  return &batch_name_;
 }
 
 

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -498,6 +498,8 @@ message InitializeModelArgs {
 
   optional int32 topics_count = 6;
   repeated string topic_name = 7;
+
+  repeated string batch_filename = 8;
 }
 
 message GetTopicModelArgs {
@@ -666,6 +668,12 @@ message MasterComponentInfo {
 	optional int64 entries_count = 2;
   }
 
+  message BatchInfo {
+    optional string name = 1;
+    optional int32 items_count = 2;
+    optional int32 token_count = 3;
+  }
+
   message ModelInfo {
     optional string name = 1;
 	optional string type = 2;
@@ -687,4 +695,14 @@ message MasterComponentInfo {
   repeated CacheEntryInfo cache_entry = 7;
   optional int32 merger_queue_size = 8;
   optional int32 processor_queue_size = 9;
+  repeated BatchInfo batch = 10;
+}
+
+message ImportBatchesArgs {
+  repeated string batch_name = 1;
+  repeated Batch batch = 3;
+}
+
+message DisposeBatchesArgs {
+  repeated string batch_name = 1;
 }


### PR DESCRIPTION
This is required for BigARTM integration with TopicMiner.

The idea is to create two API functions (`ArtmImportBatches` and `ArtmDisposeBatches`) to let user store batches in BigARTM memory space. In `ArtmImportBatches` user passes in a set of batch objects together with their string identifiers. Later those string identifiers can be used to initialize the model (`InitializeModelArgs.batch_filename`) or to process batches (`ProcessBatchesArgs.batch_filename`). This avoids unnecessary saving and re-loading batches when already reside in the memory.

The string identifier of a batch can be any string. However a recommendation would be to use something like `artm://<batch_uuid>`, to indicate that the batch is stored in BigARTM memory space.