### PR TITLE
Minor fixes in python interfaces

### DIFF
--- a/python/artm/master_component.py
+++ b/python/artm/master_component.py
@@ -108,7 +108,7 @@ class MasterComponent(object):
 
         self._lib.ArtmInitializeModel(self.master_id, init_args)
 
-    def process_batches(self, pwt, nwt, num_inner_iterations=None, batches_folder=None,
+    def process_batches(self, pwt, nwt=None, num_inner_iterations=None, batches_folder=None,
                         batches=None, regularizer_name=None, regularizer_tau=None,
                         class_ids=None, class_weights=None, find_theta=False,
                         reset_scores=False, reuse_theta=False, find_ptdw=False):
@@ -132,7 +132,8 @@ class MasterComponent(object):
         """
         args = messages.ProcessBatchesArgs()
         args.pwt_source_name = pwt
-        args.nwt_target_name = nwt
+        if nwt is not None:
+            args.nwt_target_name = nwt
         if batches_folder is not None:
             for name in os.listdir(batches_folder):
                 _, extension = os.path.splitext(name)

--- a/python/artm/model.py
+++ b/python/artm/model.py
@@ -43,6 +43,8 @@ class ARTM(object):
       will be used
       cache_theta (bool): save or not the Theta matrix in model. Necessary
       if ARTM.get_theta() usage expects, default=True
+      reuse_theta (bool): using theta from previous pass of the collection,
+      default=True
       scores(list): list of scores (objects of artm.***Score classes), default=None
       regularizers(list): list with regularizers (objects of
       artm.***Regularizer classes), default=None
@@ -65,7 +67,7 @@ class ARTM(object):
 
     # ========== CONSTRUCTOR ==========
     def __init__(self, num_processors=0, topic_names=None, num_topics=10, class_ids=None,
-                 cache_theta=True, scores=None, regularizers=None):
+                 cache_theta=True, reuse_theta=True, scores=None, regularizers=None):
         self._num_processors = 0
         self._num_topics = 10
         self._cache_theta = True
@@ -245,7 +247,7 @@ class ARTM(object):
             raise IOError('dictionary_name is None')
 
     def fit_offline(self, batch_vectorizer=None, num_collection_passes=20,
-                    num_document_passes=1, reuse_theta=True):
+                    num_document_passes=1):
         """ARTM.fit_offline() --- proceed the learning of
         topic model in off-line mode
 
@@ -255,8 +257,6 @@ class ARTM(object):
           collection, default=20
           num_document_passes (int): number of inner iterations over each document
           for inferring theta, default=1
-          reuse_theta (bool): using theta from previous pass of the collection,
-          defaul=True
 
         Note:
           ARTM.initialize() should be proceed before first call
@@ -301,7 +301,7 @@ class ARTM(object):
                                         class_ids=class_ids,
                                         class_weights=class_weights,
                                         reset_scores=True,
-                                        reuse_theta=reuse_theta)
+                                        reuse_theta=self._reuse_theta)
             self._synchronizations_processed += 1
             self.master.regularize_model(pwt=self.model_pwt,
                                          nwt=self.model_nwt,
@@ -580,7 +580,8 @@ class ARTM(object):
                                     class_ids=class_ids,
                                     class_weights=class_weights,
                                     find_theta=not find_ptdw,
-                                    find_ptdw=find_ptdw)
+                                    find_ptdw=find_ptdw,
+                                    reuse_theta=self._reuse_theta)
 
         document_ids = [item_id for item_id in theta_info.item_id]
         topic_names = [topic_name for topic_name in theta_info.topic_name]


### PR DESCRIPTION
This is not a final suggestion - I expect we should discuss this changes in more details. Here are some important topics:
* Should we expose ``reuse_theta`` in public API? It is known to be useful for certain experiments, because it allows to reproduce LDA and PLSA algorithms. It is also useful because normally users expect offline algorithm to reuse theta between iterations. However, ``reuse_theta`` flag is expensive and can not be applied to large collections. In addition, I can't decide whether we should or should not apply ``reuse_theta`` flag in ``transform`` method. On one hand, users naturally expect that on training dataset the ``transform`` method would give the same result as ``fit_transform``. On the other hand, cached theta values are not included in the model --- or example they will be dropped on ``model.export()``. So ``transform`` should always behave as if it receives new data.
* ``fit_transform`` does not perform ``fit``. I think this might be a souse of confusion!
* I would like to set ``nwt=None`` as a default in the master_component. This option (``nwt==None``) should be used for theta retrievals because it is faster and uses less memory.
* Theta regularizers should be applied in ``transform``
* We need to find a way to extract ``ptdw`` matrix via ``transform`` method. Should we add a flag for this?

