### PR TITLE
Implement framework for ptdw regularizers

### DIFF
--- a/python/artm/messages_pb2.py
+++ b/python/artm/messages_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import descriptor_pb2
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='artm/messages.proto',
   package='artm',
-  serialized_pb='\n\x13\x61rtm/messages.proto\x12\x04\x61rtm\" \n\x0b\x44oubleArray\x12\x11\n\x05value\x18\x01 \x03(\x01\x42\x02\x10\x01\"\x1f\n\nFloatArray\x12\x11\n\x05value\x18\x01 \x03(\x02\x42\x02\x10\x01\"\x1e\n\tBoolArray\x12\x11\n\x05value\x18\x01 \x03(\x08\x42\x02\x10\x01\"\x1d\n\x08IntArray\x12\x11\n\x05value\x18\x01 \x03(\x05\x42\x02\x10\x01\"\x1c\n\x0bStringArray\x12\r\n\x05value\x18\x01 \x03(\t\"=\n\x04Item\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x05\x66ield\x18\x02 \x03(\x0b\x32\x0b.artm.Field\x12\r\n\x05title\x18\x03 \x01(\t\"\x95\x02\n\x05\x46ield\x12\x13\n\x04name\x18\x01 \x01(\t:\x05@body\x12\x10\n\x08token_id\x18\x02 \x03(\x05\x12\x13\n\x0btoken_count\x18\x03 \x03(\x05\x12\x14\n\x0ctoken_offset\x18\x04 \x03(\x05\x12\x14\n\x0cstring_value\x18\x05 \x01(\t\x12\x11\n\tint_value\x18\x06 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x07 \x01(\x01\x12\x12\n\ndate_value\x18\x08 \x01(\t\x12\x14\n\x0cstring_array\x18\x10 \x03(\t\x12\x11\n\tint_array\x18\x11 \x03(\x03\x12\x14\n\x0c\x64ouble_array\x18\x12 \x03(\x01\x12\x12\n\ndate_array\x18\x13 \x03(\t\x12\x14\n\x0ctoken_weight\x18\x14 \x03(\x02\"c\n\x05\x42\x61tch\x12\r\n\x05token\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x18\n\x04item\x18\x03 \x03(\x0b\x32\n.artm.Item\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\"\x93\x01\n\x06Stream\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x11.artm.Stream.Type:\x06Global\x12\x15\n\x04name\x18\x02 \x01(\t:\x07@global\x12\x0f\n\x07modulus\x18\x03 \x01(\x05\x12\x11\n\tresiduals\x18\x04 \x03(\x05\"%\n\x04Type\x12\n\n\x06Global\x10\x00\x12\x11\n\rItemIdModulus\x10\x01\"\xd0\x02\n\x15MasterComponentConfig\x12\x11\n\tdisk_path\x18\x02 \x01(\t\x12\x1c\n\x06stream\x18\x03 \x03(\x0b\x32\x0c.artm.Stream\x12\x1d\n\x0f\x63ompact_batches\x18\x04 \x01(\x08:\x04true\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10processors_count\x18\x06 \x01(\x05\x12$\n\x18processor_queue_max_size\x18\x07 \x01(\x05:\x02\x31\x30\x12!\n\x15merger_queue_max_size\x18\x08 \x01(\x05:\x02\x31\x30\x12\'\n\x0cscore_config\x18\t \x03(\x0b\x32\x11.artm.ScoreConfig\x12&\n\x17online_batch_processing\x18\r \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x64isk_cache_path\x18\x0f \x01(\t\"d\n\x13RegularizerSettings\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03tau\x18\x02 \x01(\x01\x12#\n\x1buse_relative_regularization\x18\x03 \x01(\x08\x12\r\n\x05gamma\x18\x04 \x01(\x01\"\xa1\x04\n\x0bModelConfig\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x18\n\x0ctopics_count\x18\x02 \x01(\x05:\x02\x33\x32\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x15\n\x07\x65nabled\x18\x04 \x01(\x08:\x04true\x12\"\n\x16inner_iterations_count\x18\x05 \x01(\x05:\x02\x31\x30\x12\x19\n\nfield_name\x18\x06 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x07 \x01(\t:\x07@global\x12\x12\n\nscore_name\x18\x08 \x03(\t\x12\x1a\n\x0breuse_theta\x18\t \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10regularizer_name\x18\n \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x0b \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x0c \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\r \x03(\x02\x12\x1c\n\x0euse_sparse_bow\x18\x0e \x01(\x08:\x04true\x12\x1f\n\x10use_random_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\x12\x1c\n\x0euse_new_tokens\x18\x10 \x01(\x08:\x04true\x12\x19\n\x0bopt_for_avx\x18\x11 \x01(\x08:\x04true\x12\x37\n\x14regularizer_settings\x18\x12 \x03(\x0b\x32\x19.artm.RegularizerSettings\x12\x1e\n\x0fuse_ptdw_matrix\x18\x13 \x01(\x08:\x05\x66\x61lse\"\x8a\x02\n\x11RegularizerConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\x04type\x18\x02 \x01(\x0e\x32\x1c.artm.RegularizerConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\xaa\x01\n\x04Type\x12\x15\n\x11SmoothSparseTheta\x10\x00\x12\x13\n\x0fSmoothSparsePhi\x10\x01\x12\x13\n\x0f\x44\x65\x63orrelatorPhi\x10\x02\x12\x14\n\x10MultiLanguagePhi\x10\x03\x12\x1a\n\x16LabelRegularizationPhi\x10\x04\x12\x16\n\x12SpecifiedSparsePhi\x10\x05\x12\x17\n\x13ImproveCoherencePhi\x10\x06\"A\n\x17SmoothSparseThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x12\n\nalpha_iter\x18\x02 \x03(\x02\"V\n\x15SmoothSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"=\n\x15\x44\x65\x63orrelatorPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\"\x18\n\x16MultiLanguagePhiConfig\"]\n\x1cLabelRegularizationPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x82\x02\n\x18SpecifiedSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x1e\n\x12max_elements_count\x18\x03 \x01(\x05:\x02\x32\x30\x12#\n\x15probability_threshold\x18\x04 \x01(\x02:\x04\x30.99\x12?\n\x04mode\x18\x05 \x01(\x0e\x32#.artm.SpecifiedSparsePhiConfig.Mode:\x0cSparseTopics\"*\n\x04Mode\x12\x10\n\x0cSparseTopics\x10\x00\x12\x10\n\x0cSparseTokens\x10\x01\"Z\n\x19ImproveCoherencePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x87\x01\n\x18RegularizerInternalState\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.artm.RegularizerInternalState.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x1c\n\x04Type\x12\x14\n\x10MultiLanguagePhi\x10\x03\"C\n\x1dMultiLanguagePhiInternalState\x12\"\n\x17no_regularization_calls\x18\x01 \x01(\x05:\x01\x30\"\xd1\x01\n\x10\x44ictionaryConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x05\x65ntry\x18\x02 \x03(\x0b\x32\x15.artm.DictionaryEntry\x12\x19\n\x11total_token_count\x18\x03 \x01(\x05\x12\x19\n\x11total_items_count\x18\x04 \x01(\x05\x12\x37\n\x0c\x63ooc_entries\x18\x05 \x01(\x0b\x32!.artm.DictionaryCoocurenceEntries\x12\x1a\n\x12total_token_weight\x18\x06 \x01(\x02\"\xbd\x01\n\x0f\x44ictionaryEntry\x12\x11\n\tkey_token\x18\x01 \x01(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x02\x12\x14\n\x0cvalue_tokens\x18\x04 \x03(\t\x12 \n\x06values\x18\x05 \x01(\x0b\x32\x10.artm.FloatArray\x12\x13\n\x0btoken_count\x18\x06 \x01(\x05\x12\x13\n\x0bitems_count\x18\x07 \x01(\x05\x12\x14\n\x0ctoken_weight\x18\x08 \x01(\x02\"}\n\x1b\x44ictionaryCoocurenceEntries\x12\x13\n\x0b\x66irst_index\x18\x01 \x03(\x05\x12\x14\n\x0csecond_index\x18\x02 \x03(\x05\x12\r\n\x05value\x18\x03 \x03(\x02\x12$\n\x15symmetric_cooc_values\x18\x04 \x01(\x08:\x05\x66\x61lse\"\xe6\x01\n\x0bScoreConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x04type\x18\x02 \x01(\x0e\x32\x16.artm.ScoreConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xe0\x01\n\tScoreData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x04type\x18\x02 \x01(\x0e\x32\x14.artm.ScoreData.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xcc\x02\n\x15PerplexityScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12J\n\nmodel_type\x18\x03 \x01(\x0e\x32 .artm.PerplexityScoreConfig.Type:\x14UnigramDocumentModel\x12\x17\n\x0f\x64ictionary_name\x18\x04 \x01(\t\x12\"\n\x12theta_sparsity_eps\x18\x05 \x01(\x02:\x06\x31\x65-037\x12!\n\x19theta_sparsity_topic_name\x18\x06 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x07 \x03(\t\"<\n\x04Type\x12\x18\n\x14UnigramDocumentModel\x10\x00\x12\x1a\n\x16UnigramCollectionModel\x10\x01\"\xbc\x01\n\x0fPerplexityScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x0b\n\x03raw\x18\x02 \x01(\x01\x12\x12\n\nnormalizer\x18\x03 \x01(\x01\x12\x12\n\nzero_words\x18\x04 \x01(\x05\x12\x1c\n\x14theta_sparsity_value\x18\x05 \x01(\x01\x12\"\n\x1atheta_sparsity_zero_topics\x18\x06 \x01(\x05\x12#\n\x1btheta_sparsity_total_topics\x18\x07 \x01(\x05\"|\n\x18SparsityThetaScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x03\x65ps\x18\x03 \x01(\x02:\x06\x31\x65-037\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"N\n\x12SparsityThetaScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_topics\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_topics\x18\x03 \x01(\x05\"c\n\x16SparsityPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"L\n\x10SparsityPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_tokens\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x05\"T\n\x19ItemsProcessedScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\"$\n\x13ItemsProcessedScore\x12\r\n\x05value\x18\x01 \x01(\x05\"\x8a\x01\n\x14TopTokensScoreConfig\x12\x16\n\nnum_tokens\x18\x01 \x01(\x05:\x02\x31\x30\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x04 \x01(\t\"\xad\x01\n\x0eTopTokensScore\x12\x13\n\x0bnum_entries\x18\x01 \x01(\x05\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_index\x18\x03 \x03(\x05\x12\r\n\x05token\x18\x04 \x03(\t\x12\x0e\n\x06weight\x18\x05 \x03(\x02\x12#\n\tcoherence\x18\x06 \x01(\x0b\x32\x10.artm.FloatArray\x12\x19\n\x11\x61verage_coherence\x18\x07 \x01(\x02\"\x7f\n\x17ThetaSnippetScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x07item_id\x18\x03 \x03(\x05\x42\x02\x10\x01\x12\x16\n\nitem_count\x18\x04 \x01(\x05:\x02\x31\x30\"F\n\x11ThetaSnippetScore\x12\x0f\n\x07item_id\x18\x01 \x03(\x05\x12 \n\x06values\x18\x02 \x03(\x0b\x32\x10.artm.FloatArray\"\xb2\x01\n\x16TopicKernelScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\'\n\x1aprobability_mass_threshold\x18\x04 \x01(\x01:\x03\x30.1\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x05 \x01(\t\"\xff\x02\n\x10TopicKernelScore\x12&\n\x0bkernel_size\x18\x01 \x01(\x0b\x32\x11.artm.DoubleArray\x12(\n\rkernel_purity\x18\x02 \x01(\x0b\x32\x11.artm.DoubleArray\x12*\n\x0fkernel_contrast\x18\x03 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x1b\n\x13\x61verage_kernel_size\x18\x04 \x01(\x01\x12\x1d\n\x15\x61verage_kernel_purity\x18\x05 \x01(\x01\x12\x1f\n\x17\x61verage_kernel_contrast\x18\x06 \x01(\x01\x12$\n\tcoherence\x18\x07 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x19\n\x11\x61verage_coherence\x18\x08 \x01(\x02\x12(\n\rkernel_tokens\x18\t \x03(\x0b\x32\x11.artm.StringArray\x12%\n\ntopic_name\x18\n \x01(\x0b\x32\x11.artm.StringArray\"d\n\x17TopicMassPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"_\n\x11TopicMassPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_ratio\x18\x03 \x03(\x01\x12\x12\n\ntopic_mass\x18\x04 \x03(\x01\"\x94\x03\n\nTopicModel\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x14\n\x0ctopics_count\x18\x02 \x01(\x05\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\r\n\x05token\x18\x04 \x03(\t\x12\'\n\rtoken_weights\x18\x05 \x03(\x0b\x32\x10.artm.FloatArray\x12\x10\n\x08\x63lass_id\x18\x06 \x03(\t\x12\x11\n\tinternals\x18\x07 \x01(\x0c\x12#\n\x0btopic_index\x18\x08 \x03(\x0b\x32\x0e.artm.IntArray\x12\x36\n\x0eoperation_type\x18\t \x03(\x0e\x32\x1e.artm.TopicModel.OperationType\x1a\x35\n\x13TopicModelInternals\x12\x1e\n\x04n_wt\x18\x01 \x03(\x0b\x32\x10.artm.FloatArray\"U\n\rOperationType\x12\x0e\n\nInitialize\x10\x00\x12\r\n\tIncrement\x10\x01\x12\r\n\tOverwrite\x10\x02\x12\n\n\x06Remove\x10\x03\x12\n\n\x06Ignore\x10\x04\"\xc5\x01\n\x0bThetaMatrix\x12\x1a\n\nmodel_name\x18\x01 \x01(\t:\x06@model\x12\x0f\n\x07item_id\x18\x02 \x03(\x05\x12&\n\x0citem_weights\x18\x03 \x03(\x0b\x32\x10.artm.FloatArray\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x14\n\x0ctopics_count\x18\x05 \x01(\x05\x12\x12\n\nitem_title\x18\x06 \x03(\t\x12#\n\x0btopic_index\x18\x07 \x03(\x0b\x32\x0e.artm.IntArray\"\xe3\x03\n\x16\x43ollectionParserConfig\x12\x42\n\x06\x66ormat\x18\x01 \x01(\x0e\x32#.artm.CollectionParserConfig.Format:\rBagOfWordsUci\x12\x19\n\x11\x64ocword_file_path\x18\x02 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x03 \x01(\t\x12\x15\n\rtarget_folder\x18\x04 \x01(\t\x12\x1c\n\x14\x64ictionary_file_name\x18\x05 \x01(\t\x12!\n\x13num_items_per_batch\x18\x06 \x01(\x05:\x04\x31\x30\x30\x30\x12\x1a\n\x12\x63ooccurrence_token\x18\x07 \x03(\t\x12%\n\x17use_unity_based_indices\x18\x08 \x01(\x08:\x04true\x12\x1a\n\x0bgather_cooc\x18\t \x01(\x08:\x05\x66\x61lse\x12\x1d\n\x15\x63ooccurrence_class_id\x18\n \x03(\t\x12(\n\x19use_symmetric_cooc_values\x18\x0b \x01(\x08:\x05\x66\x61lse\"Q\n\x06\x46ormat\x12\x11\n\rBagOfWordsUci\x10\x00\x12\x10\n\x0cMatrixMarket\x10\x01\x12\x10\n\x0cVowpalWabbit\x10\x02\x12\x10\n\x0c\x43ooccurrence\x10\x03\"\x7f\n\x14SynchronizeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0c\x64\x65\x63\x61y_weight\x18\x02 \x01(\x02:\x01\x30\x12!\n\x13invoke_regularizers\x18\x03 \x01(\x08:\x04true\x12\x17\n\x0c\x61pply_weight\x18\x04 \x01(\x02:\x01\x31\"\xe3\x03\n\x13InitializeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\x12\x45\n\x0bsource_type\x18\x03 \x01(\x0e\x32$.artm.InitializeModelArgs.SourceType:\nDictionary\x12\x11\n\tdisk_path\x18\x04 \x01(\t\x12\x30\n\x06\x66ilter\x18\x05 \x03(\x0b\x32 .artm.InitializeModelArgs.Filter\x12\x14\n\x0ctopics_count\x18\x06 \x01(\x05\x12\x12\n\ntopic_name\x18\x07 \x03(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x08 \x03(\t\x1a\xa5\x01\n\x06\x46ilter\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\t\x12\x16\n\x0emin_percentage\x18\x02 \x01(\x02\x12\x16\n\x0emax_percentage\x18\x03 \x01(\x02\x12\x11\n\tmin_items\x18\x04 \x01(\x05\x12\x11\n\tmax_items\x18\x05 \x01(\x05\x12\x17\n\x0fmin_total_count\x18\x06 \x01(\x05\x12\x1a\n\x12min_one_item_count\x18\x07 \x01(\x05\")\n\nSourceType\x12\x0e\n\nDictionary\x10\x00\x12\x0b\n\x07\x42\x61tches\x10\x01\"\xf4\x02\n\x11GetTopicModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\r\n\x05token\x18\x03 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x03(\t\x12\x19\n\x11use_sparse_format\x18\x05 \x01(\x08\x12\x13\n\x03\x65ps\x18\x06 \x01(\x02:\x06\x31\x65-037\x12>\n\x0crequest_type\x18\x07 \x01(\x0e\x32#.artm.GetTopicModelArgs.RequestType:\x03Pwt\x12\x42\n\rmatrix_layout\x18\x08 \x01(\x0e\x32$.artm.GetTopicModelArgs.MatrixLayout:\x05\x44\x65nse\";\n\x0bRequestType\x12\x07\n\x03Pwt\x10\x00\x12\x07\n\x03Nwt\x10\x01\x12\x0e\n\nTopicNames\x10\x02\x12\n\n\x06Tokens\x10\x03\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"\xa5\x02\n\x12GetThetaMatrixArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x02 \x01(\x0b\x32\x0b.artm.Batch\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x13\n\x0btopic_index\x18\x04 \x03(\x05\x12\x1a\n\x0b\x63lean_cache\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11use_sparse_format\x18\x06 \x01(\x08\x12\x13\n\x03\x65ps\x18\x07 \x01(\x02:\x06\x31\x65-037\x12\x43\n\rmatrix_layout\x18\x08 \x01(\x0e\x32%.artm.GetThetaMatrixArgs.MatrixLayout:\x05\x44\x65nse\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"W\n\x11GetScoreValueArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\nscore_name\x18\x02 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x01(\x0b\x32\x0b.artm.Batch\"\x82\x01\n\x0c\x41\x64\x64\x42\x61tchArgs\x12\x1a\n\x05\x62\x61tch\x18\x01 \x01(\x0b\x32\x0b.artm.Batch\x12 \n\x14timeout_milliseconds\x18\x02 \x01(\x05:\x02-1\x12\x1b\n\x0creset_scores\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x62\x61tch_file_name\x18\x04 \x01(\t\"a\n\x13InvokeIterationArgs\x12\x1b\n\x10iterations_count\x18\x01 \x01(\x05:\x01\x31\x12\x1a\n\x0creset_scores\x18\x02 \x01(\x08:\x04true\x12\x11\n\tdisk_path\x18\x03 \x01(\t\"0\n\x0cWaitIdleArgs\x12 \n\x14timeout_milliseconds\x18\x01 \x01(\x05:\x02-1\"8\n\x0f\x45xportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"8\n\x0fImportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"%\n\x0f\x41ttachModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\"\xcc\x04\n\x12ProcessBatchesArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12\x17\n\x0fpwt_source_name\x18\x03 \x01(\t\x12\"\n\x16inner_iterations_count\x18\x04 \x01(\x05:\x02\x31\x30\x12\x1c\n\x0bstream_name\x18\x05 \x01(\t:\x07@global\x12\x18\n\x10regularizer_name\x18\x06 \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x07 \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x08 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\t \x03(\x02\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12\x1a\n\x0creset_scores\x18\r \x01(\x08:\x04true\x12J\n\x11theta_matrix_type\x18\x0e \x01(\x0e\x32(.artm.ProcessBatchesArgs.ThetaMatrixType:\x05\x43\x61\x63he\x12\x14\n\x0c\x62\x61tch_weight\x18\x0f \x03(\x02\x12\x1e\n\x0fuse_ptdw_matrix\x18\x10 \x01(\x08:\x05\x66\x61lse\"\\\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\x12\r\n\tDensePtdw\x10\x04\x12\x0e\n\nSparsePtdw\x10\x05\"d\n\x14ProcessBatchesResult\x12#\n\nscore_data\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\x12\'\n\x0ctheta_matrix\x18\x02 \x01(\x0b\x32\x11.artm.ThetaMatrix\"m\n\x0eMergeModelArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x03(\t\x12\x15\n\rsource_weight\x18\x03 \x03(\x02\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"\x99\x01\n\x13RegularizeModelArgs\x12\x17\n\x0frwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fpwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x03 \x01(\t\x12\x37\n\x14regularizer_settings\x18\x04 \x03(\x0b\x32\x19.artm.RegularizerSettings\"_\n\x12NormalizeModelArgs\x12\x17\n\x0fpwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0frwt_source_name\x18\x03 \x01(\t\"B\n\x14ImportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"\xc1\x01\n\x15\x43opyRequestResultArgs\x12Q\n\x0crequest_type\x18\x01 \x01(\x0e\x32\'.artm.CopyRequestResultArgs.RequestType:\x12\x44\x65\x66\x61ultRequestType\"U\n\x0bRequestType\x12\x16\n\x12\x44\x65\x66\x61ultRequestType\x10\x00\x12\x16\n\x12GetThetaSecondPass\x10\x01\x12\x16\n\x12GetModelSecondPass\x10\x02\"\x1e\n\x1c\x44uplicateMasterComponentArgs\"\x1c\n\x1aGetMasterComponentInfoArgs\"\xc1\x06\n\x13MasterComponentInfo\x12\x11\n\tmaster_id\x18\x01 \x01(\x05\x12+\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x1b.artm.MasterComponentConfig\x12>\n\x0bregularizer\x18\x03 \x03(\x0b\x32).artm.MasterComponentInfo.RegularizerInfo\x12\x32\n\x05score\x18\x04 \x03(\x0b\x32#.artm.MasterComponentInfo.ScoreInfo\x12<\n\ndictionary\x18\x05 \x03(\x0b\x32(.artm.MasterComponentInfo.DictionaryInfo\x12\x32\n\x05model\x18\x06 \x03(\x0b\x32#.artm.MasterComponentInfo.ModelInfo\x12=\n\x0b\x63\x61\x63he_entry\x18\x07 \x03(\x0b\x32(.artm.MasterComponentInfo.CacheEntryInfo\x12\x19\n\x11merger_queue_size\x18\x08 \x01(\x05\x12\x1c\n\x14processor_queue_size\x18\t \x01(\x05\x12\x32\n\x05\x62\x61tch\x18\n \x03(\x0b\x32#.artm.MasterComponentInfo.BatchInfo\x1a-\n\x0fRegularizerInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\'\n\tScoreInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\x35\n\x0e\x44ictionaryInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rentries_count\x18\x02 \x01(\x03\x1a\x43\n\tBatchInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0bitems_count\x18\x02 \x01(\x05\x12\x13\n\x0btoken_count\x18\x03 \x01(\x05\x1aR\n\tModelInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x13\n\x0btoken_count\x18\x04 \x01(\x05\x1a\x30\n\x0e\x43\x61\x63heEntryInfo\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tbyte_size\x18\x02 \x01(\x05\"C\n\x11ImportBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x03(\x0b\x32\x0b.artm.Batch\"(\n\x12\x44isposeBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t')
+  serialized_pb='\n\x13\x61rtm/messages.proto\x12\x04\x61rtm\" \n\x0b\x44oubleArray\x12\x11\n\x05value\x18\x01 \x03(\x01\x42\x02\x10\x01\"\x1f\n\nFloatArray\x12\x11\n\x05value\x18\x01 \x03(\x02\x42\x02\x10\x01\"\x1e\n\tBoolArray\x12\x11\n\x05value\x18\x01 \x03(\x08\x42\x02\x10\x01\"\x1d\n\x08IntArray\x12\x11\n\x05value\x18\x01 \x03(\x05\x42\x02\x10\x01\"\x1c\n\x0bStringArray\x12\r\n\x05value\x18\x01 \x03(\t\"=\n\x04Item\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x05\x66ield\x18\x02 \x03(\x0b\x32\x0b.artm.Field\x12\r\n\x05title\x18\x03 \x01(\t\"\x95\x02\n\x05\x46ield\x12\x13\n\x04name\x18\x01 \x01(\t:\x05@body\x12\x10\n\x08token_id\x18\x02 \x03(\x05\x12\x13\n\x0btoken_count\x18\x03 \x03(\x05\x12\x14\n\x0ctoken_offset\x18\x04 \x03(\x05\x12\x14\n\x0cstring_value\x18\x05 \x01(\t\x12\x11\n\tint_value\x18\x06 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x07 \x01(\x01\x12\x12\n\ndate_value\x18\x08 \x01(\t\x12\x14\n\x0cstring_array\x18\x10 \x03(\t\x12\x11\n\tint_array\x18\x11 \x03(\x03\x12\x14\n\x0c\x64ouble_array\x18\x12 \x03(\x01\x12\x12\n\ndate_array\x18\x13 \x03(\t\x12\x14\n\x0ctoken_weight\x18\x14 \x03(\x02\"c\n\x05\x42\x61tch\x12\r\n\x05token\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x18\n\x04item\x18\x03 \x03(\x0b\x32\n.artm.Item\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\"\x93\x01\n\x06Stream\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x11.artm.Stream.Type:\x06Global\x12\x15\n\x04name\x18\x02 \x01(\t:\x07@global\x12\x0f\n\x07modulus\x18\x03 \x01(\x05\x12\x11\n\tresiduals\x18\x04 \x03(\x05\"%\n\x04Type\x12\n\n\x06Global\x10\x00\x12\x11\n\rItemIdModulus\x10\x01\"\xd0\x02\n\x15MasterComponentConfig\x12\x11\n\tdisk_path\x18\x02 \x01(\t\x12\x1c\n\x06stream\x18\x03 \x03(\x0b\x32\x0c.artm.Stream\x12\x1d\n\x0f\x63ompact_batches\x18\x04 \x01(\x08:\x04true\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10processors_count\x18\x06 \x01(\x05\x12$\n\x18processor_queue_max_size\x18\x07 \x01(\x05:\x02\x31\x30\x12!\n\x15merger_queue_max_size\x18\x08 \x01(\x05:\x02\x31\x30\x12\'\n\x0cscore_config\x18\t \x03(\x0b\x32\x11.artm.ScoreConfig\x12&\n\x17online_batch_processing\x18\r \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x64isk_cache_path\x18\x0f \x01(\t\"d\n\x13RegularizerSettings\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03tau\x18\x02 \x01(\x01\x12#\n\x1buse_relative_regularization\x18\x03 \x01(\x08\x12\r\n\x05gamma\x18\x04 \x01(\x01\"\x81\x04\n\x0bModelConfig\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x18\n\x0ctopics_count\x18\x02 \x01(\x05:\x02\x33\x32\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x15\n\x07\x65nabled\x18\x04 \x01(\x08:\x04true\x12\"\n\x16inner_iterations_count\x18\x05 \x01(\x05:\x02\x31\x30\x12\x19\n\nfield_name\x18\x06 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x07 \x01(\t:\x07@global\x12\x12\n\nscore_name\x18\x08 \x03(\t\x12\x1a\n\x0breuse_theta\x18\t \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10regularizer_name\x18\n \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x0b \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x0c \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\r \x03(\x02\x12\x1c\n\x0euse_sparse_bow\x18\x0e \x01(\x08:\x04true\x12\x1f\n\x10use_random_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\x12\x1c\n\x0euse_new_tokens\x18\x10 \x01(\x08:\x04true\x12\x19\n\x0bopt_for_avx\x18\x11 \x01(\x08:\x04true\x12\x37\n\x14regularizer_settings\x18\x12 \x03(\x0b\x32\x19.artm.RegularizerSettings\"\x9a\x02\n\x11RegularizerConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\x04type\x18\x02 \x01(\x0e\x32\x1c.artm.RegularizerConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\xba\x01\n\x04Type\x12\x15\n\x11SmoothSparseTheta\x10\x00\x12\x13\n\x0fSmoothSparsePhi\x10\x01\x12\x13\n\x0f\x44\x65\x63orrelatorPhi\x10\x02\x12\x14\n\x10MultiLanguagePhi\x10\x03\x12\x1a\n\x16LabelRegularizationPhi\x10\x04\x12\x16\n\x12SpecifiedSparsePhi\x10\x05\x12\x17\n\x13ImproveCoherencePhi\x10\x06\x12\x0e\n\nSmoothPtdw\x10\x07\"A\n\x17SmoothSparseThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x12\n\nalpha_iter\x18\x02 \x03(\x02\"V\n\x15SmoothSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"=\n\x15\x44\x65\x63orrelatorPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\"\x18\n\x16MultiLanguagePhiConfig\"]\n\x1cLabelRegularizationPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x82\x02\n\x18SpecifiedSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x1e\n\x12max_elements_count\x18\x03 \x01(\x05:\x02\x32\x30\x12#\n\x15probability_threshold\x18\x04 \x01(\x02:\x04\x30.99\x12?\n\x04mode\x18\x05 \x01(\x0e\x32#.artm.SpecifiedSparsePhiConfig.Mode:\x0cSparseTopics\"*\n\x04Mode\x12\x10\n\x0cSparseTopics\x10\x00\x12\x10\n\x0cSparseTokens\x10\x01\"Z\n\x19ImproveCoherencePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\xa4\x01\n\x10SmoothPtdwConfig\x12\x38\n\x04type\x18\x01 \x01(\x0e\x32\x1b.artm.SmoothPtdwConfig.Type:\rMovingAverage\x12\x12\n\x06window\x18\x03 \x01(\x05:\x02\x31\x30\x12\x14\n\tthreshold\x18\x04 \x01(\x01:\x01\x31\",\n\x04Type\x12\x11\n\rMovingAverage\x10\x01\x12\x11\n\rMovingProduct\x10\x02\"\x87\x01\n\x18RegularizerInternalState\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.artm.RegularizerInternalState.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x1c\n\x04Type\x12\x14\n\x10MultiLanguagePhi\x10\x03\"C\n\x1dMultiLanguagePhiInternalState\x12\"\n\x17no_regularization_calls\x18\x01 \x01(\x05:\x01\x30\"\xd1\x01\n\x10\x44ictionaryConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x05\x65ntry\x18\x02 \x03(\x0b\x32\x15.artm.DictionaryEntry\x12\x19\n\x11total_token_count\x18\x03 \x01(\x05\x12\x19\n\x11total_items_count\x18\x04 \x01(\x05\x12\x37\n\x0c\x63ooc_entries\x18\x05 \x01(\x0b\x32!.artm.DictionaryCoocurenceEntries\x12\x1a\n\x12total_token_weight\x18\x06 \x01(\x02\"\xbd\x01\n\x0f\x44ictionaryEntry\x12\x11\n\tkey_token\x18\x01 \x01(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x02\x12\x14\n\x0cvalue_tokens\x18\x04 \x03(\t\x12 \n\x06values\x18\x05 \x01(\x0b\x32\x10.artm.FloatArray\x12\x13\n\x0btoken_count\x18\x06 \x01(\x05\x12\x13\n\x0bitems_count\x18\x07 \x01(\x05\x12\x14\n\x0ctoken_weight\x18\x08 \x01(\x02\"}\n\x1b\x44ictionaryCoocurenceEntries\x12\x13\n\x0b\x66irst_index\x18\x01 \x03(\x05\x12\x14\n\x0csecond_index\x18\x02 \x03(\x05\x12\r\n\x05value\x18\x03 \x03(\x02\x12$\n\x15symmetric_cooc_values\x18\x04 \x01(\x08:\x05\x66\x61lse\"\xe6\x01\n\x0bScoreConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x04type\x18\x02 \x01(\x0e\x32\x16.artm.ScoreConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xe0\x01\n\tScoreData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x04type\x18\x02 \x01(\x0e\x32\x14.artm.ScoreData.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xcc\x02\n\x15PerplexityScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12J\n\nmodel_type\x18\x03 \x01(\x0e\x32 .artm.PerplexityScoreConfig.Type:\x14UnigramDocumentModel\x12\x17\n\x0f\x64ictionary_name\x18\x04 \x01(\t\x12\"\n\x12theta_sparsity_eps\x18\x05 \x01(\x02:\x06\x31\x65-037\x12!\n\x19theta_sparsity_topic_name\x18\x06 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x07 \x03(\t\"<\n\x04Type\x12\x18\n\x14UnigramDocumentModel\x10\x00\x12\x1a\n\x16UnigramCollectionModel\x10\x01\"\xbc\x01\n\x0fPerplexityScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x0b\n\x03raw\x18\x02 \x01(\x01\x12\x12\n\nnormalizer\x18\x03 \x01(\x01\x12\x12\n\nzero_words\x18\x04 \x01(\x05\x12\x1c\n\x14theta_sparsity_value\x18\x05 \x01(\x01\x12\"\n\x1atheta_sparsity_zero_topics\x18\x06 \x01(\x05\x12#\n\x1btheta_sparsity_total_topics\x18\x07 \x01(\x05\"|\n\x18SparsityThetaScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x03\x65ps\x18\x03 \x01(\x02:\x06\x31\x65-037\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"N\n\x12SparsityThetaScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_topics\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_topics\x18\x03 \x01(\x05\"c\n\x16SparsityPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"L\n\x10SparsityPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_tokens\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x05\"T\n\x19ItemsProcessedScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\"$\n\x13ItemsProcessedScore\x12\r\n\x05value\x18\x01 \x01(\x05\"\x8a\x01\n\x14TopTokensScoreConfig\x12\x16\n\nnum_tokens\x18\x01 \x01(\x05:\x02\x31\x30\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x04 \x01(\t\"\xad\x01\n\x0eTopTokensScore\x12\x13\n\x0bnum_entries\x18\x01 \x01(\x05\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_index\x18\x03 \x03(\x05\x12\r\n\x05token\x18\x04 \x03(\t\x12\x0e\n\x06weight\x18\x05 \x03(\x02\x12#\n\tcoherence\x18\x06 \x01(\x0b\x32\x10.artm.FloatArray\x12\x19\n\x11\x61verage_coherence\x18\x07 \x01(\x02\"\x7f\n\x17ThetaSnippetScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x07item_id\x18\x03 \x03(\x05\x42\x02\x10\x01\x12\x16\n\nitem_count\x18\x04 \x01(\x05:\x02\x31\x30\"F\n\x11ThetaSnippetScore\x12\x0f\n\x07item_id\x18\x01 \x03(\x05\x12 \n\x06values\x18\x02 \x03(\x0b\x32\x10.artm.FloatArray\"\xb2\x01\n\x16TopicKernelScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\'\n\x1aprobability_mass_threshold\x18\x04 \x01(\x01:\x03\x30.1\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x05 \x01(\t\"\xff\x02\n\x10TopicKernelScore\x12&\n\x0bkernel_size\x18\x01 \x01(\x0b\x32\x11.artm.DoubleArray\x12(\n\rkernel_purity\x18\x02 \x01(\x0b\x32\x11.artm.DoubleArray\x12*\n\x0fkernel_contrast\x18\x03 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x1b\n\x13\x61verage_kernel_size\x18\x04 \x01(\x01\x12\x1d\n\x15\x61verage_kernel_purity\x18\x05 \x01(\x01\x12\x1f\n\x17\x61verage_kernel_contrast\x18\x06 \x01(\x01\x12$\n\tcoherence\x18\x07 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x19\n\x11\x61verage_coherence\x18\x08 \x01(\x02\x12(\n\rkernel_tokens\x18\t \x03(\x0b\x32\x11.artm.StringArray\x12%\n\ntopic_name\x18\n \x01(\x0b\x32\x11.artm.StringArray\"d\n\x17TopicMassPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"_\n\x11TopicMassPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_ratio\x18\x03 \x03(\x01\x12\x12\n\ntopic_mass\x18\x04 \x03(\x01\"\x94\x03\n\nTopicModel\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x14\n\x0ctopics_count\x18\x02 \x01(\x05\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\r\n\x05token\x18\x04 \x03(\t\x12\'\n\rtoken_weights\x18\x05 \x03(\x0b\x32\x10.artm.FloatArray\x12\x10\n\x08\x63lass_id\x18\x06 \x03(\t\x12\x11\n\tinternals\x18\x07 \x01(\x0c\x12#\n\x0btopic_index\x18\x08 \x03(\x0b\x32\x0e.artm.IntArray\x12\x36\n\x0eoperation_type\x18\t \x03(\x0e\x32\x1e.artm.TopicModel.OperationType\x1a\x35\n\x13TopicModelInternals\x12\x1e\n\x04n_wt\x18\x01 \x03(\x0b\x32\x10.artm.FloatArray\"U\n\rOperationType\x12\x0e\n\nInitialize\x10\x00\x12\r\n\tIncrement\x10\x01\x12\r\n\tOverwrite\x10\x02\x12\n\n\x06Remove\x10\x03\x12\n\n\x06Ignore\x10\x04\"\xc5\x01\n\x0bThetaMatrix\x12\x1a\n\nmodel_name\x18\x01 \x01(\t:\x06@model\x12\x0f\n\x07item_id\x18\x02 \x03(\x05\x12&\n\x0citem_weights\x18\x03 \x03(\x0b\x32\x10.artm.FloatArray\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x14\n\x0ctopics_count\x18\x05 \x01(\x05\x12\x12\n\nitem_title\x18\x06 \x03(\t\x12#\n\x0btopic_index\x18\x07 \x03(\x0b\x32\x0e.artm.IntArray\"\xe3\x03\n\x16\x43ollectionParserConfig\x12\x42\n\x06\x66ormat\x18\x01 \x01(\x0e\x32#.artm.CollectionParserConfig.Format:\rBagOfWordsUci\x12\x19\n\x11\x64ocword_file_path\x18\x02 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x03 \x01(\t\x12\x15\n\rtarget_folder\x18\x04 \x01(\t\x12\x1c\n\x14\x64ictionary_file_name\x18\x05 \x01(\t\x12!\n\x13num_items_per_batch\x18\x06 \x01(\x05:\x04\x31\x30\x30\x30\x12\x1a\n\x12\x63ooccurrence_token\x18\x07 \x03(\t\x12%\n\x17use_unity_based_indices\x18\x08 \x01(\x08:\x04true\x12\x1a\n\x0bgather_cooc\x18\t \x01(\x08:\x05\x66\x61lse\x12\x1d\n\x15\x63ooccurrence_class_id\x18\n \x03(\t\x12(\n\x19use_symmetric_cooc_values\x18\x0b \x01(\x08:\x05\x66\x61lse\"Q\n\x06\x46ormat\x12\x11\n\rBagOfWordsUci\x10\x00\x12\x10\n\x0cMatrixMarket\x10\x01\x12\x10\n\x0cVowpalWabbit\x10\x02\x12\x10\n\x0c\x43ooccurrence\x10\x03\"\x7f\n\x14SynchronizeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0c\x64\x65\x63\x61y_weight\x18\x02 \x01(\x02:\x01\x30\x12!\n\x13invoke_regularizers\x18\x03 \x01(\x08:\x04true\x12\x17\n\x0c\x61pply_weight\x18\x04 \x01(\x02:\x01\x31\"\xe3\x03\n\x13InitializeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\x12\x45\n\x0bsource_type\x18\x03 \x01(\x0e\x32$.artm.InitializeModelArgs.SourceType:\nDictionary\x12\x11\n\tdisk_path\x18\x04 \x01(\t\x12\x30\n\x06\x66ilter\x18\x05 \x03(\x0b\x32 .artm.InitializeModelArgs.Filter\x12\x14\n\x0ctopics_count\x18\x06 \x01(\x05\x12\x12\n\ntopic_name\x18\x07 \x03(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x08 \x03(\t\x1a\xa5\x01\n\x06\x46ilter\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\t\x12\x16\n\x0emin_percentage\x18\x02 \x01(\x02\x12\x16\n\x0emax_percentage\x18\x03 \x01(\x02\x12\x11\n\tmin_items\x18\x04 \x01(\x05\x12\x11\n\tmax_items\x18\x05 \x01(\x05\x12\x17\n\x0fmin_total_count\x18\x06 \x01(\x05\x12\x1a\n\x12min_one_item_count\x18\x07 \x01(\x05\")\n\nSourceType\x12\x0e\n\nDictionary\x10\x00\x12\x0b\n\x07\x42\x61tches\x10\x01\"\xf4\x02\n\x11GetTopicModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\r\n\x05token\x18\x03 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x03(\t\x12\x19\n\x11use_sparse_format\x18\x05 \x01(\x08\x12\x13\n\x03\x65ps\x18\x06 \x01(\x02:\x06\x31\x65-037\x12>\n\x0crequest_type\x18\x07 \x01(\x0e\x32#.artm.GetTopicModelArgs.RequestType:\x03Pwt\x12\x42\n\rmatrix_layout\x18\x08 \x01(\x0e\x32$.artm.GetTopicModelArgs.MatrixLayout:\x05\x44\x65nse\";\n\x0bRequestType\x12\x07\n\x03Pwt\x10\x00\x12\x07\n\x03Nwt\x10\x01\x12\x0e\n\nTopicNames\x10\x02\x12\n\n\x06Tokens\x10\x03\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"\xa5\x02\n\x12GetThetaMatrixArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x02 \x01(\x0b\x32\x0b.artm.Batch\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x13\n\x0btopic_index\x18\x04 \x03(\x05\x12\x1a\n\x0b\x63lean_cache\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11use_sparse_format\x18\x06 \x01(\x08\x12\x13\n\x03\x65ps\x18\x07 \x01(\x02:\x06\x31\x65-037\x12\x43\n\rmatrix_layout\x18\x08 \x01(\x0e\x32%.artm.GetThetaMatrixArgs.MatrixLayout:\x05\x44\x65nse\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"W\n\x11GetScoreValueArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\nscore_name\x18\x02 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x01(\x0b\x32\x0b.artm.Batch\"\x82\x01\n\x0c\x41\x64\x64\x42\x61tchArgs\x12\x1a\n\x05\x62\x61tch\x18\x01 \x01(\x0b\x32\x0b.artm.Batch\x12 \n\x14timeout_milliseconds\x18\x02 \x01(\x05:\x02-1\x12\x1b\n\x0creset_scores\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x62\x61tch_file_name\x18\x04 \x01(\t\"a\n\x13InvokeIterationArgs\x12\x1b\n\x10iterations_count\x18\x01 \x01(\x05:\x01\x31\x12\x1a\n\x0creset_scores\x18\x02 \x01(\x08:\x04true\x12\x11\n\tdisk_path\x18\x03 \x01(\t\"0\n\x0cWaitIdleArgs\x12 \n\x14timeout_milliseconds\x18\x01 \x01(\x05:\x02-1\"8\n\x0f\x45xportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"8\n\x0fImportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"%\n\x0f\x41ttachModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\"\xac\x04\n\x12ProcessBatchesArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12\x17\n\x0fpwt_source_name\x18\x03 \x01(\t\x12\"\n\x16inner_iterations_count\x18\x04 \x01(\x05:\x02\x31\x30\x12\x1c\n\x0bstream_name\x18\x05 \x01(\t:\x07@global\x12\x18\n\x10regularizer_name\x18\x06 \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x07 \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x08 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\t \x03(\x02\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12\x1a\n\x0creset_scores\x18\r \x01(\x08:\x04true\x12J\n\x11theta_matrix_type\x18\x0e \x01(\x0e\x32(.artm.ProcessBatchesArgs.ThetaMatrixType:\x05\x43\x61\x63he\x12\x14\n\x0c\x62\x61tch_weight\x18\x0f \x03(\x02\"\\\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\x12\r\n\tDensePtdw\x10\x04\x12\x0e\n\nSparsePtdw\x10\x05\"d\n\x14ProcessBatchesResult\x12#\n\nscore_data\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\x12\'\n\x0ctheta_matrix\x18\x02 \x01(\x0b\x32\x11.artm.ThetaMatrix\"m\n\x0eMergeModelArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x03(\t\x12\x15\n\rsource_weight\x18\x03 \x03(\x02\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"\x99\x01\n\x13RegularizeModelArgs\x12\x17\n\x0frwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fpwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x03 \x01(\t\x12\x37\n\x14regularizer_settings\x18\x04 \x03(\x0b\x32\x19.artm.RegularizerSettings\"_\n\x12NormalizeModelArgs\x12\x17\n\x0fpwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0frwt_source_name\x18\x03 \x01(\t\"B\n\x14ImportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"\xc1\x01\n\x15\x43opyRequestResultArgs\x12Q\n\x0crequest_type\x18\x01 \x01(\x0e\x32\'.artm.CopyRequestResultArgs.RequestType:\x12\x44\x65\x66\x61ultRequestType\"U\n\x0bRequestType\x12\x16\n\x12\x44\x65\x66\x61ultRequestType\x10\x00\x12\x16\n\x12GetThetaSecondPass\x10\x01\x12\x16\n\x12GetModelSecondPass\x10\x02\"\x1e\n\x1c\x44uplicateMasterComponentArgs\"\x1c\n\x1aGetMasterComponentInfoArgs\"\xc1\x06\n\x13MasterComponentInfo\x12\x11\n\tmaster_id\x18\x01 \x01(\x05\x12+\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x1b.artm.MasterComponentConfig\x12>\n\x0bregularizer\x18\x03 \x03(\x0b\x32).artm.MasterComponentInfo.RegularizerInfo\x12\x32\n\x05score\x18\x04 \x03(\x0b\x32#.artm.MasterComponentInfo.ScoreInfo\x12<\n\ndictionary\x18\x05 \x03(\x0b\x32(.artm.MasterComponentInfo.DictionaryInfo\x12\x32\n\x05model\x18\x06 \x03(\x0b\x32#.artm.MasterComponentInfo.ModelInfo\x12=\n\x0b\x63\x61\x63he_entry\x18\x07 \x03(\x0b\x32(.artm.MasterComponentInfo.CacheEntryInfo\x12\x19\n\x11merger_queue_size\x18\x08 \x01(\x05\x12\x1c\n\x14processor_queue_size\x18\t \x01(\x05\x12\x32\n\x05\x62\x61tch\x18\n \x03(\x0b\x32#.artm.MasterComponentInfo.BatchInfo\x1a-\n\x0fRegularizerInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\'\n\tScoreInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\x35\n\x0e\x44ictionaryInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rentries_count\x18\x02 \x01(\x03\x1a\x43\n\tBatchInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0bitems_count\x18\x02 \x01(\x05\x12\x13\n\x0btoken_count\x18\x03 \x01(\x05\x1aR\n\tModelInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x13\n\x0btoken_count\x18\x04 \x01(\x05\x1a\x30\n\x0e\x43\x61\x63heEntryInfo\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tbyte_size\x18\x02 \x01(\x05\"C\n\x11ImportBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x03(\x0b\x32\x0b.artm.Batch\"(\n\x12\x44isposeBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t')
 
 
 
@@ -72,11 +72,15 @@ _REGULARIZERCONFIG_TYPE = _descriptor.EnumDescriptor(
       name='ImproveCoherencePhi', index=6, number=6,
       options=None,
       type=None),
+    _descriptor.EnumValueDescriptor(
+      name='SmoothPtdw', index=7, number=7,
+      options=None,
+      type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=1869,
-  serialized_end=2039,
+  serialized_start=1837,
+  serialized_end=2023,
 )
 
 _SPECIFIEDSPARSEPHICONFIG_MODE = _descriptor.EnumDescriptor(
@@ -96,8 +100,29 @@ _SPECIFIEDSPARSEPHICONFIG_MODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2597,
-  serialized_end=2639,
+  serialized_start=2581,
+  serialized_end=2623,
+)
+
+_SMOOTHPTDWCONFIG_TYPE = _descriptor.EnumDescriptor(
+  name='Type',
+  full_name='artm.SmoothPtdwConfig.Type',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='MovingAverage', index=0, number=1,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='MovingProduct', index=1, number=2,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=2838,
+  serialized_end=2882,
 )
 
 _REGULARIZERINTERNALSTATE_TYPE = _descriptor.EnumDescriptor(
@@ -113,8 +138,8 @@ _REGULARIZERINTERNALSTATE_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2841,
-  serialized_end=2869,
+  serialized_start=2992,
+  serialized_end=3020,
 )
 
 _SCORECONFIG_TYPE = _descriptor.EnumDescriptor(
@@ -158,8 +183,8 @@ _SCORECONFIG_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=3556,
-  serialized_end=3702,
+  serialized_start=3707,
+  serialized_end=3853,
 )
 
 _SCOREDATA_TYPE = _descriptor.EnumDescriptor(
@@ -203,8 +228,8 @@ _SCOREDATA_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=3556,
-  serialized_end=3702,
+  serialized_start=3707,
+  serialized_end=3853,
 )
 
 _PERPLEXITYSCORECONFIG_TYPE = _descriptor.EnumDescriptor(
@@ -224,8 +249,8 @@ _PERPLEXITYSCORECONFIG_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=4204,
-  serialized_end=4264,
+  serialized_start=4355,
+  serialized_end=4415,
 )
 
 _TOPICMODEL_OPERATIONTYPE = _descriptor.EnumDescriptor(
@@ -257,8 +282,8 @@ _TOPICMODEL_OPERATIONTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=6570,
-  serialized_end=6655,
+  serialized_start=6721,
+  serialized_end=6806,
 )
 
 _COLLECTIONPARSERCONFIG_FORMAT = _descriptor.EnumDescriptor(
@@ -286,8 +311,8 @@ _COLLECTIONPARSERCONFIG_FORMAT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=7260,
-  serialized_end=7341,
+  serialized_start=7411,
+  serialized_end=7492,
 )
 
 _INITIALIZEMODELARGS_SOURCETYPE = _descriptor.EnumDescriptor(
@@ -307,8 +332,8 @@ _INITIALIZEMODELARGS_SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=7915,
-  serialized_end=7956,
+  serialized_start=8066,
+  serialized_end=8107,
 )
 
 _GETTOPICMODELARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
@@ -336,8 +361,8 @@ _GETTOPICMODELARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8233,
-  serialized_end=8292,
+  serialized_start=8384,
+  serialized_end=8443,
 )
 
 _GETTOPICMODELARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
@@ -357,8 +382,8 @@ _GETTOPICMODELARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8294,
-  serialized_end=8331,
+  serialized_start=8445,
+  serialized_end=8482,
 )
 
 _GETTHETAMATRIXARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
@@ -378,8 +403,8 @@ _GETTHETAMATRIXARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8294,
-  serialized_end=8331,
+  serialized_start=8445,
+  serialized_end=8482,
 )
 
 _PROCESSBATCHESARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
@@ -415,8 +440,8 @@ _PROCESSBATCHESARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9652,
-  serialized_end=9744,
+  serialized_start=9771,
+  serialized_end=9863,
 )
 
 _COPYREQUESTRESULTARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
@@ -440,8 +465,8 @@ _COPYREQUESTRESULTARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10389,
-  serialized_end=10474,
+  serialized_start=10508,
+  serialized_end=10593,
 )
 
 
@@ -1118,13 +1143,6 @@ _MODELCONFIG = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
-    _descriptor.FieldDescriptor(
-      name='use_ptdw_matrix', full_name='artm.ModelConfig.use_ptdw_matrix', index=18,
-      number=19, type=8, cpp_type=7, label=1,
-      has_default_value=True, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
   ],
   extensions=[
   ],
@@ -1135,7 +1153,7 @@ _MODELCONFIG = _descriptor.Descriptor(
   is_extendable=False,
   extension_ranges=[],
   serialized_start=1225,
-  serialized_end=1770,
+  serialized_end=1738,
 )
 
 
@@ -1177,8 +1195,8 @@ _REGULARIZERCONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=1773,
-  serialized_end=2039,
+  serialized_start=1741,
+  serialized_end=2023,
 )
 
 
@@ -1212,8 +1230,8 @@ _SMOOTHSPARSETHETACONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2041,
-  serialized_end=2106,
+  serialized_start=2025,
+  serialized_end=2090,
 )
 
 
@@ -1254,8 +1272,8 @@ _SMOOTHSPARSEPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2108,
-  serialized_end=2194,
+  serialized_start=2092,
+  serialized_end=2178,
 )
 
 
@@ -1289,8 +1307,8 @@ _DECORRELATORPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2196,
-  serialized_end=2257,
+  serialized_start=2180,
+  serialized_end=2241,
 )
 
 
@@ -1310,8 +1328,8 @@ _MULTILANGUAGEPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2259,
-  serialized_end=2283,
+  serialized_start=2243,
+  serialized_end=2267,
 )
 
 
@@ -1352,8 +1370,8 @@ _LABELREGULARIZATIONPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2285,
-  serialized_end=2378,
+  serialized_start=2269,
+  serialized_end=2362,
 )
 
 
@@ -1409,8 +1427,8 @@ _SPECIFIEDSPARSEPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2381,
-  serialized_end=2639,
+  serialized_start=2365,
+  serialized_end=2623,
 )
 
 
@@ -1451,8 +1469,51 @@ _IMPROVECOHERENCEPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2641,
-  serialized_end=2731,
+  serialized_start=2625,
+  serialized_end=2715,
+)
+
+
+_SMOOTHPTDWCONFIG = _descriptor.Descriptor(
+  name='SmoothPtdwConfig',
+  full_name='artm.SmoothPtdwConfig',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='type', full_name='artm.SmoothPtdwConfig.type', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=True, default_value=1,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='window', full_name='artm.SmoothPtdwConfig.window', index=1,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=True, default_value=10,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='threshold', full_name='artm.SmoothPtdwConfig.threshold', index=2,
+      number=4, type=1, cpp_type=5, label=1,
+      has_default_value=True, default_value=1,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+    _SMOOTHPTDWCONFIG_TYPE,
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=2718,
+  serialized_end=2882,
 )
 
 
@@ -1494,8 +1555,8 @@ _REGULARIZERINTERNALSTATE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2734,
-  serialized_end=2869,
+  serialized_start=2885,
+  serialized_end=3020,
 )
 
 
@@ -1522,8 +1583,8 @@ _MULTILANGUAGEPHIINTERNALSTATE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2871,
-  serialized_end=2938,
+  serialized_start=3022,
+  serialized_end=3089,
 )
 
 
@@ -1585,8 +1646,8 @@ _DICTIONARYCONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2941,
-  serialized_end=3150,
+  serialized_start=3092,
+  serialized_end=3301,
 )
 
 
@@ -1662,8 +1723,8 @@ _DICTIONARYENTRY = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3153,
-  serialized_end=3342,
+  serialized_start=3304,
+  serialized_end=3493,
 )
 
 
@@ -1711,8 +1772,8 @@ _DICTIONARYCOOCURENCEENTRIES = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3344,
-  serialized_end=3469,
+  serialized_start=3495,
+  serialized_end=3620,
 )
 
 
@@ -1754,8 +1815,8 @@ _SCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3472,
-  serialized_end=3702,
+  serialized_start=3623,
+  serialized_end=3853,
 )
 
 
@@ -1797,8 +1858,8 @@ _SCOREDATA = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3705,
-  serialized_end=3929,
+  serialized_start=3856,
+  serialized_end=4080,
 )
 
 
@@ -1868,8 +1929,8 @@ _PERPLEXITYSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3932,
-  serialized_end=4264,
+  serialized_start=4083,
+  serialized_end=4415,
 )
 
 
@@ -1938,8 +1999,8 @@ _PERPLEXITYSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4267,
-  serialized_end=4455,
+  serialized_start=4418,
+  serialized_end=4606,
 )
 
 
@@ -1987,8 +2048,8 @@ _SPARSITYTHETASCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4457,
-  serialized_end=4581,
+  serialized_start=4608,
+  serialized_end=4732,
 )
 
 
@@ -2029,8 +2090,8 @@ _SPARSITYTHETASCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4583,
-  serialized_end=4661,
+  serialized_start=4734,
+  serialized_end=4812,
 )
 
 
@@ -2071,8 +2132,8 @@ _SPARSITYPHISCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4663,
-  serialized_end=4762,
+  serialized_start=4814,
+  serialized_end=4913,
 )
 
 
@@ -2113,8 +2174,8 @@ _SPARSITYPHISCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4764,
-  serialized_end=4840,
+  serialized_start=4915,
+  serialized_end=4991,
 )
 
 
@@ -2148,8 +2209,8 @@ _ITEMSPROCESSEDSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4842,
-  serialized_end=4926,
+  serialized_start=4993,
+  serialized_end=5077,
 )
 
 
@@ -2176,8 +2237,8 @@ _ITEMSPROCESSEDSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4928,
-  serialized_end=4964,
+  serialized_start=5079,
+  serialized_end=5115,
 )
 
 
@@ -2225,8 +2286,8 @@ _TOPTOKENSSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4967,
-  serialized_end=5105,
+  serialized_start=5118,
+  serialized_end=5256,
 )
 
 
@@ -2295,8 +2356,8 @@ _TOPTOKENSSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5108,
-  serialized_end=5281,
+  serialized_start=5259,
+  serialized_end=5432,
 )
 
 
@@ -2344,8 +2405,8 @@ _THETASNIPPETSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5283,
-  serialized_end=5410,
+  serialized_start=5434,
+  serialized_end=5561,
 )
 
 
@@ -2379,8 +2440,8 @@ _THETASNIPPETSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5412,
-  serialized_end=5482,
+  serialized_start=5563,
+  serialized_end=5633,
 )
 
 
@@ -2435,8 +2496,8 @@ _TOPICKERNELSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5485,
-  serialized_end=5663,
+  serialized_start=5636,
+  serialized_end=5814,
 )
 
 
@@ -2526,8 +2587,8 @@ _TOPICKERNELSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5666,
-  serialized_end=6049,
+  serialized_start=5817,
+  serialized_end=6200,
 )
 
 
@@ -2568,8 +2629,8 @@ _TOPICMASSPHISCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6051,
-  serialized_end=6151,
+  serialized_start=6202,
+  serialized_end=6302,
 )
 
 
@@ -2617,8 +2678,8 @@ _TOPICMASSPHISCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6153,
-  serialized_end=6248,
+  serialized_start=6304,
+  serialized_end=6399,
 )
 
 
@@ -2645,8 +2706,8 @@ _TOPICMODEL_TOPICMODELINTERNALS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6515,
-  serialized_end=6568,
+  serialized_start=6666,
+  serialized_end=6719,
 )
 
 _TOPICMODEL = _descriptor.Descriptor(
@@ -2729,8 +2790,8 @@ _TOPICMODEL = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6251,
-  serialized_end=6655,
+  serialized_start=6402,
+  serialized_end=6806,
 )
 
 
@@ -2799,8 +2860,8 @@ _THETAMATRIX = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6658,
-  serialized_end=6855,
+  serialized_start=6809,
+  serialized_end=7006,
 )
 
 
@@ -2898,8 +2959,8 @@ _COLLECTIONPARSERCONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6858,
-  serialized_end=7341,
+  serialized_start=7009,
+  serialized_end=7492,
 )
 
 
@@ -2947,8 +3008,8 @@ _SYNCHRONIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7343,
-  serialized_end=7470,
+  serialized_start=7494,
+  serialized_end=7621,
 )
 
 
@@ -3017,8 +3078,8 @@ _INITIALIZEMODELARGS_FILTER = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7748,
-  serialized_end=7913,
+  serialized_start=7899,
+  serialized_end=8064,
 )
 
 _INITIALIZEMODELARGS = _descriptor.Descriptor(
@@ -3094,8 +3155,8 @@ _INITIALIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7473,
-  serialized_end=7956,
+  serialized_start=7624,
+  serialized_end=8107,
 )
 
 
@@ -3173,8 +3234,8 @@ _GETTOPICMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7959,
-  serialized_end=8331,
+  serialized_start=8110,
+  serialized_end=8482,
 )
 
 
@@ -3251,8 +3312,8 @@ _GETTHETAMATRIXARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8334,
-  serialized_end=8627,
+  serialized_start=8485,
+  serialized_end=8778,
 )
 
 
@@ -3293,8 +3354,8 @@ _GETSCOREVALUEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8629,
-  serialized_end=8716,
+  serialized_start=8780,
+  serialized_end=8867,
 )
 
 
@@ -3342,8 +3403,8 @@ _ADDBATCHARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8719,
-  serialized_end=8849,
+  serialized_start=8870,
+  serialized_end=9000,
 )
 
 
@@ -3384,8 +3445,8 @@ _INVOKEITERATIONARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8851,
-  serialized_end=8948,
+  serialized_start=9002,
+  serialized_end=9099,
 )
 
 
@@ -3412,8 +3473,8 @@ _WAITIDLEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8950,
-  serialized_end=8998,
+  serialized_start=9101,
+  serialized_end=9149,
 )
 
 
@@ -3447,8 +3508,8 @@ _EXPORTMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9000,
-  serialized_end=9056,
+  serialized_start=9151,
+  serialized_end=9207,
 )
 
 
@@ -3482,8 +3543,8 @@ _IMPORTMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9058,
-  serialized_end=9114,
+  serialized_start=9209,
+  serialized_end=9265,
 )
 
 
@@ -3510,8 +3571,8 @@ _ATTACHMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9116,
-  serialized_end=9153,
+  serialized_start=9267,
+  serialized_end=9304,
 )
 
 
@@ -3627,13 +3688,6 @@ _PROCESSBATCHESARGS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
-    _descriptor.FieldDescriptor(
-      name='use_ptdw_matrix', full_name='artm.ProcessBatchesArgs.use_ptdw_matrix', index=15,
-      number=16, type=8, cpp_type=7, label=1,
-      has_default_value=True, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
   ],
   extensions=[
   ],
@@ -3644,8 +3698,8 @@ _PROCESSBATCHESARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9156,
-  serialized_end=9744,
+  serialized_start=9307,
+  serialized_end=9863,
 )
 
 
@@ -3679,8 +3733,8 @@ _PROCESSBATCHESRESULT = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9746,
-  serialized_end=9846,
+  serialized_start=9865,
+  serialized_end=9965,
 )
 
 
@@ -3728,8 +3782,8 @@ _MERGEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9848,
-  serialized_end=9957,
+  serialized_start=9967,
+  serialized_end=10076,
 )
 
 
@@ -3777,8 +3831,8 @@ _REGULARIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9960,
-  serialized_end=10113,
+  serialized_start=10079,
+  serialized_end=10232,
 )
 
 
@@ -3819,8 +3873,8 @@ _NORMALIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10115,
-  serialized_end=10210,
+  serialized_start=10234,
+  serialized_end=10329,
 )
 
 
@@ -3854,8 +3908,8 @@ _IMPORTDICTIONARYARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10212,
-  serialized_end=10278,
+  serialized_start=10331,
+  serialized_end=10397,
 )
 
 
@@ -3883,8 +3937,8 @@ _COPYREQUESTRESULTARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10281,
-  serialized_end=10474,
+  serialized_start=10400,
+  serialized_end=10593,
 )
 
 
@@ -3904,8 +3958,8 @@ _DUPLICATEMASTERCOMPONENTARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10476,
-  serialized_end=10506,
+  serialized_start=10595,
+  serialized_end=10625,
 )
 
 
@@ -3925,8 +3979,8 @@ _GETMASTERCOMPONENTINFOARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10508,
-  serialized_end=10536,
+  serialized_start=10627,
+  serialized_end=10655,
 )
 
 
@@ -3960,8 +4014,8 @@ _MASTERCOMPONENTINFO_REGULARIZERINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11028,
-  serialized_end=11073,
+  serialized_start=11147,
+  serialized_end=11192,
 )
 
 _MASTERCOMPONENTINFO_SCOREINFO = _descriptor.Descriptor(
@@ -3994,8 +4048,8 @@ _MASTERCOMPONENTINFO_SCOREINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11075,
-  serialized_end=11114,
+  serialized_start=11194,
+  serialized_end=11233,
 )
 
 _MASTERCOMPONENTINFO_DICTIONARYINFO = _descriptor.Descriptor(
@@ -4028,8 +4082,8 @@ _MASTERCOMPONENTINFO_DICTIONARYINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11116,
-  serialized_end=11169,
+  serialized_start=11235,
+  serialized_end=11288,
 )
 
 _MASTERCOMPONENTINFO_BATCHINFO = _descriptor.Descriptor(
@@ -4069,8 +4123,8 @@ _MASTERCOMPONENTINFO_BATCHINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11171,
-  serialized_end=11238,
+  serialized_start=11290,
+  serialized_end=11357,
 )
 
 _MASTERCOMPONENTINFO_MODELINFO = _descriptor.Descriptor(
@@ -4117,8 +4171,8 @@ _MASTERCOMPONENTINFO_MODELINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11240,
-  serialized_end=11322,
+  serialized_start=11359,
+  serialized_end=11441,
 )
 
 _MASTERCOMPONENTINFO_CACHEENTRYINFO = _descriptor.Descriptor(
@@ -4151,8 +4205,8 @@ _MASTERCOMPONENTINFO_CACHEENTRYINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11324,
-  serialized_end=11372,
+  serialized_start=11443,
+  serialized_end=11491,
 )
 
 _MASTERCOMPONENTINFO = _descriptor.Descriptor(
@@ -4241,8 +4295,8 @@ _MASTERCOMPONENTINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10539,
-  serialized_end=11372,
+  serialized_start=10658,
+  serialized_end=11491,
 )
 
 
@@ -4276,8 +4330,8 @@ _IMPORTBATCHESARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11374,
-  serialized_end=11441,
+  serialized_start=11493,
+  serialized_end=11560,
 )
 
 
@@ -4304,8 +4358,8 @@ _DISPOSEBATCHESARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11443,
-  serialized_end=11483,
+  serialized_start=11562,
+  serialized_end=11602,
 )
 
 _ITEM.fields_by_name['field'].message_type = _FIELD
@@ -4319,6 +4373,8 @@ _REGULARIZERCONFIG.fields_by_name['type'].enum_type = _REGULARIZERCONFIG_TYPE
 _REGULARIZERCONFIG_TYPE.containing_type = _REGULARIZERCONFIG;
 _SPECIFIEDSPARSEPHICONFIG.fields_by_name['mode'].enum_type = _SPECIFIEDSPARSEPHICONFIG_MODE
 _SPECIFIEDSPARSEPHICONFIG_MODE.containing_type = _SPECIFIEDSPARSEPHICONFIG;
+_SMOOTHPTDWCONFIG.fields_by_name['type'].enum_type = _SMOOTHPTDWCONFIG_TYPE
+_SMOOTHPTDWCONFIG_TYPE.containing_type = _SMOOTHPTDWCONFIG;
 _REGULARIZERINTERNALSTATE.fields_by_name['type'].enum_type = _REGULARIZERINTERNALSTATE_TYPE
 _REGULARIZERINTERNALSTATE_TYPE.containing_type = _REGULARIZERINTERNALSTATE;
 _DICTIONARYCONFIG.fields_by_name['entry'].message_type = _DICTIONARYENTRY
@@ -4402,6 +4458,7 @@ DESCRIPTOR.message_types_by_name['MultiLanguagePhiConfig'] = _MULTILANGUAGEPHICO
 DESCRIPTOR.message_types_by_name['LabelRegularizationPhiConfig'] = _LABELREGULARIZATIONPHICONFIG
 DESCRIPTOR.message_types_by_name['SpecifiedSparsePhiConfig'] = _SPECIFIEDSPARSEPHICONFIG
 DESCRIPTOR.message_types_by_name['ImproveCoherencePhiConfig'] = _IMPROVECOHERENCEPHICONFIG
+DESCRIPTOR.message_types_by_name['SmoothPtdwConfig'] = _SMOOTHPTDWCONFIG
 DESCRIPTOR.message_types_by_name['RegularizerInternalState'] = _REGULARIZERINTERNALSTATE
 DESCRIPTOR.message_types_by_name['MultiLanguagePhiInternalState'] = _MULTILANGUAGEPHIINTERNALSTATE
 DESCRIPTOR.message_types_by_name['DictionaryConfig'] = _DICTIONARYCONFIG
@@ -4571,6 +4628,12 @@ class ImproveCoherencePhiConfig(_message.Message):
   DESCRIPTOR = _IMPROVECOHERENCEPHICONFIG
 
   # @@protoc_insertion_point(class_scope:artm.ImproveCoherencePhiConfig)
+
+class SmoothPtdwConfig(_message.Message):
+  __metaclass__ = _reflection.GeneratedProtocolMessageType
+  DESCRIPTOR = _SMOOTHPTDWCONFIG
+
+  # @@protoc_insertion_point(class_scope:artm.SmoothPtdwConfig)
 
 class RegularizerInternalState(_message.Message):
   __metaclass__ = _reflection.GeneratedProtocolMessageType

--- a/python/artm/wrapper/messages_pb2.py
+++ b/python/artm/wrapper/messages_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import descriptor_pb2
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='artm/messages.proto',
   package='artm',
-  serialized_pb='\n\x13\x61rtm/messages.proto\x12\x04\x61rtm\" \n\x0b\x44oubleArray\x12\x11\n\x05value\x18\x01 \x03(\x01\x42\x02\x10\x01\"\x1f\n\nFloatArray\x12\x11\n\x05value\x18\x01 \x03(\x02\x42\x02\x10\x01\"\x1e\n\tBoolArray\x12\x11\n\x05value\x18\x01 \x03(\x08\x42\x02\x10\x01\"\x1d\n\x08IntArray\x12\x11\n\x05value\x18\x01 \x03(\x05\x42\x02\x10\x01\"\x1c\n\x0bStringArray\x12\r\n\x05value\x18\x01 \x03(\t\"=\n\x04Item\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x05\x66ield\x18\x02 \x03(\x0b\x32\x0b.artm.Field\x12\r\n\x05title\x18\x03 \x01(\t\"\x95\x02\n\x05\x46ield\x12\x13\n\x04name\x18\x01 \x01(\t:\x05@body\x12\x10\n\x08token_id\x18\x02 \x03(\x05\x12\x13\n\x0btoken_count\x18\x03 \x03(\x05\x12\x14\n\x0ctoken_offset\x18\x04 \x03(\x05\x12\x14\n\x0cstring_value\x18\x05 \x01(\t\x12\x11\n\tint_value\x18\x06 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x07 \x01(\x01\x12\x12\n\ndate_value\x18\x08 \x01(\t\x12\x14\n\x0cstring_array\x18\x10 \x03(\t\x12\x11\n\tint_array\x18\x11 \x03(\x03\x12\x14\n\x0c\x64ouble_array\x18\x12 \x03(\x01\x12\x12\n\ndate_array\x18\x13 \x03(\t\x12\x14\n\x0ctoken_weight\x18\x14 \x03(\x02\"c\n\x05\x42\x61tch\x12\r\n\x05token\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x18\n\x04item\x18\x03 \x03(\x0b\x32\n.artm.Item\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\"\x93\x01\n\x06Stream\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x11.artm.Stream.Type:\x06Global\x12\x15\n\x04name\x18\x02 \x01(\t:\x07@global\x12\x0f\n\x07modulus\x18\x03 \x01(\x05\x12\x11\n\tresiduals\x18\x04 \x03(\x05\"%\n\x04Type\x12\n\n\x06Global\x10\x00\x12\x11\n\rItemIdModulus\x10\x01\"\xd0\x02\n\x15MasterComponentConfig\x12\x11\n\tdisk_path\x18\x02 \x01(\t\x12\x1c\n\x06stream\x18\x03 \x03(\x0b\x32\x0c.artm.Stream\x12\x1d\n\x0f\x63ompact_batches\x18\x04 \x01(\x08:\x04true\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10processors_count\x18\x06 \x01(\x05\x12$\n\x18processor_queue_max_size\x18\x07 \x01(\x05:\x02\x31\x30\x12!\n\x15merger_queue_max_size\x18\x08 \x01(\x05:\x02\x31\x30\x12\'\n\x0cscore_config\x18\t \x03(\x0b\x32\x11.artm.ScoreConfig\x12&\n\x17online_batch_processing\x18\r \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x64isk_cache_path\x18\x0f \x01(\t\"d\n\x13RegularizerSettings\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03tau\x18\x02 \x01(\x01\x12#\n\x1buse_relative_regularization\x18\x03 \x01(\x08\x12\r\n\x05gamma\x18\x04 \x01(\x01\"\xa1\x04\n\x0bModelConfig\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x18\n\x0ctopics_count\x18\x02 \x01(\x05:\x02\x33\x32\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x15\n\x07\x65nabled\x18\x04 \x01(\x08:\x04true\x12\"\n\x16inner_iterations_count\x18\x05 \x01(\x05:\x02\x31\x30\x12\x19\n\nfield_name\x18\x06 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x07 \x01(\t:\x07@global\x12\x12\n\nscore_name\x18\x08 \x03(\t\x12\x1a\n\x0breuse_theta\x18\t \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10regularizer_name\x18\n \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x0b \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x0c \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\r \x03(\x02\x12\x1c\n\x0euse_sparse_bow\x18\x0e \x01(\x08:\x04true\x12\x1f\n\x10use_random_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\x12\x1c\n\x0euse_new_tokens\x18\x10 \x01(\x08:\x04true\x12\x19\n\x0bopt_for_avx\x18\x11 \x01(\x08:\x04true\x12\x37\n\x14regularizer_settings\x18\x12 \x03(\x0b\x32\x19.artm.RegularizerSettings\x12\x1e\n\x0fuse_ptdw_matrix\x18\x13 \x01(\x08:\x05\x66\x61lse\"\x8a\x02\n\x11RegularizerConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\x04type\x18\x02 \x01(\x0e\x32\x1c.artm.RegularizerConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\xaa\x01\n\x04Type\x12\x15\n\x11SmoothSparseTheta\x10\x00\x12\x13\n\x0fSmoothSparsePhi\x10\x01\x12\x13\n\x0f\x44\x65\x63orrelatorPhi\x10\x02\x12\x14\n\x10MultiLanguagePhi\x10\x03\x12\x1a\n\x16LabelRegularizationPhi\x10\x04\x12\x16\n\x12SpecifiedSparsePhi\x10\x05\x12\x17\n\x13ImproveCoherencePhi\x10\x06\"A\n\x17SmoothSparseThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x12\n\nalpha_iter\x18\x02 \x03(\x02\"V\n\x15SmoothSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"=\n\x15\x44\x65\x63orrelatorPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\"\x18\n\x16MultiLanguagePhiConfig\"]\n\x1cLabelRegularizationPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x82\x02\n\x18SpecifiedSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x1e\n\x12max_elements_count\x18\x03 \x01(\x05:\x02\x32\x30\x12#\n\x15probability_threshold\x18\x04 \x01(\x02:\x04\x30.99\x12?\n\x04mode\x18\x05 \x01(\x0e\x32#.artm.SpecifiedSparsePhiConfig.Mode:\x0cSparseTopics\"*\n\x04Mode\x12\x10\n\x0cSparseTopics\x10\x00\x12\x10\n\x0cSparseTokens\x10\x01\"Z\n\x19ImproveCoherencePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x87\x01\n\x18RegularizerInternalState\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.artm.RegularizerInternalState.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x1c\n\x04Type\x12\x14\n\x10MultiLanguagePhi\x10\x03\"C\n\x1dMultiLanguagePhiInternalState\x12\"\n\x17no_regularization_calls\x18\x01 \x01(\x05:\x01\x30\"\xd1\x01\n\x10\x44ictionaryConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x05\x65ntry\x18\x02 \x03(\x0b\x32\x15.artm.DictionaryEntry\x12\x19\n\x11total_token_count\x18\x03 \x01(\x05\x12\x19\n\x11total_items_count\x18\x04 \x01(\x05\x12\x37\n\x0c\x63ooc_entries\x18\x05 \x01(\x0b\x32!.artm.DictionaryCoocurenceEntries\x12\x1a\n\x12total_token_weight\x18\x06 \x01(\x02\"\xbd\x01\n\x0f\x44ictionaryEntry\x12\x11\n\tkey_token\x18\x01 \x01(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x02\x12\x14\n\x0cvalue_tokens\x18\x04 \x03(\t\x12 \n\x06values\x18\x05 \x01(\x0b\x32\x10.artm.FloatArray\x12\x13\n\x0btoken_count\x18\x06 \x01(\x05\x12\x13\n\x0bitems_count\x18\x07 \x01(\x05\x12\x14\n\x0ctoken_weight\x18\x08 \x01(\x02\"}\n\x1b\x44ictionaryCoocurenceEntries\x12\x13\n\x0b\x66irst_index\x18\x01 \x03(\x05\x12\x14\n\x0csecond_index\x18\x02 \x03(\x05\x12\r\n\x05value\x18\x03 \x03(\x02\x12$\n\x15symmetric_cooc_values\x18\x04 \x01(\x08:\x05\x66\x61lse\"\xe6\x01\n\x0bScoreConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x04type\x18\x02 \x01(\x0e\x32\x16.artm.ScoreConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xe0\x01\n\tScoreData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x04type\x18\x02 \x01(\x0e\x32\x14.artm.ScoreData.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xcc\x02\n\x15PerplexityScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12J\n\nmodel_type\x18\x03 \x01(\x0e\x32 .artm.PerplexityScoreConfig.Type:\x14UnigramDocumentModel\x12\x17\n\x0f\x64ictionary_name\x18\x04 \x01(\t\x12\"\n\x12theta_sparsity_eps\x18\x05 \x01(\x02:\x06\x31\x65-037\x12!\n\x19theta_sparsity_topic_name\x18\x06 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x07 \x03(\t\"<\n\x04Type\x12\x18\n\x14UnigramDocumentModel\x10\x00\x12\x1a\n\x16UnigramCollectionModel\x10\x01\"\xbc\x01\n\x0fPerplexityScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x0b\n\x03raw\x18\x02 \x01(\x01\x12\x12\n\nnormalizer\x18\x03 \x01(\x01\x12\x12\n\nzero_words\x18\x04 \x01(\x05\x12\x1c\n\x14theta_sparsity_value\x18\x05 \x01(\x01\x12\"\n\x1atheta_sparsity_zero_topics\x18\x06 \x01(\x05\x12#\n\x1btheta_sparsity_total_topics\x18\x07 \x01(\x05\"|\n\x18SparsityThetaScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x03\x65ps\x18\x03 \x01(\x02:\x06\x31\x65-037\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"N\n\x12SparsityThetaScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_topics\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_topics\x18\x03 \x01(\x05\"c\n\x16SparsityPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"L\n\x10SparsityPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_tokens\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x05\"T\n\x19ItemsProcessedScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\"$\n\x13ItemsProcessedScore\x12\r\n\x05value\x18\x01 \x01(\x05\"\x8a\x01\n\x14TopTokensScoreConfig\x12\x16\n\nnum_tokens\x18\x01 \x01(\x05:\x02\x31\x30\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x04 \x01(\t\"\xad\x01\n\x0eTopTokensScore\x12\x13\n\x0bnum_entries\x18\x01 \x01(\x05\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_index\x18\x03 \x03(\x05\x12\r\n\x05token\x18\x04 \x03(\t\x12\x0e\n\x06weight\x18\x05 \x03(\x02\x12#\n\tcoherence\x18\x06 \x01(\x0b\x32\x10.artm.FloatArray\x12\x19\n\x11\x61verage_coherence\x18\x07 \x01(\x02\"\x7f\n\x17ThetaSnippetScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x07item_id\x18\x03 \x03(\x05\x42\x02\x10\x01\x12\x16\n\nitem_count\x18\x04 \x01(\x05:\x02\x31\x30\"F\n\x11ThetaSnippetScore\x12\x0f\n\x07item_id\x18\x01 \x03(\x05\x12 \n\x06values\x18\x02 \x03(\x0b\x32\x10.artm.FloatArray\"\xb2\x01\n\x16TopicKernelScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\'\n\x1aprobability_mass_threshold\x18\x04 \x01(\x01:\x03\x30.1\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x05 \x01(\t\"\xff\x02\n\x10TopicKernelScore\x12&\n\x0bkernel_size\x18\x01 \x01(\x0b\x32\x11.artm.DoubleArray\x12(\n\rkernel_purity\x18\x02 \x01(\x0b\x32\x11.artm.DoubleArray\x12*\n\x0fkernel_contrast\x18\x03 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x1b\n\x13\x61verage_kernel_size\x18\x04 \x01(\x01\x12\x1d\n\x15\x61verage_kernel_purity\x18\x05 \x01(\x01\x12\x1f\n\x17\x61verage_kernel_contrast\x18\x06 \x01(\x01\x12$\n\tcoherence\x18\x07 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x19\n\x11\x61verage_coherence\x18\x08 \x01(\x02\x12(\n\rkernel_tokens\x18\t \x03(\x0b\x32\x11.artm.StringArray\x12%\n\ntopic_name\x18\n \x01(\x0b\x32\x11.artm.StringArray\"d\n\x17TopicMassPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"_\n\x11TopicMassPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_ratio\x18\x03 \x03(\x01\x12\x12\n\ntopic_mass\x18\x04 \x03(\x01\"\x94\x03\n\nTopicModel\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x14\n\x0ctopics_count\x18\x02 \x01(\x05\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\r\n\x05token\x18\x04 \x03(\t\x12\'\n\rtoken_weights\x18\x05 \x03(\x0b\x32\x10.artm.FloatArray\x12\x10\n\x08\x63lass_id\x18\x06 \x03(\t\x12\x11\n\tinternals\x18\x07 \x01(\x0c\x12#\n\x0btopic_index\x18\x08 \x03(\x0b\x32\x0e.artm.IntArray\x12\x36\n\x0eoperation_type\x18\t \x03(\x0e\x32\x1e.artm.TopicModel.OperationType\x1a\x35\n\x13TopicModelInternals\x12\x1e\n\x04n_wt\x18\x01 \x03(\x0b\x32\x10.artm.FloatArray\"U\n\rOperationType\x12\x0e\n\nInitialize\x10\x00\x12\r\n\tIncrement\x10\x01\x12\r\n\tOverwrite\x10\x02\x12\n\n\x06Remove\x10\x03\x12\n\n\x06Ignore\x10\x04\"\xc5\x01\n\x0bThetaMatrix\x12\x1a\n\nmodel_name\x18\x01 \x01(\t:\x06@model\x12\x0f\n\x07item_id\x18\x02 \x03(\x05\x12&\n\x0citem_weights\x18\x03 \x03(\x0b\x32\x10.artm.FloatArray\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x14\n\x0ctopics_count\x18\x05 \x01(\x05\x12\x12\n\nitem_title\x18\x06 \x03(\t\x12#\n\x0btopic_index\x18\x07 \x03(\x0b\x32\x0e.artm.IntArray\"\xe3\x03\n\x16\x43ollectionParserConfig\x12\x42\n\x06\x66ormat\x18\x01 \x01(\x0e\x32#.artm.CollectionParserConfig.Format:\rBagOfWordsUci\x12\x19\n\x11\x64ocword_file_path\x18\x02 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x03 \x01(\t\x12\x15\n\rtarget_folder\x18\x04 \x01(\t\x12\x1c\n\x14\x64ictionary_file_name\x18\x05 \x01(\t\x12!\n\x13num_items_per_batch\x18\x06 \x01(\x05:\x04\x31\x30\x30\x30\x12\x1a\n\x12\x63ooccurrence_token\x18\x07 \x03(\t\x12%\n\x17use_unity_based_indices\x18\x08 \x01(\x08:\x04true\x12\x1a\n\x0bgather_cooc\x18\t \x01(\x08:\x05\x66\x61lse\x12\x1d\n\x15\x63ooccurrence_class_id\x18\n \x03(\t\x12(\n\x19use_symmetric_cooc_values\x18\x0b \x01(\x08:\x05\x66\x61lse\"Q\n\x06\x46ormat\x12\x11\n\rBagOfWordsUci\x10\x00\x12\x10\n\x0cMatrixMarket\x10\x01\x12\x10\n\x0cVowpalWabbit\x10\x02\x12\x10\n\x0c\x43ooccurrence\x10\x03\"\x7f\n\x14SynchronizeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0c\x64\x65\x63\x61y_weight\x18\x02 \x01(\x02:\x01\x30\x12!\n\x13invoke_regularizers\x18\x03 \x01(\x08:\x04true\x12\x17\n\x0c\x61pply_weight\x18\x04 \x01(\x02:\x01\x31\"\xe3\x03\n\x13InitializeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\x12\x45\n\x0bsource_type\x18\x03 \x01(\x0e\x32$.artm.InitializeModelArgs.SourceType:\nDictionary\x12\x11\n\tdisk_path\x18\x04 \x01(\t\x12\x30\n\x06\x66ilter\x18\x05 \x03(\x0b\x32 .artm.InitializeModelArgs.Filter\x12\x14\n\x0ctopics_count\x18\x06 \x01(\x05\x12\x12\n\ntopic_name\x18\x07 \x03(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x08 \x03(\t\x1a\xa5\x01\n\x06\x46ilter\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\t\x12\x16\n\x0emin_percentage\x18\x02 \x01(\x02\x12\x16\n\x0emax_percentage\x18\x03 \x01(\x02\x12\x11\n\tmin_items\x18\x04 \x01(\x05\x12\x11\n\tmax_items\x18\x05 \x01(\x05\x12\x17\n\x0fmin_total_count\x18\x06 \x01(\x05\x12\x1a\n\x12min_one_item_count\x18\x07 \x01(\x05\")\n\nSourceType\x12\x0e\n\nDictionary\x10\x00\x12\x0b\n\x07\x42\x61tches\x10\x01\"\xf4\x02\n\x11GetTopicModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\r\n\x05token\x18\x03 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x03(\t\x12\x19\n\x11use_sparse_format\x18\x05 \x01(\x08\x12\x13\n\x03\x65ps\x18\x06 \x01(\x02:\x06\x31\x65-037\x12>\n\x0crequest_type\x18\x07 \x01(\x0e\x32#.artm.GetTopicModelArgs.RequestType:\x03Pwt\x12\x42\n\rmatrix_layout\x18\x08 \x01(\x0e\x32$.artm.GetTopicModelArgs.MatrixLayout:\x05\x44\x65nse\";\n\x0bRequestType\x12\x07\n\x03Pwt\x10\x00\x12\x07\n\x03Nwt\x10\x01\x12\x0e\n\nTopicNames\x10\x02\x12\n\n\x06Tokens\x10\x03\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"\xa5\x02\n\x12GetThetaMatrixArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x02 \x01(\x0b\x32\x0b.artm.Batch\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x13\n\x0btopic_index\x18\x04 \x03(\x05\x12\x1a\n\x0b\x63lean_cache\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11use_sparse_format\x18\x06 \x01(\x08\x12\x13\n\x03\x65ps\x18\x07 \x01(\x02:\x06\x31\x65-037\x12\x43\n\rmatrix_layout\x18\x08 \x01(\x0e\x32%.artm.GetThetaMatrixArgs.MatrixLayout:\x05\x44\x65nse\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"W\n\x11GetScoreValueArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\nscore_name\x18\x02 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x01(\x0b\x32\x0b.artm.Batch\"\x82\x01\n\x0c\x41\x64\x64\x42\x61tchArgs\x12\x1a\n\x05\x62\x61tch\x18\x01 \x01(\x0b\x32\x0b.artm.Batch\x12 \n\x14timeout_milliseconds\x18\x02 \x01(\x05:\x02-1\x12\x1b\n\x0creset_scores\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x62\x61tch_file_name\x18\x04 \x01(\t\"a\n\x13InvokeIterationArgs\x12\x1b\n\x10iterations_count\x18\x01 \x01(\x05:\x01\x31\x12\x1a\n\x0creset_scores\x18\x02 \x01(\x08:\x04true\x12\x11\n\tdisk_path\x18\x03 \x01(\t\"0\n\x0cWaitIdleArgs\x12 \n\x14timeout_milliseconds\x18\x01 \x01(\x05:\x02-1\"8\n\x0f\x45xportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"8\n\x0fImportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"%\n\x0f\x41ttachModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\"\xcc\x04\n\x12ProcessBatchesArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12\x17\n\x0fpwt_source_name\x18\x03 \x01(\t\x12\"\n\x16inner_iterations_count\x18\x04 \x01(\x05:\x02\x31\x30\x12\x1c\n\x0bstream_name\x18\x05 \x01(\t:\x07@global\x12\x18\n\x10regularizer_name\x18\x06 \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x07 \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x08 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\t \x03(\x02\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12\x1a\n\x0creset_scores\x18\r \x01(\x08:\x04true\x12J\n\x11theta_matrix_type\x18\x0e \x01(\x0e\x32(.artm.ProcessBatchesArgs.ThetaMatrixType:\x05\x43\x61\x63he\x12\x14\n\x0c\x62\x61tch_weight\x18\x0f \x03(\x02\x12\x1e\n\x0fuse_ptdw_matrix\x18\x10 \x01(\x08:\x05\x66\x61lse\"\\\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\x12\r\n\tDensePtdw\x10\x04\x12\x0e\n\nSparsePtdw\x10\x05\"d\n\x14ProcessBatchesResult\x12#\n\nscore_data\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\x12\'\n\x0ctheta_matrix\x18\x02 \x01(\x0b\x32\x11.artm.ThetaMatrix\"m\n\x0eMergeModelArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x03(\t\x12\x15\n\rsource_weight\x18\x03 \x03(\x02\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"\x99\x01\n\x13RegularizeModelArgs\x12\x17\n\x0frwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fpwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x03 \x01(\t\x12\x37\n\x14regularizer_settings\x18\x04 \x03(\x0b\x32\x19.artm.RegularizerSettings\"_\n\x12NormalizeModelArgs\x12\x17\n\x0fpwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0frwt_source_name\x18\x03 \x01(\t\"B\n\x14ImportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"\xc1\x01\n\x15\x43opyRequestResultArgs\x12Q\n\x0crequest_type\x18\x01 \x01(\x0e\x32\'.artm.CopyRequestResultArgs.RequestType:\x12\x44\x65\x66\x61ultRequestType\"U\n\x0bRequestType\x12\x16\n\x12\x44\x65\x66\x61ultRequestType\x10\x00\x12\x16\n\x12GetThetaSecondPass\x10\x01\x12\x16\n\x12GetModelSecondPass\x10\x02\"\x1e\n\x1c\x44uplicateMasterComponentArgs\"\x1c\n\x1aGetMasterComponentInfoArgs\"\xc1\x06\n\x13MasterComponentInfo\x12\x11\n\tmaster_id\x18\x01 \x01(\x05\x12+\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x1b.artm.MasterComponentConfig\x12>\n\x0bregularizer\x18\x03 \x03(\x0b\x32).artm.MasterComponentInfo.RegularizerInfo\x12\x32\n\x05score\x18\x04 \x03(\x0b\x32#.artm.MasterComponentInfo.ScoreInfo\x12<\n\ndictionary\x18\x05 \x03(\x0b\x32(.artm.MasterComponentInfo.DictionaryInfo\x12\x32\n\x05model\x18\x06 \x03(\x0b\x32#.artm.MasterComponentInfo.ModelInfo\x12=\n\x0b\x63\x61\x63he_entry\x18\x07 \x03(\x0b\x32(.artm.MasterComponentInfo.CacheEntryInfo\x12\x19\n\x11merger_queue_size\x18\x08 \x01(\x05\x12\x1c\n\x14processor_queue_size\x18\t \x01(\x05\x12\x32\n\x05\x62\x61tch\x18\n \x03(\x0b\x32#.artm.MasterComponentInfo.BatchInfo\x1a-\n\x0fRegularizerInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\'\n\tScoreInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\x35\n\x0e\x44ictionaryInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rentries_count\x18\x02 \x01(\x03\x1a\x43\n\tBatchInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0bitems_count\x18\x02 \x01(\x05\x12\x13\n\x0btoken_count\x18\x03 \x01(\x05\x1aR\n\tModelInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x13\n\x0btoken_count\x18\x04 \x01(\x05\x1a\x30\n\x0e\x43\x61\x63heEntryInfo\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tbyte_size\x18\x02 \x01(\x05\"C\n\x11ImportBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x03(\x0b\x32\x0b.artm.Batch\"(\n\x12\x44isposeBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t')
+  serialized_pb='\n\x13\x61rtm/messages.proto\x12\x04\x61rtm\" \n\x0b\x44oubleArray\x12\x11\n\x05value\x18\x01 \x03(\x01\x42\x02\x10\x01\"\x1f\n\nFloatArray\x12\x11\n\x05value\x18\x01 \x03(\x02\x42\x02\x10\x01\"\x1e\n\tBoolArray\x12\x11\n\x05value\x18\x01 \x03(\x08\x42\x02\x10\x01\"\x1d\n\x08IntArray\x12\x11\n\x05value\x18\x01 \x03(\x05\x42\x02\x10\x01\"\x1c\n\x0bStringArray\x12\r\n\x05value\x18\x01 \x03(\t\"=\n\x04Item\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x05\x66ield\x18\x02 \x03(\x0b\x32\x0b.artm.Field\x12\r\n\x05title\x18\x03 \x01(\t\"\x95\x02\n\x05\x46ield\x12\x13\n\x04name\x18\x01 \x01(\t:\x05@body\x12\x10\n\x08token_id\x18\x02 \x03(\x05\x12\x13\n\x0btoken_count\x18\x03 \x03(\x05\x12\x14\n\x0ctoken_offset\x18\x04 \x03(\x05\x12\x14\n\x0cstring_value\x18\x05 \x01(\t\x12\x11\n\tint_value\x18\x06 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x07 \x01(\x01\x12\x12\n\ndate_value\x18\x08 \x01(\t\x12\x14\n\x0cstring_array\x18\x10 \x03(\t\x12\x11\n\tint_array\x18\x11 \x03(\x03\x12\x14\n\x0c\x64ouble_array\x18\x12 \x03(\x01\x12\x12\n\ndate_array\x18\x13 \x03(\t\x12\x14\n\x0ctoken_weight\x18\x14 \x03(\x02\"c\n\x05\x42\x61tch\x12\r\n\x05token\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x18\n\x04item\x18\x03 \x03(\x0b\x32\n.artm.Item\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\"\x93\x01\n\x06Stream\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x11.artm.Stream.Type:\x06Global\x12\x15\n\x04name\x18\x02 \x01(\t:\x07@global\x12\x0f\n\x07modulus\x18\x03 \x01(\x05\x12\x11\n\tresiduals\x18\x04 \x03(\x05\"%\n\x04Type\x12\n\n\x06Global\x10\x00\x12\x11\n\rItemIdModulus\x10\x01\"\xd0\x02\n\x15MasterComponentConfig\x12\x11\n\tdisk_path\x18\x02 \x01(\t\x12\x1c\n\x06stream\x18\x03 \x03(\x0b\x32\x0c.artm.Stream\x12\x1d\n\x0f\x63ompact_batches\x18\x04 \x01(\x08:\x04true\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10processors_count\x18\x06 \x01(\x05\x12$\n\x18processor_queue_max_size\x18\x07 \x01(\x05:\x02\x31\x30\x12!\n\x15merger_queue_max_size\x18\x08 \x01(\x05:\x02\x31\x30\x12\'\n\x0cscore_config\x18\t \x03(\x0b\x32\x11.artm.ScoreConfig\x12&\n\x17online_batch_processing\x18\r \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x64isk_cache_path\x18\x0f \x01(\t\"d\n\x13RegularizerSettings\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03tau\x18\x02 \x01(\x01\x12#\n\x1buse_relative_regularization\x18\x03 \x01(\x08\x12\r\n\x05gamma\x18\x04 \x01(\x01\"\x81\x04\n\x0bModelConfig\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x18\n\x0ctopics_count\x18\x02 \x01(\x05:\x02\x33\x32\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x15\n\x07\x65nabled\x18\x04 \x01(\x08:\x04true\x12\"\n\x16inner_iterations_count\x18\x05 \x01(\x05:\x02\x31\x30\x12\x19\n\nfield_name\x18\x06 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x07 \x01(\t:\x07@global\x12\x12\n\nscore_name\x18\x08 \x03(\t\x12\x1a\n\x0breuse_theta\x18\t \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10regularizer_name\x18\n \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x0b \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x0c \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\r \x03(\x02\x12\x1c\n\x0euse_sparse_bow\x18\x0e \x01(\x08:\x04true\x12\x1f\n\x10use_random_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\x12\x1c\n\x0euse_new_tokens\x18\x10 \x01(\x08:\x04true\x12\x19\n\x0bopt_for_avx\x18\x11 \x01(\x08:\x04true\x12\x37\n\x14regularizer_settings\x18\x12 \x03(\x0b\x32\x19.artm.RegularizerSettings\"\x9a\x02\n\x11RegularizerConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\x04type\x18\x02 \x01(\x0e\x32\x1c.artm.RegularizerConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\xba\x01\n\x04Type\x12\x15\n\x11SmoothSparseTheta\x10\x00\x12\x13\n\x0fSmoothSparsePhi\x10\x01\x12\x13\n\x0f\x44\x65\x63orrelatorPhi\x10\x02\x12\x14\n\x10MultiLanguagePhi\x10\x03\x12\x1a\n\x16LabelRegularizationPhi\x10\x04\x12\x16\n\x12SpecifiedSparsePhi\x10\x05\x12\x17\n\x13ImproveCoherencePhi\x10\x06\x12\x0e\n\nSmoothPtdw\x10\x07\"A\n\x17SmoothSparseThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x12\n\nalpha_iter\x18\x02 \x03(\x02\"V\n\x15SmoothSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"=\n\x15\x44\x65\x63orrelatorPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\"\x18\n\x16MultiLanguagePhiConfig\"]\n\x1cLabelRegularizationPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x82\x02\n\x18SpecifiedSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x1e\n\x12max_elements_count\x18\x03 \x01(\x05:\x02\x32\x30\x12#\n\x15probability_threshold\x18\x04 \x01(\x02:\x04\x30.99\x12?\n\x04mode\x18\x05 \x01(\x0e\x32#.artm.SpecifiedSparsePhiConfig.Mode:\x0cSparseTopics\"*\n\x04Mode\x12\x10\n\x0cSparseTopics\x10\x00\x12\x10\n\x0cSparseTokens\x10\x01\"Z\n\x19ImproveCoherencePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\xa4\x01\n\x10SmoothPtdwConfig\x12\x38\n\x04type\x18\x01 \x01(\x0e\x32\x1b.artm.SmoothPtdwConfig.Type:\rMovingAverage\x12\x12\n\x06window\x18\x03 \x01(\x05:\x02\x31\x30\x12\x14\n\tthreshold\x18\x04 \x01(\x01:\x01\x31\",\n\x04Type\x12\x11\n\rMovingAverage\x10\x01\x12\x11\n\rMovingProduct\x10\x02\"\x87\x01\n\x18RegularizerInternalState\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x04type\x18\x02 \x01(\x0e\x32#.artm.RegularizerInternalState.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x1c\n\x04Type\x12\x14\n\x10MultiLanguagePhi\x10\x03\"C\n\x1dMultiLanguagePhiInternalState\x12\"\n\x17no_regularization_calls\x18\x01 \x01(\x05:\x01\x30\"\xd1\x01\n\x10\x44ictionaryConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x05\x65ntry\x18\x02 \x03(\x0b\x32\x15.artm.DictionaryEntry\x12\x19\n\x11total_token_count\x18\x03 \x01(\x05\x12\x19\n\x11total_items_count\x18\x04 \x01(\x05\x12\x37\n\x0c\x63ooc_entries\x18\x05 \x01(\x0b\x32!.artm.DictionaryCoocurenceEntries\x12\x1a\n\x12total_token_weight\x18\x06 \x01(\x02\"\xbd\x01\n\x0f\x44ictionaryEntry\x12\x11\n\tkey_token\x18\x01 \x01(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x01(\t\x12\r\n\x05value\x18\x03 \x01(\x02\x12\x14\n\x0cvalue_tokens\x18\x04 \x03(\t\x12 \n\x06values\x18\x05 \x01(\x0b\x32\x10.artm.FloatArray\x12\x13\n\x0btoken_count\x18\x06 \x01(\x05\x12\x13\n\x0bitems_count\x18\x07 \x01(\x05\x12\x14\n\x0ctoken_weight\x18\x08 \x01(\x02\"}\n\x1b\x44ictionaryCoocurenceEntries\x12\x13\n\x0b\x66irst_index\x18\x01 \x03(\x05\x12\x14\n\x0csecond_index\x18\x02 \x03(\x05\x12\r\n\x05value\x18\x03 \x03(\x02\x12$\n\x15symmetric_cooc_values\x18\x04 \x01(\x08:\x05\x66\x61lse\"\xe6\x01\n\x0bScoreConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x04type\x18\x02 \x01(\x0e\x32\x16.artm.ScoreConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xe0\x01\n\tScoreData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x04type\x18\x02 \x01(\x0e\x32\x14.artm.ScoreData.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\x92\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\"\xcc\x02\n\x15PerplexityScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12J\n\nmodel_type\x18\x03 \x01(\x0e\x32 .artm.PerplexityScoreConfig.Type:\x14UnigramDocumentModel\x12\x17\n\x0f\x64ictionary_name\x18\x04 \x01(\t\x12\"\n\x12theta_sparsity_eps\x18\x05 \x01(\x02:\x06\x31\x65-037\x12!\n\x19theta_sparsity_topic_name\x18\x06 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x07 \x03(\t\"<\n\x04Type\x12\x18\n\x14UnigramDocumentModel\x10\x00\x12\x1a\n\x16UnigramCollectionModel\x10\x01\"\xbc\x01\n\x0fPerplexityScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x0b\n\x03raw\x18\x02 \x01(\x01\x12\x12\n\nnormalizer\x18\x03 \x01(\x01\x12\x12\n\nzero_words\x18\x04 \x01(\x05\x12\x1c\n\x14theta_sparsity_value\x18\x05 \x01(\x01\x12\"\n\x1atheta_sparsity_zero_topics\x18\x06 \x01(\x05\x12#\n\x1btheta_sparsity_total_topics\x18\x07 \x01(\x05\"|\n\x18SparsityThetaScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x03\x65ps\x18\x03 \x01(\x02:\x06\x31\x65-037\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"N\n\x12SparsityThetaScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_topics\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_topics\x18\x03 \x01(\x05\"c\n\x16SparsityPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"L\n\x10SparsityPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_tokens\x18\x02 \x01(\x05\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x05\"T\n\x19ItemsProcessedScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\"$\n\x13ItemsProcessedScore\x12\r\n\x05value\x18\x01 \x01(\x05\"\x8a\x01\n\x14TopTokensScoreConfig\x12\x16\n\nnum_tokens\x18\x01 \x01(\x05:\x02\x31\x30\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x04 \x01(\t\"\xad\x01\n\x0eTopTokensScore\x12\x13\n\x0bnum_entries\x18\x01 \x01(\x05\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_index\x18\x03 \x03(\x05\x12\r\n\x05token\x18\x04 \x03(\t\x12\x0e\n\x06weight\x18\x05 \x03(\x02\x12#\n\tcoherence\x18\x06 \x01(\x0b\x32\x10.artm.FloatArray\x12\x19\n\x11\x61verage_coherence\x18\x07 \x01(\x02\"\x7f\n\x17ThetaSnippetScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x07item_id\x18\x03 \x03(\x05\x42\x02\x10\x01\x12\x16\n\nitem_count\x18\x04 \x01(\x05:\x02\x31\x30\"F\n\x11ThetaSnippetScore\x12\x0f\n\x07item_id\x18\x01 \x03(\x05\x12 \n\x06values\x18\x02 \x03(\x0b\x32\x10.artm.FloatArray\"\xb2\x01\n\x16TopicKernelScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\'\n\x1aprobability_mass_threshold\x18\x04 \x01(\x01:\x03\x30.1\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x05 \x01(\t\"\xff\x02\n\x10TopicKernelScore\x12&\n\x0bkernel_size\x18\x01 \x01(\x0b\x32\x11.artm.DoubleArray\x12(\n\rkernel_purity\x18\x02 \x01(\x0b\x32\x11.artm.DoubleArray\x12*\n\x0fkernel_contrast\x18\x03 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x1b\n\x13\x61verage_kernel_size\x18\x04 \x01(\x01\x12\x1d\n\x15\x61verage_kernel_purity\x18\x05 \x01(\x01\x12\x1f\n\x17\x61verage_kernel_contrast\x18\x06 \x01(\x01\x12$\n\tcoherence\x18\x07 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x19\n\x11\x61verage_coherence\x18\x08 \x01(\x02\x12(\n\rkernel_tokens\x18\t \x03(\x0b\x32\x11.artm.StringArray\x12%\n\ntopic_name\x18\n \x01(\x0b\x32\x11.artm.StringArray\"d\n\x17TopicMassPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"_\n\x11TopicMassPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_ratio\x18\x03 \x03(\x01\x12\x12\n\ntopic_mass\x18\x04 \x03(\x01\"\x94\x03\n\nTopicModel\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x14\n\x0ctopics_count\x18\x02 \x01(\x05\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\r\n\x05token\x18\x04 \x03(\t\x12\'\n\rtoken_weights\x18\x05 \x03(\x0b\x32\x10.artm.FloatArray\x12\x10\n\x08\x63lass_id\x18\x06 \x03(\t\x12\x11\n\tinternals\x18\x07 \x01(\x0c\x12#\n\x0btopic_index\x18\x08 \x03(\x0b\x32\x0e.artm.IntArray\x12\x36\n\x0eoperation_type\x18\t \x03(\x0e\x32\x1e.artm.TopicModel.OperationType\x1a\x35\n\x13TopicModelInternals\x12\x1e\n\x04n_wt\x18\x01 \x03(\x0b\x32\x10.artm.FloatArray\"U\n\rOperationType\x12\x0e\n\nInitialize\x10\x00\x12\r\n\tIncrement\x10\x01\x12\r\n\tOverwrite\x10\x02\x12\n\n\x06Remove\x10\x03\x12\n\n\x06Ignore\x10\x04\"\xc5\x01\n\x0bThetaMatrix\x12\x1a\n\nmodel_name\x18\x01 \x01(\t:\x06@model\x12\x0f\n\x07item_id\x18\x02 \x03(\x05\x12&\n\x0citem_weights\x18\x03 \x03(\x0b\x32\x10.artm.FloatArray\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x14\n\x0ctopics_count\x18\x05 \x01(\x05\x12\x12\n\nitem_title\x18\x06 \x03(\t\x12#\n\x0btopic_index\x18\x07 \x03(\x0b\x32\x0e.artm.IntArray\"\xe3\x03\n\x16\x43ollectionParserConfig\x12\x42\n\x06\x66ormat\x18\x01 \x01(\x0e\x32#.artm.CollectionParserConfig.Format:\rBagOfWordsUci\x12\x19\n\x11\x64ocword_file_path\x18\x02 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x03 \x01(\t\x12\x15\n\rtarget_folder\x18\x04 \x01(\t\x12\x1c\n\x14\x64ictionary_file_name\x18\x05 \x01(\t\x12!\n\x13num_items_per_batch\x18\x06 \x01(\x05:\x04\x31\x30\x30\x30\x12\x1a\n\x12\x63ooccurrence_token\x18\x07 \x03(\t\x12%\n\x17use_unity_based_indices\x18\x08 \x01(\x08:\x04true\x12\x1a\n\x0bgather_cooc\x18\t \x01(\x08:\x05\x66\x61lse\x12\x1d\n\x15\x63ooccurrence_class_id\x18\n \x03(\t\x12(\n\x19use_symmetric_cooc_values\x18\x0b \x01(\x08:\x05\x66\x61lse\"Q\n\x06\x46ormat\x12\x11\n\rBagOfWordsUci\x10\x00\x12\x10\n\x0cMatrixMarket\x10\x01\x12\x10\n\x0cVowpalWabbit\x10\x02\x12\x10\n\x0c\x43ooccurrence\x10\x03\"\x7f\n\x14SynchronizeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0c\x64\x65\x63\x61y_weight\x18\x02 \x01(\x02:\x01\x30\x12!\n\x13invoke_regularizers\x18\x03 \x01(\x08:\x04true\x12\x17\n\x0c\x61pply_weight\x18\x04 \x01(\x02:\x01\x31\"\xe3\x03\n\x13InitializeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\x12\x45\n\x0bsource_type\x18\x03 \x01(\x0e\x32$.artm.InitializeModelArgs.SourceType:\nDictionary\x12\x11\n\tdisk_path\x18\x04 \x01(\t\x12\x30\n\x06\x66ilter\x18\x05 \x03(\x0b\x32 .artm.InitializeModelArgs.Filter\x12\x14\n\x0ctopics_count\x18\x06 \x01(\x05\x12\x12\n\ntopic_name\x18\x07 \x03(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x08 \x03(\t\x1a\xa5\x01\n\x06\x46ilter\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\t\x12\x16\n\x0emin_percentage\x18\x02 \x01(\x02\x12\x16\n\x0emax_percentage\x18\x03 \x01(\x02\x12\x11\n\tmin_items\x18\x04 \x01(\x05\x12\x11\n\tmax_items\x18\x05 \x01(\x05\x12\x17\n\x0fmin_total_count\x18\x06 \x01(\x05\x12\x1a\n\x12min_one_item_count\x18\x07 \x01(\x05\")\n\nSourceType\x12\x0e\n\nDictionary\x10\x00\x12\x0b\n\x07\x42\x61tches\x10\x01\"\xf4\x02\n\x11GetTopicModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\r\n\x05token\x18\x03 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x03(\t\x12\x19\n\x11use_sparse_format\x18\x05 \x01(\x08\x12\x13\n\x03\x65ps\x18\x06 \x01(\x02:\x06\x31\x65-037\x12>\n\x0crequest_type\x18\x07 \x01(\x0e\x32#.artm.GetTopicModelArgs.RequestType:\x03Pwt\x12\x42\n\rmatrix_layout\x18\x08 \x01(\x0e\x32$.artm.GetTopicModelArgs.MatrixLayout:\x05\x44\x65nse\";\n\x0bRequestType\x12\x07\n\x03Pwt\x10\x00\x12\x07\n\x03Nwt\x10\x01\x12\x0e\n\nTopicNames\x10\x02\x12\n\n\x06Tokens\x10\x03\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"\xa5\x02\n\x12GetThetaMatrixArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x02 \x01(\x0b\x32\x0b.artm.Batch\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x13\n\x0btopic_index\x18\x04 \x03(\x05\x12\x1a\n\x0b\x63lean_cache\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11use_sparse_format\x18\x06 \x01(\x08\x12\x13\n\x03\x65ps\x18\x07 \x01(\x02:\x06\x31\x65-037\x12\x43\n\rmatrix_layout\x18\x08 \x01(\x0e\x32%.artm.GetThetaMatrixArgs.MatrixLayout:\x05\x44\x65nse\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"W\n\x11GetScoreValueArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\nscore_name\x18\x02 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x01(\x0b\x32\x0b.artm.Batch\"\x82\x01\n\x0c\x41\x64\x64\x42\x61tchArgs\x12\x1a\n\x05\x62\x61tch\x18\x01 \x01(\x0b\x32\x0b.artm.Batch\x12 \n\x14timeout_milliseconds\x18\x02 \x01(\x05:\x02-1\x12\x1b\n\x0creset_scores\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x62\x61tch_file_name\x18\x04 \x01(\t\"a\n\x13InvokeIterationArgs\x12\x1b\n\x10iterations_count\x18\x01 \x01(\x05:\x01\x31\x12\x1a\n\x0creset_scores\x18\x02 \x01(\x08:\x04true\x12\x11\n\tdisk_path\x18\x03 \x01(\t\"0\n\x0cWaitIdleArgs\x12 \n\x14timeout_milliseconds\x18\x01 \x01(\x05:\x02-1\"8\n\x0f\x45xportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"8\n\x0fImportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"%\n\x0f\x41ttachModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\"\xac\x04\n\x12ProcessBatchesArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12\x17\n\x0fpwt_source_name\x18\x03 \x01(\t\x12\"\n\x16inner_iterations_count\x18\x04 \x01(\x05:\x02\x31\x30\x12\x1c\n\x0bstream_name\x18\x05 \x01(\t:\x07@global\x12\x18\n\x10regularizer_name\x18\x06 \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x07 \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x08 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\t \x03(\x02\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12\x1a\n\x0creset_scores\x18\r \x01(\x08:\x04true\x12J\n\x11theta_matrix_type\x18\x0e \x01(\x0e\x32(.artm.ProcessBatchesArgs.ThetaMatrixType:\x05\x43\x61\x63he\x12\x14\n\x0c\x62\x61tch_weight\x18\x0f \x03(\x02\"\\\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\x12\r\n\tDensePtdw\x10\x04\x12\x0e\n\nSparsePtdw\x10\x05\"d\n\x14ProcessBatchesResult\x12#\n\nscore_data\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\x12\'\n\x0ctheta_matrix\x18\x02 \x01(\x0b\x32\x11.artm.ThetaMatrix\"m\n\x0eMergeModelArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x03(\t\x12\x15\n\rsource_weight\x18\x03 \x03(\x02\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"\x99\x01\n\x13RegularizeModelArgs\x12\x17\n\x0frwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fpwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x03 \x01(\t\x12\x37\n\x14regularizer_settings\x18\x04 \x03(\x0b\x32\x19.artm.RegularizerSettings\"_\n\x12NormalizeModelArgs\x12\x17\n\x0fpwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0frwt_source_name\x18\x03 \x01(\t\"B\n\x14ImportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"\xc1\x01\n\x15\x43opyRequestResultArgs\x12Q\n\x0crequest_type\x18\x01 \x01(\x0e\x32\'.artm.CopyRequestResultArgs.RequestType:\x12\x44\x65\x66\x61ultRequestType\"U\n\x0bRequestType\x12\x16\n\x12\x44\x65\x66\x61ultRequestType\x10\x00\x12\x16\n\x12GetThetaSecondPass\x10\x01\x12\x16\n\x12GetModelSecondPass\x10\x02\"\x1e\n\x1c\x44uplicateMasterComponentArgs\"\x1c\n\x1aGetMasterComponentInfoArgs\"\xc1\x06\n\x13MasterComponentInfo\x12\x11\n\tmaster_id\x18\x01 \x01(\x05\x12+\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x1b.artm.MasterComponentConfig\x12>\n\x0bregularizer\x18\x03 \x03(\x0b\x32).artm.MasterComponentInfo.RegularizerInfo\x12\x32\n\x05score\x18\x04 \x03(\x0b\x32#.artm.MasterComponentInfo.ScoreInfo\x12<\n\ndictionary\x18\x05 \x03(\x0b\x32(.artm.MasterComponentInfo.DictionaryInfo\x12\x32\n\x05model\x18\x06 \x03(\x0b\x32#.artm.MasterComponentInfo.ModelInfo\x12=\n\x0b\x63\x61\x63he_entry\x18\x07 \x03(\x0b\x32(.artm.MasterComponentInfo.CacheEntryInfo\x12\x19\n\x11merger_queue_size\x18\x08 \x01(\x05\x12\x1c\n\x14processor_queue_size\x18\t \x01(\x05\x12\x32\n\x05\x62\x61tch\x18\n \x03(\x0b\x32#.artm.MasterComponentInfo.BatchInfo\x1a-\n\x0fRegularizerInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\'\n\tScoreInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\x35\n\x0e\x44ictionaryInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rentries_count\x18\x02 \x01(\x03\x1a\x43\n\tBatchInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0bitems_count\x18\x02 \x01(\x05\x12\x13\n\x0btoken_count\x18\x03 \x01(\x05\x1aR\n\tModelInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x13\n\x0btoken_count\x18\x04 \x01(\x05\x1a\x30\n\x0e\x43\x61\x63heEntryInfo\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tbyte_size\x18\x02 \x01(\x05\"C\n\x11ImportBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x03(\x0b\x32\x0b.artm.Batch\"(\n\x12\x44isposeBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t')
 
 
 
@@ -72,11 +72,15 @@ _REGULARIZERCONFIG_TYPE = _descriptor.EnumDescriptor(
       name='ImproveCoherencePhi', index=6, number=6,
       options=None,
       type=None),
+    _descriptor.EnumValueDescriptor(
+      name='SmoothPtdw', index=7, number=7,
+      options=None,
+      type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=1869,
-  serialized_end=2039,
+  serialized_start=1837,
+  serialized_end=2023,
 )
 
 _SPECIFIEDSPARSEPHICONFIG_MODE = _descriptor.EnumDescriptor(
@@ -96,8 +100,29 @@ _SPECIFIEDSPARSEPHICONFIG_MODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2597,
-  serialized_end=2639,
+  serialized_start=2581,
+  serialized_end=2623,
+)
+
+_SMOOTHPTDWCONFIG_TYPE = _descriptor.EnumDescriptor(
+  name='Type',
+  full_name='artm.SmoothPtdwConfig.Type',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='MovingAverage', index=0, number=1,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='MovingProduct', index=1, number=2,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=2838,
+  serialized_end=2882,
 )
 
 _REGULARIZERINTERNALSTATE_TYPE = _descriptor.EnumDescriptor(
@@ -113,8 +138,8 @@ _REGULARIZERINTERNALSTATE_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2841,
-  serialized_end=2869,
+  serialized_start=2992,
+  serialized_end=3020,
 )
 
 _SCORECONFIG_TYPE = _descriptor.EnumDescriptor(
@@ -158,8 +183,8 @@ _SCORECONFIG_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=3556,
-  serialized_end=3702,
+  serialized_start=3707,
+  serialized_end=3853,
 )
 
 _SCOREDATA_TYPE = _descriptor.EnumDescriptor(
@@ -203,8 +228,8 @@ _SCOREDATA_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=3556,
-  serialized_end=3702,
+  serialized_start=3707,
+  serialized_end=3853,
 )
 
 _PERPLEXITYSCORECONFIG_TYPE = _descriptor.EnumDescriptor(
@@ -224,8 +249,8 @@ _PERPLEXITYSCORECONFIG_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=4204,
-  serialized_end=4264,
+  serialized_start=4355,
+  serialized_end=4415,
 )
 
 _TOPICMODEL_OPERATIONTYPE = _descriptor.EnumDescriptor(
@@ -257,8 +282,8 @@ _TOPICMODEL_OPERATIONTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=6570,
-  serialized_end=6655,
+  serialized_start=6721,
+  serialized_end=6806,
 )
 
 _COLLECTIONPARSERCONFIG_FORMAT = _descriptor.EnumDescriptor(
@@ -286,8 +311,8 @@ _COLLECTIONPARSERCONFIG_FORMAT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=7260,
-  serialized_end=7341,
+  serialized_start=7411,
+  serialized_end=7492,
 )
 
 _INITIALIZEMODELARGS_SOURCETYPE = _descriptor.EnumDescriptor(
@@ -307,8 +332,8 @@ _INITIALIZEMODELARGS_SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=7915,
-  serialized_end=7956,
+  serialized_start=8066,
+  serialized_end=8107,
 )
 
 _GETTOPICMODELARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
@@ -336,8 +361,8 @@ _GETTOPICMODELARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8233,
-  serialized_end=8292,
+  serialized_start=8384,
+  serialized_end=8443,
 )
 
 _GETTOPICMODELARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
@@ -357,8 +382,8 @@ _GETTOPICMODELARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8294,
-  serialized_end=8331,
+  serialized_start=8445,
+  serialized_end=8482,
 )
 
 _GETTHETAMATRIXARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
@@ -378,8 +403,8 @@ _GETTHETAMATRIXARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8294,
-  serialized_end=8331,
+  serialized_start=8445,
+  serialized_end=8482,
 )
 
 _PROCESSBATCHESARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
@@ -415,8 +440,8 @@ _PROCESSBATCHESARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9652,
-  serialized_end=9744,
+  serialized_start=9771,
+  serialized_end=9863,
 )
 
 _COPYREQUESTRESULTARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
@@ -440,8 +465,8 @@ _COPYREQUESTRESULTARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10389,
-  serialized_end=10474,
+  serialized_start=10508,
+  serialized_end=10593,
 )
 
 
@@ -1118,13 +1143,6 @@ _MODELCONFIG = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
-    _descriptor.FieldDescriptor(
-      name='use_ptdw_matrix', full_name='artm.ModelConfig.use_ptdw_matrix', index=18,
-      number=19, type=8, cpp_type=7, label=1,
-      has_default_value=True, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
   ],
   extensions=[
   ],
@@ -1135,7 +1153,7 @@ _MODELCONFIG = _descriptor.Descriptor(
   is_extendable=False,
   extension_ranges=[],
   serialized_start=1225,
-  serialized_end=1770,
+  serialized_end=1738,
 )
 
 
@@ -1177,8 +1195,8 @@ _REGULARIZERCONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=1773,
-  serialized_end=2039,
+  serialized_start=1741,
+  serialized_end=2023,
 )
 
 
@@ -1212,8 +1230,8 @@ _SMOOTHSPARSETHETACONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2041,
-  serialized_end=2106,
+  serialized_start=2025,
+  serialized_end=2090,
 )
 
 
@@ -1254,8 +1272,8 @@ _SMOOTHSPARSEPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2108,
-  serialized_end=2194,
+  serialized_start=2092,
+  serialized_end=2178,
 )
 
 
@@ -1289,8 +1307,8 @@ _DECORRELATORPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2196,
-  serialized_end=2257,
+  serialized_start=2180,
+  serialized_end=2241,
 )
 
 
@@ -1310,8 +1328,8 @@ _MULTILANGUAGEPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2259,
-  serialized_end=2283,
+  serialized_start=2243,
+  serialized_end=2267,
 )
 
 
@@ -1352,8 +1370,8 @@ _LABELREGULARIZATIONPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2285,
-  serialized_end=2378,
+  serialized_start=2269,
+  serialized_end=2362,
 )
 
 
@@ -1409,8 +1427,8 @@ _SPECIFIEDSPARSEPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2381,
-  serialized_end=2639,
+  serialized_start=2365,
+  serialized_end=2623,
 )
 
 
@@ -1451,8 +1469,51 @@ _IMPROVECOHERENCEPHICONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2641,
-  serialized_end=2731,
+  serialized_start=2625,
+  serialized_end=2715,
+)
+
+
+_SMOOTHPTDWCONFIG = _descriptor.Descriptor(
+  name='SmoothPtdwConfig',
+  full_name='artm.SmoothPtdwConfig',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='type', full_name='artm.SmoothPtdwConfig.type', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=True, default_value=1,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='window', full_name='artm.SmoothPtdwConfig.window', index=1,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=True, default_value=10,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='threshold', full_name='artm.SmoothPtdwConfig.threshold', index=2,
+      number=4, type=1, cpp_type=5, label=1,
+      has_default_value=True, default_value=1,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+    _SMOOTHPTDWCONFIG_TYPE,
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=2718,
+  serialized_end=2882,
 )
 
 
@@ -1494,8 +1555,8 @@ _REGULARIZERINTERNALSTATE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2734,
-  serialized_end=2869,
+  serialized_start=2885,
+  serialized_end=3020,
 )
 
 
@@ -1522,8 +1583,8 @@ _MULTILANGUAGEPHIINTERNALSTATE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2871,
-  serialized_end=2938,
+  serialized_start=3022,
+  serialized_end=3089,
 )
 
 
@@ -1585,8 +1646,8 @@ _DICTIONARYCONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=2941,
-  serialized_end=3150,
+  serialized_start=3092,
+  serialized_end=3301,
 )
 
 
@@ -1662,8 +1723,8 @@ _DICTIONARYENTRY = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3153,
-  serialized_end=3342,
+  serialized_start=3304,
+  serialized_end=3493,
 )
 
 
@@ -1711,8 +1772,8 @@ _DICTIONARYCOOCURENCEENTRIES = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3344,
-  serialized_end=3469,
+  serialized_start=3495,
+  serialized_end=3620,
 )
 
 
@@ -1754,8 +1815,8 @@ _SCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3472,
-  serialized_end=3702,
+  serialized_start=3623,
+  serialized_end=3853,
 )
 
 
@@ -1797,8 +1858,8 @@ _SCOREDATA = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3705,
-  serialized_end=3929,
+  serialized_start=3856,
+  serialized_end=4080,
 )
 
 
@@ -1868,8 +1929,8 @@ _PERPLEXITYSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3932,
-  serialized_end=4264,
+  serialized_start=4083,
+  serialized_end=4415,
 )
 
 
@@ -1938,8 +1999,8 @@ _PERPLEXITYSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4267,
-  serialized_end=4455,
+  serialized_start=4418,
+  serialized_end=4606,
 )
 
 
@@ -1987,8 +2048,8 @@ _SPARSITYTHETASCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4457,
-  serialized_end=4581,
+  serialized_start=4608,
+  serialized_end=4732,
 )
 
 
@@ -2029,8 +2090,8 @@ _SPARSITYTHETASCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4583,
-  serialized_end=4661,
+  serialized_start=4734,
+  serialized_end=4812,
 )
 
 
@@ -2071,8 +2132,8 @@ _SPARSITYPHISCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4663,
-  serialized_end=4762,
+  serialized_start=4814,
+  serialized_end=4913,
 )
 
 
@@ -2113,8 +2174,8 @@ _SPARSITYPHISCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4764,
-  serialized_end=4840,
+  serialized_start=4915,
+  serialized_end=4991,
 )
 
 
@@ -2148,8 +2209,8 @@ _ITEMSPROCESSEDSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4842,
-  serialized_end=4926,
+  serialized_start=4993,
+  serialized_end=5077,
 )
 
 
@@ -2176,8 +2237,8 @@ _ITEMSPROCESSEDSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4928,
-  serialized_end=4964,
+  serialized_start=5079,
+  serialized_end=5115,
 )
 
 
@@ -2225,8 +2286,8 @@ _TOPTOKENSSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4967,
-  serialized_end=5105,
+  serialized_start=5118,
+  serialized_end=5256,
 )
 
 
@@ -2295,8 +2356,8 @@ _TOPTOKENSSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5108,
-  serialized_end=5281,
+  serialized_start=5259,
+  serialized_end=5432,
 )
 
 
@@ -2344,8 +2405,8 @@ _THETASNIPPETSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5283,
-  serialized_end=5410,
+  serialized_start=5434,
+  serialized_end=5561,
 )
 
 
@@ -2379,8 +2440,8 @@ _THETASNIPPETSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5412,
-  serialized_end=5482,
+  serialized_start=5563,
+  serialized_end=5633,
 )
 
 
@@ -2435,8 +2496,8 @@ _TOPICKERNELSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5485,
-  serialized_end=5663,
+  serialized_start=5636,
+  serialized_end=5814,
 )
 
 
@@ -2526,8 +2587,8 @@ _TOPICKERNELSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5666,
-  serialized_end=6049,
+  serialized_start=5817,
+  serialized_end=6200,
 )
 
 
@@ -2568,8 +2629,8 @@ _TOPICMASSPHISCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6051,
-  serialized_end=6151,
+  serialized_start=6202,
+  serialized_end=6302,
 )
 
 
@@ -2617,8 +2678,8 @@ _TOPICMASSPHISCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6153,
-  serialized_end=6248,
+  serialized_start=6304,
+  serialized_end=6399,
 )
 
 
@@ -2645,8 +2706,8 @@ _TOPICMODEL_TOPICMODELINTERNALS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6515,
-  serialized_end=6568,
+  serialized_start=6666,
+  serialized_end=6719,
 )
 
 _TOPICMODEL = _descriptor.Descriptor(
@@ -2729,8 +2790,8 @@ _TOPICMODEL = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6251,
-  serialized_end=6655,
+  serialized_start=6402,
+  serialized_end=6806,
 )
 
 
@@ -2799,8 +2860,8 @@ _THETAMATRIX = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6658,
-  serialized_end=6855,
+  serialized_start=6809,
+  serialized_end=7006,
 )
 
 
@@ -2898,8 +2959,8 @@ _COLLECTIONPARSERCONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6858,
-  serialized_end=7341,
+  serialized_start=7009,
+  serialized_end=7492,
 )
 
 
@@ -2947,8 +3008,8 @@ _SYNCHRONIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7343,
-  serialized_end=7470,
+  serialized_start=7494,
+  serialized_end=7621,
 )
 
 
@@ -3017,8 +3078,8 @@ _INITIALIZEMODELARGS_FILTER = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7748,
-  serialized_end=7913,
+  serialized_start=7899,
+  serialized_end=8064,
 )
 
 _INITIALIZEMODELARGS = _descriptor.Descriptor(
@@ -3094,8 +3155,8 @@ _INITIALIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7473,
-  serialized_end=7956,
+  serialized_start=7624,
+  serialized_end=8107,
 )
 
 
@@ -3173,8 +3234,8 @@ _GETTOPICMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7959,
-  serialized_end=8331,
+  serialized_start=8110,
+  serialized_end=8482,
 )
 
 
@@ -3251,8 +3312,8 @@ _GETTHETAMATRIXARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8334,
-  serialized_end=8627,
+  serialized_start=8485,
+  serialized_end=8778,
 )
 
 
@@ -3293,8 +3354,8 @@ _GETSCOREVALUEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8629,
-  serialized_end=8716,
+  serialized_start=8780,
+  serialized_end=8867,
 )
 
 
@@ -3342,8 +3403,8 @@ _ADDBATCHARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8719,
-  serialized_end=8849,
+  serialized_start=8870,
+  serialized_end=9000,
 )
 
 
@@ -3384,8 +3445,8 @@ _INVOKEITERATIONARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8851,
-  serialized_end=8948,
+  serialized_start=9002,
+  serialized_end=9099,
 )
 
 
@@ -3412,8 +3473,8 @@ _WAITIDLEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8950,
-  serialized_end=8998,
+  serialized_start=9101,
+  serialized_end=9149,
 )
 
 
@@ -3447,8 +3508,8 @@ _EXPORTMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9000,
-  serialized_end=9056,
+  serialized_start=9151,
+  serialized_end=9207,
 )
 
 
@@ -3482,8 +3543,8 @@ _IMPORTMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9058,
-  serialized_end=9114,
+  serialized_start=9209,
+  serialized_end=9265,
 )
 
 
@@ -3510,8 +3571,8 @@ _ATTACHMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9116,
-  serialized_end=9153,
+  serialized_start=9267,
+  serialized_end=9304,
 )
 
 
@@ -3627,13 +3688,6 @@ _PROCESSBATCHESARGS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
-    _descriptor.FieldDescriptor(
-      name='use_ptdw_matrix', full_name='artm.ProcessBatchesArgs.use_ptdw_matrix', index=15,
-      number=16, type=8, cpp_type=7, label=1,
-      has_default_value=True, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
   ],
   extensions=[
   ],
@@ -3644,8 +3698,8 @@ _PROCESSBATCHESARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9156,
-  serialized_end=9744,
+  serialized_start=9307,
+  serialized_end=9863,
 )
 
 
@@ -3679,8 +3733,8 @@ _PROCESSBATCHESRESULT = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9746,
-  serialized_end=9846,
+  serialized_start=9865,
+  serialized_end=9965,
 )
 
 
@@ -3728,8 +3782,8 @@ _MERGEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9848,
-  serialized_end=9957,
+  serialized_start=9967,
+  serialized_end=10076,
 )
 
 
@@ -3777,8 +3831,8 @@ _REGULARIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9960,
-  serialized_end=10113,
+  serialized_start=10079,
+  serialized_end=10232,
 )
 
 
@@ -3819,8 +3873,8 @@ _NORMALIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10115,
-  serialized_end=10210,
+  serialized_start=10234,
+  serialized_end=10329,
 )
 
 
@@ -3854,8 +3908,8 @@ _IMPORTDICTIONARYARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10212,
-  serialized_end=10278,
+  serialized_start=10331,
+  serialized_end=10397,
 )
 
 
@@ -3883,8 +3937,8 @@ _COPYREQUESTRESULTARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10281,
-  serialized_end=10474,
+  serialized_start=10400,
+  serialized_end=10593,
 )
 
 
@@ -3904,8 +3958,8 @@ _DUPLICATEMASTERCOMPONENTARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10476,
-  serialized_end=10506,
+  serialized_start=10595,
+  serialized_end=10625,
 )
 
 
@@ -3925,8 +3979,8 @@ _GETMASTERCOMPONENTINFOARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10508,
-  serialized_end=10536,
+  serialized_start=10627,
+  serialized_end=10655,
 )
 
 
@@ -3960,8 +4014,8 @@ _MASTERCOMPONENTINFO_REGULARIZERINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11028,
-  serialized_end=11073,
+  serialized_start=11147,
+  serialized_end=11192,
 )
 
 _MASTERCOMPONENTINFO_SCOREINFO = _descriptor.Descriptor(
@@ -3994,8 +4048,8 @@ _MASTERCOMPONENTINFO_SCOREINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11075,
-  serialized_end=11114,
+  serialized_start=11194,
+  serialized_end=11233,
 )
 
 _MASTERCOMPONENTINFO_DICTIONARYINFO = _descriptor.Descriptor(
@@ -4028,8 +4082,8 @@ _MASTERCOMPONENTINFO_DICTIONARYINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11116,
-  serialized_end=11169,
+  serialized_start=11235,
+  serialized_end=11288,
 )
 
 _MASTERCOMPONENTINFO_BATCHINFO = _descriptor.Descriptor(
@@ -4069,8 +4123,8 @@ _MASTERCOMPONENTINFO_BATCHINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11171,
-  serialized_end=11238,
+  serialized_start=11290,
+  serialized_end=11357,
 )
 
 _MASTERCOMPONENTINFO_MODELINFO = _descriptor.Descriptor(
@@ -4117,8 +4171,8 @@ _MASTERCOMPONENTINFO_MODELINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11240,
-  serialized_end=11322,
+  serialized_start=11359,
+  serialized_end=11441,
 )
 
 _MASTERCOMPONENTINFO_CACHEENTRYINFO = _descriptor.Descriptor(
@@ -4151,8 +4205,8 @@ _MASTERCOMPONENTINFO_CACHEENTRYINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11324,
-  serialized_end=11372,
+  serialized_start=11443,
+  serialized_end=11491,
 )
 
 _MASTERCOMPONENTINFO = _descriptor.Descriptor(
@@ -4241,8 +4295,8 @@ _MASTERCOMPONENTINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10539,
-  serialized_end=11372,
+  serialized_start=10658,
+  serialized_end=11491,
 )
 
 
@@ -4276,8 +4330,8 @@ _IMPORTBATCHESARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11374,
-  serialized_end=11441,
+  serialized_start=11493,
+  serialized_end=11560,
 )
 
 
@@ -4304,8 +4358,8 @@ _DISPOSEBATCHESARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11443,
-  serialized_end=11483,
+  serialized_start=11562,
+  serialized_end=11602,
 )
 
 _ITEM.fields_by_name['field'].message_type = _FIELD
@@ -4319,6 +4373,8 @@ _REGULARIZERCONFIG.fields_by_name['type'].enum_type = _REGULARIZERCONFIG_TYPE
 _REGULARIZERCONFIG_TYPE.containing_type = _REGULARIZERCONFIG;
 _SPECIFIEDSPARSEPHICONFIG.fields_by_name['mode'].enum_type = _SPECIFIEDSPARSEPHICONFIG_MODE
 _SPECIFIEDSPARSEPHICONFIG_MODE.containing_type = _SPECIFIEDSPARSEPHICONFIG;
+_SMOOTHPTDWCONFIG.fields_by_name['type'].enum_type = _SMOOTHPTDWCONFIG_TYPE
+_SMOOTHPTDWCONFIG_TYPE.containing_type = _SMOOTHPTDWCONFIG;
 _REGULARIZERINTERNALSTATE.fields_by_name['type'].enum_type = _REGULARIZERINTERNALSTATE_TYPE
 _REGULARIZERINTERNALSTATE_TYPE.containing_type = _REGULARIZERINTERNALSTATE;
 _DICTIONARYCONFIG.fields_by_name['entry'].message_type = _DICTIONARYENTRY
@@ -4402,6 +4458,7 @@ DESCRIPTOR.message_types_by_name['MultiLanguagePhiConfig'] = _MULTILANGUAGEPHICO
 DESCRIPTOR.message_types_by_name['LabelRegularizationPhiConfig'] = _LABELREGULARIZATIONPHICONFIG
 DESCRIPTOR.message_types_by_name['SpecifiedSparsePhiConfig'] = _SPECIFIEDSPARSEPHICONFIG
 DESCRIPTOR.message_types_by_name['ImproveCoherencePhiConfig'] = _IMPROVECOHERENCEPHICONFIG
+DESCRIPTOR.message_types_by_name['SmoothPtdwConfig'] = _SMOOTHPTDWCONFIG
 DESCRIPTOR.message_types_by_name['RegularizerInternalState'] = _REGULARIZERINTERNALSTATE
 DESCRIPTOR.message_types_by_name['MultiLanguagePhiInternalState'] = _MULTILANGUAGEPHIINTERNALSTATE
 DESCRIPTOR.message_types_by_name['DictionaryConfig'] = _DICTIONARYCONFIG
@@ -4571,6 +4628,12 @@ class ImproveCoherencePhiConfig(_message.Message):
   DESCRIPTOR = _IMPROVECOHERENCEPHICONFIG
 
   # @@protoc_insertion_point(class_scope:artm.ImproveCoherencePhiConfig)
+
+class SmoothPtdwConfig(_message.Message):
+  __metaclass__ = _reflection.GeneratedProtocolMessageType
+  DESCRIPTOR = _SMOOTHPTDWCONFIG
+
+  # @@protoc_insertion_point(class_scope:artm.SmoothPtdwConfig)
 
 class RegularizerInternalState(_message.Message):
   __metaclass__ = _reflection.GeneratedProtocolMessageType

--- a/src/artm/CMakeLists.txt
+++ b/src/artm/CMakeLists.txt
@@ -62,6 +62,8 @@ set(SRC_LIST
 	regularizer/label_regularization_phi.h
 	regularizer/smooth_sparse_theta.cc
 	regularizer/smooth_sparse_theta.h
+	regularizer/smooth_ptdw.cc
+	regularizer/smooth_ptdw.h
 	regularizer/specified_sparse_phi.cc
 	regularizer/specified_sparse_phi.h
 	regularizer/improve_coherence_phi.cc

--- a/src/artm/core/helpers.cc
+++ b/src/artm/core/helpers.cc
@@ -723,7 +723,6 @@ std::string Helpers::Describe(const ::artm::ModelConfig& message) {
   ss << ", use_sparse_bow=" << (message.use_sparse_bow() ? "yes" : "no");
   ss << ", use_random_theta=" << (message.use_random_theta() ? "yes" : "no");
   ss << ", use_new_tokens=" << (message.use_new_tokens() ? "yes" : "no");
-  ss << ", use_ptdw_matrix=" << (message.use_ptdw_matrix() ? "yes" : "no");
   return ss.str();
 }
 
@@ -777,7 +776,6 @@ std::string Helpers::Describe(const ::artm::ProcessBatchesArgs& message) {
   ss << ", opt_for_avx=" << (message.opt_for_avx() ? "yes" : "no");
   ss << ", use_sparse_bow=" << (message.use_sparse_bow() ? "yes" : "no");
   ss << ", reset_scores=" << (message.reset_scores() ? "yes" : "no");
-  ss << ", use_ptdw_matrix=" << (message.use_ptdw_matrix() ? "yes" : "no");
   return ss.str();
 }
 

--- a/src/artm/core/instance.cc
+++ b/src/artm/core/instance.cc
@@ -29,6 +29,7 @@
 #include "artm/regularizer/label_regularization_phi.h"
 #include "artm/regularizer/specified_sparse_phi.h"
 #include "artm/regularizer/improve_coherence_phi.h"
+#include "artm/regularizer/smooth_ptdw.h"
 
 #include "artm/score/items_processed.h"
 #include "artm/score/sparsity_theta.h"
@@ -271,6 +272,12 @@ void Instance::CreateOrReconfigureRegularizer(const RegularizerConfig& config) {
     case artm::RegularizerConfig_Type_ImproveCoherencePhi: {
       CREATE_OR_RECONFIGURE_REGULARIZER(::artm::ImproveCoherencePhiConfig,
                                         ::artm::regularizer::ImproveCoherencePhi);
+      break;
+    }
+
+    case artm::RegularizerConfig_Type_SmoothPtdw: {
+      CREATE_OR_RECONFIGURE_REGULARIZER(::artm::SmoothPtdwConfig,
+                                        ::artm::regularizer::SmoothPtdw);
       break;
     }
 

--- a/src/artm/core/master_component.cc
+++ b/src/artm/core/master_component.cc
@@ -294,7 +294,6 @@ void MasterComponent::RequestProcessBatches(const ProcessBatchesArgs& process_ba
   if (args.has_reuse_theta()) model_config.set_reuse_theta(args.reuse_theta());
   if (args.has_opt_for_avx()) model_config.set_opt_for_avx(args.opt_for_avx());
   if (args.has_use_sparse_bow()) model_config.set_use_sparse_bow(args.use_sparse_bow());
-  if (args.has_use_ptdw_matrix()) model_config.set_use_ptdw_matrix(args.use_ptdw_matrix());
 
   std::shared_ptr<const TopicModel> topic_model = instance_->merger()->GetLatestTopicModel(model_name);
   std::shared_ptr<const PhiMatrix> phi_matrix = instance_->merger()->GetPhiMatrix(model_name);
@@ -365,10 +364,6 @@ void MasterComponent::RequestProcessBatches(const ProcessBatchesArgs& process_ba
     pi->mutable_model_config()->CopyFrom(model_config);
     pi->set_task_id(task_id);
     pi->set_caller(ProcessorInput::Caller::ProcessBatches);
-
-    if (args.theta_matrix_type() == ProcessBatchesArgs_ThetaMatrixType_DensePtdw ||
-        args.theta_matrix_type() == ProcessBatchesArgs_ThetaMatrixType_SparsePtdw)
-      pi->mutable_model_config()->set_use_ptdw_matrix(true);
 
     if (args.reuse_theta())
       pi->set_reuse_theta_cache_manager(instance_->cache_manager());

--- a/src/artm/core/processor.cc
+++ b/src/artm/core/processor.cc
@@ -41,6 +41,62 @@ const float kProcessorEps = 1e-16;
 namespace artm {
 namespace core {
 
+class RegularizeThetaAgentCollection : public RegularizeThetaAgent {
+ private:
+  std::vector<std::shared_ptr<RegularizeThetaAgent>> agents_;
+
+ public:
+  void AddAgent(std::shared_ptr<RegularizeThetaAgent> agent) {
+    if (agent != nullptr)
+      agents_.push_back(agent);
+  }
+
+  bool empty() const { return agents_.empty(); }
+
+  virtual void Apply(int item_index, int inner_iter, int topics_size, float* theta) const {
+    for (auto& agent : agents_)
+      agent->Apply(item_index, inner_iter, topics_size, theta);
+  }
+};
+
+class RegularizePtdwAgentCollection : public RegularizePtdwAgent {
+ private:
+  std::vector<std::shared_ptr<RegularizePtdwAgent>> agents_;
+
+ public:
+  void AddAgent(std::shared_ptr<RegularizePtdwAgent> agent) {
+    if (agent != nullptr)
+      agents_.push_back(agent);
+  }
+
+  bool empty() const { return agents_.empty(); }
+
+  virtual void Apply(int item_index, int inner_iter, ::artm::utility::DenseMatrix<float>* ptdw) const {
+    for (auto& agent : agents_)
+      agent->Apply(item_index, inner_iter, ptdw);
+  }
+};
+
+class NormalizeThetaAgent : public RegularizeThetaAgent {
+ public:
+  virtual void Apply(int item_index, int inner_iter, int topics_size, float* theta) const {
+    float sum = 0.0f;
+    for (int topic_index = 0; topic_index < topics_size; ++topic_index) {
+      float val = theta[topic_index];
+      if (val > 0)
+        sum += val;
+    }
+
+    float sum_inv = sum > 0.0f ? (1.0f / sum) : 0.0f;
+    for (int topic_index = 0; topic_index < topics_size; ++topic_index) {
+      float val = sum_inv * theta[topic_index];
+      if (val < 1e-16f) val = 0.0f;
+      theta[topic_index] = val;
+    }
+  }
+};
+
+
 static void CreateThetaCacheEntry(DataLoaderCacheEntry* new_cache_entry_ptr,
                                   DenseMatrix<float>* theta_matrix,
                                   const Batch& batch,
@@ -325,10 +381,9 @@ InitializePhi(const Batch& batch, const ModelConfig& model_config,
   return phi_matrix;
 }
 
-static std::shared_ptr<RegularizeThetaAgentCollection>
-CreateRegularizerAgents(const Batch& batch, const ModelConfig& model_config, const InstanceSchema& schema) {
-  auto retval = std::make_shared<RegularizeThetaAgentCollection>();
-
+static void
+CreateRegularizerAgents(const Batch& batch, const ModelConfig& model_config, const InstanceSchema& schema,
+                        RegularizeThetaAgentCollection* theta_agents, RegularizePtdwAgentCollection* ptdw_agents) {
   for (int reg_index = 0; reg_index < model_config.regularizer_settings_size(); ++reg_index) {
     std::string reg_name = model_config.regularizer_settings(reg_index).name();
     double tau = model_config.regularizer_settings(reg_index).tau();
@@ -338,10 +393,15 @@ CreateRegularizerAgents(const Batch& batch, const ModelConfig& model_config, con
       continue;
     }
 
-    retval->AddAgent(regularizer->CreateRegularizeThetaAgent(batch, model_config, tau));
+    if (theta_agents != nullptr)
+      theta_agents->AddAgent(regularizer->CreateRegularizeThetaAgent(batch, model_config, tau));
+
+    if (ptdw_agents != nullptr)
+      ptdw_agents->AddAgent(regularizer->CreateRegularizePtdwAgent(batch, model_config, tau));
   }
 
-  return retval;
+  if (theta_agents != nullptr)
+    theta_agents->AddAgent(std::make_shared<NormalizeThetaAgent>());
 }
 
 static std::shared_ptr<CsrMatrix<float>>
@@ -406,17 +466,16 @@ InitializeDenseNdw(const Batch& batch) {
 
 static void
 InferThetaAndUpdateNwtSparse(const ModelConfig& model_config, const Batch& batch, float batch_weight, const Mask* mask,
-                             const InstanceSchema& schema, const CsrMatrix<float>& sparse_ndw,
-                             const ::artm::core::PhiMatrix& p_wt, DenseMatrix<float>* theta_matrix,
+                             const CsrMatrix<float>& sparse_ndw,
+                             const ::artm::core::PhiMatrix& p_wt,
+                             const RegularizeThetaAgentCollection& theta_agents,
+                             DenseMatrix<float>* theta_matrix,
                              NwtWriteAdapter* nwt_writer, util::Blas* blas,
                              DataLoaderCacheEntry* new_cache_entry_ptr = nullptr) {
   DenseMatrix<float> n_td(theta_matrix->no_rows(), theta_matrix->no_columns(), false);
   const int topics_count = model_config.topics_count();
   const int docs_count = theta_matrix->no_columns();
   const int tokens_count = batch.token_size();
-
-  std::shared_ptr<RegularizeThetaAgentCollection> agents = CreateRegularizerAgents(batch, model_config, schema);
-  agents->AddAgent(std::make_shared<NormalizeThetaAgent>());
 
   std::vector<int> token_id(batch.token_size(), -1);
   for (int token_index = 0; token_index < batch.token_size(); ++token_index)
@@ -469,7 +528,7 @@ InferThetaAndUpdateNwtSparse(const ModelConfig& model_config, const Batch& batch
       for (int k = 0; k < topics_count; ++k)
         theta_ptr[k] *= ntd_ptr[k];
 
-      agents->Apply(d, inner_iter, model_config.topics_count(), theta_ptr);
+      theta_agents.Apply(d, inner_iter, model_config.topics_count(), theta_ptr);
     }
   }
   } else {
@@ -492,7 +551,7 @@ InferThetaAndUpdateNwtSparse(const ModelConfig& model_config, const Batch& batch
     AssignDenseMatrixByProduct(*theta_matrix, n_td, theta_matrix);
 
     for (int item_index = 0; item_index < batch.item_size(); ++item_index)
-      agents->Apply(item_index, inner_iter, model_config.topics_count(), &(*theta_matrix)(0, item_index));  // NOLINT
+      theta_agents.Apply(item_index, inner_iter, model_config.topics_count(), &(*theta_matrix)(0, item_index));  // NOLINT
   }
   }
 
@@ -536,8 +595,11 @@ InferThetaAndUpdateNwtSparse(const ModelConfig& model_config, const Batch& batch
 
 static void
 InferPtdwAndUpdateNwtSparse(const ModelConfig& model_config, const Batch& batch, float batch_weight, const Mask* mask,
-                            const InstanceSchema& schema, const CsrMatrix<float>& sparse_ndw,
-                            const ::artm::core::PhiMatrix& p_wt, DenseMatrix<float>* theta_matrix,
+                            const CsrMatrix<float>& sparse_ndw,
+                            const ::artm::core::PhiMatrix& p_wt,
+                            const RegularizeThetaAgentCollection& theta_agents,
+                            const RegularizePtdwAgentCollection& ptdw_agents,
+                            DenseMatrix<float>* theta_matrix,
                             NwtWriteAdapter* nwt_writer, util::Blas* blas,
                             DataLoaderCacheEntry* new_cache_entry_ptr = nullptr,
                             DataLoaderCacheEntry* new_ptdw_cache_entry_ptr = nullptr) {
@@ -545,9 +607,6 @@ InferPtdwAndUpdateNwtSparse(const ModelConfig& model_config, const Batch& batch,
   const int topics_count = model_config.topics_count();
   const int docs_count = theta_matrix->no_columns();
   const int tokens_count = batch.token_size();
-
-  std::shared_ptr<RegularizeThetaAgentCollection> agents = CreateRegularizerAgents(batch, model_config, schema);
-  agents->AddAgent(std::make_shared<NormalizeThetaAgent>());
 
   std::vector<int> token_id(batch.token_size(), -1);
   for (int token_index = 0; token_index < batch.token_size(); ++token_index)
@@ -593,10 +652,7 @@ InferPtdwAndUpdateNwtSparse(const ModelConfig& model_config, const Batch& batch,
           ptdw_ptr[k] *= Z;
       }
 
-      // ToDo: Apply ptdw regularizer here (if needed)
-      // For now ust put the code here.
-      // Later we may do via regularizer's framework like this:
-      // ptdw_agents->Apply(d, inner_iter, topics_count, local_ptdw)
+      ptdw_agents.Apply(d, inner_iter, &local_ptdw);
 
       if (!last_iteration) {  // update theta matrix (except for the last iteration)
         for (int k = 0; k < topics_count; ++k)
@@ -611,7 +667,7 @@ InferPtdwAndUpdateNwtSparse(const ModelConfig& model_config, const Batch& batch,
         for (int k = 0; k < topics_count; ++k)
           theta_ptr[k] = ntd_ptr[k];
 
-        agents->Apply(d, inner_iter, topics_count, theta_ptr);
+        theta_agents.Apply(d, inner_iter, topics_count, theta_ptr);
       } else {  // update n_wt matrix (on the last iteration)
         const bool in_mask = (mask == nullptr || mask->value(d));
         if (nwt_writer != nullptr && in_mask) {
@@ -667,13 +723,13 @@ InferThetaAndUpdateNwtDense(const ModelConfig& model_config, const Batch& batch,
 
     AssignDenseMatrixByProduct(*theta_matrix, prod_trans_phi_Z, theta_matrix);
 
-    std::shared_ptr<RegularizeThetaAgentCollection> agents = CreateRegularizerAgents(batch, model_config, schema);
-    agents->AddAgent(std::make_shared<NormalizeThetaAgent>());
+    RegularizeThetaAgentCollection theta_agents;
+    CreateRegularizerAgents(batch, model_config, schema, &theta_agents, /* ptdw_agents =*/ nullptr);
 
     std::vector<float> theta_copy(topics_count, 0.0f);
     for (int item_index = 0; item_index < batch.item_size(); ++item_index) {
       for (int i = 0; i < topics_count; ++i) theta_copy[i] = (*theta_matrix)(i, item_index);
-      agents->Apply(item_index, inner_iter, model_config.topics_count(), &theta_copy[0]);
+      theta_agents.Apply(item_index, inner_iter, model_config.topics_count(), &theta_copy[0]);
       for (int i = 0; i < topics_count; ++i) (*theta_matrix)(i, item_index) = theta_copy[i];
     }
   }
@@ -825,12 +881,18 @@ void Processor::FindThetaMatrix(const Batch& batch,
     return;  // return from lambda; goes to next step of std::for_each
   }
 
-  if (model_config.use_sparse_bow() && model_config.use_ptdw_matrix()) {
-    InferPtdwAndUpdateNwtSparse(model_config, batch, 1.0f, nullptr, *schema, *sparse_ndw, p_wt,
-                                theta_matrix.get(), nullptr, blas);
-  } else if (model_config.use_sparse_bow()) {
-    InferThetaAndUpdateNwtSparse(model_config, batch, 1.0f, nullptr, *schema, *sparse_ndw, p_wt,
-                                 theta_matrix.get(), nullptr, blas);
+  if (model_config.use_sparse_bow()) {
+    RegularizeThetaAgentCollection theta_agents;
+    RegularizePtdwAgentCollection ptdw_agents;
+    CreateRegularizerAgents(batch, model_config, *schema, &theta_agents, &ptdw_agents);
+
+    if (ptdw_agents.empty()) {
+      InferThetaAndUpdateNwtSparse(model_config, batch, 1.0f, nullptr, *sparse_ndw, p_wt,
+                                   theta_agents, theta_matrix.get(), nullptr, blas);
+    } else {
+      InferPtdwAndUpdateNwtSparse(model_config, batch, 1.0f, nullptr, *sparse_ndw, p_wt,
+                                  theta_agents, ptdw_agents, theta_matrix.get(), nullptr, blas);
+    }
   } else {
     // We don't need 'UpdateNwt' part, but for Dense mode it is hard to split this function.
     InferThetaAndUpdateNwtDense(model_config, batch, 1.0f, nullptr, *schema, *dense_ndw, p_wt,
@@ -1040,15 +1102,23 @@ void Processor::ThreadFunction() {
           new_ptdw_cache_entry_ptr->mutable_topic_name()->CopyFrom(model_increment->topic_model().topic_name());
         }
 
-        if (model_config.use_sparse_bow() && model_config.use_ptdw_matrix()) {
-          CuckooWatch cuckoo2("InferPtdwAndUpdateNwtSparse", &cuckoo, kTimeLoggingThreshold);
-          InferPtdwAndUpdateNwtSparse(model_config, batch, part->batch_weight(), stream_mask, *schema, *sparse_ndw,
-                                      p_wt, theta_matrix.get(), nwt_writer.get(), blas, new_cache_entry_ptr.get(),
-                                      new_ptdw_cache_entry_ptr.get());
-        } else if (model_config.use_sparse_bow()) {
-          CuckooWatch cuckoo2("InferThetaAndUpdateNwtSparse", &cuckoo, kTimeLoggingThreshold);
-          InferThetaAndUpdateNwtSparse(model_config, batch, part->batch_weight(), stream_mask, *schema, *sparse_ndw,
-                                       p_wt, theta_matrix.get(), nwt_writer.get(), blas, new_cache_entry_ptr.get());
+        if (model_config.use_sparse_bow()) {
+          RegularizeThetaAgentCollection theta_agents;
+          RegularizePtdwAgentCollection ptdw_agents;
+          CreateRegularizerAgents(batch, model_config, *schema, &theta_agents, &ptdw_agents);
+
+          if (ptdw_agents.empty() && !part->has_ptdw_cache_manager()) {
+            CuckooWatch cuckoo2("InferThetaAndUpdateNwtSparse", &cuckoo, kTimeLoggingThreshold);
+            InferThetaAndUpdateNwtSparse(model_config, batch, part->batch_weight(), stream_mask, *sparse_ndw,
+                                         p_wt, theta_agents, theta_matrix.get(), nwt_writer.get(),
+                                         blas, new_cache_entry_ptr.get());
+          } else {
+            CuckooWatch cuckoo2("InferPtdwAndUpdateNwtSparse", &cuckoo, kTimeLoggingThreshold);
+            InferPtdwAndUpdateNwtSparse(model_config, batch, part->batch_weight(), stream_mask, *sparse_ndw,
+                                        p_wt, theta_agents, ptdw_agents, theta_matrix.get(), nwt_writer.get(),
+                                        blas, new_cache_entry_ptr.get(),
+                                        new_ptdw_cache_entry_ptr.get());
+          }
         } else {
           CuckooWatch cuckoo2("InferThetaAndUpdateNwtDense", &cuckoo, kTimeLoggingThreshold);
           InferThetaAndUpdateNwtDense(model_config, batch, part->batch_weight(), stream_mask, *schema, *dense_ndw,

--- a/src/artm/messages.pb.cc
+++ b/src/artm/messages.pb.cc
@@ -83,6 +83,10 @@ const ::google::protobuf::EnumDescriptor* SpecifiedSparsePhiConfig_Mode_descript
 const ::google::protobuf::Descriptor* ImproveCoherencePhiConfig_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ImproveCoherencePhiConfig_reflection_ = NULL;
+const ::google::protobuf::Descriptor* SmoothPtdwConfig_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  SmoothPtdwConfig_reflection_ = NULL;
+const ::google::protobuf::EnumDescriptor* SmoothPtdwConfig_Type_descriptor_ = NULL;
 const ::google::protobuf::Descriptor* RegularizerInternalState_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   RegularizerInternalState_reflection_ = NULL;
@@ -476,7 +480,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RegularizerSettings));
   ModelConfig_descriptor_ = file->message_type(11);
-  static const int ModelConfig_offsets_[19] = {
+  static const int ModelConfig_offsets_[18] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ModelConfig, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ModelConfig, topics_count_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ModelConfig, topic_name_),
@@ -495,7 +499,6 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ModelConfig, use_new_tokens_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ModelConfig, opt_for_avx_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ModelConfig, regularizer_settings_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ModelConfig, use_ptdw_matrix_),
   };
   ModelConfig_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -643,7 +646,25 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ImproveCoherencePhiConfig));
-  RegularizerInternalState_descriptor_ = file->message_type(20);
+  SmoothPtdwConfig_descriptor_ = file->message_type(20);
+  static const int SmoothPtdwConfig_offsets_[3] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SmoothPtdwConfig, type_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SmoothPtdwConfig, window_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SmoothPtdwConfig, threshold_),
+  };
+  SmoothPtdwConfig_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      SmoothPtdwConfig_descriptor_,
+      SmoothPtdwConfig::default_instance_,
+      SmoothPtdwConfig_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SmoothPtdwConfig, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SmoothPtdwConfig, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(SmoothPtdwConfig));
+  SmoothPtdwConfig_Type_descriptor_ = SmoothPtdwConfig_descriptor_->enum_type(0);
+  RegularizerInternalState_descriptor_ = file->message_type(21);
   static const int RegularizerInternalState_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RegularizerInternalState, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RegularizerInternalState, type_),
@@ -661,7 +682,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RegularizerInternalState));
   RegularizerInternalState_Type_descriptor_ = RegularizerInternalState_descriptor_->enum_type(0);
-  MultiLanguagePhiInternalState_descriptor_ = file->message_type(21);
+  MultiLanguagePhiInternalState_descriptor_ = file->message_type(22);
   static const int MultiLanguagePhiInternalState_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MultiLanguagePhiInternalState, no_regularization_calls_),
   };
@@ -676,7 +697,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(MultiLanguagePhiInternalState));
-  DictionaryConfig_descriptor_ = file->message_type(22);
+  DictionaryConfig_descriptor_ = file->message_type(23);
   static const int DictionaryConfig_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DictionaryConfig, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DictionaryConfig, entry_),
@@ -696,7 +717,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(DictionaryConfig));
-  DictionaryEntry_descriptor_ = file->message_type(23);
+  DictionaryEntry_descriptor_ = file->message_type(24);
   static const int DictionaryEntry_offsets_[8] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DictionaryEntry, key_token_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DictionaryEntry, class_id_),
@@ -718,7 +739,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(DictionaryEntry));
-  DictionaryCoocurenceEntries_descriptor_ = file->message_type(24);
+  DictionaryCoocurenceEntries_descriptor_ = file->message_type(25);
   static const int DictionaryCoocurenceEntries_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DictionaryCoocurenceEntries, first_index_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DictionaryCoocurenceEntries, second_index_),
@@ -736,7 +757,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(DictionaryCoocurenceEntries));
-  ScoreConfig_descriptor_ = file->message_type(25);
+  ScoreConfig_descriptor_ = file->message_type(26);
   static const int ScoreConfig_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScoreConfig, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScoreConfig, type_),
@@ -754,7 +775,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ScoreConfig));
   ScoreConfig_Type_descriptor_ = ScoreConfig_descriptor_->enum_type(0);
-  ScoreData_descriptor_ = file->message_type(26);
+  ScoreData_descriptor_ = file->message_type(27);
   static const int ScoreData_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScoreData, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScoreData, type_),
@@ -772,7 +793,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ScoreData));
   ScoreData_Type_descriptor_ = ScoreData_descriptor_->enum_type(0);
-  PerplexityScoreConfig_descriptor_ = file->message_type(27);
+  PerplexityScoreConfig_descriptor_ = file->message_type(28);
   static const int PerplexityScoreConfig_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PerplexityScoreConfig, field_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PerplexityScoreConfig, stream_name_),
@@ -794,7 +815,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(PerplexityScoreConfig));
   PerplexityScoreConfig_Type_descriptor_ = PerplexityScoreConfig_descriptor_->enum_type(0);
-  PerplexityScore_descriptor_ = file->message_type(28);
+  PerplexityScore_descriptor_ = file->message_type(29);
   static const int PerplexityScore_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PerplexityScore, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PerplexityScore, raw_),
@@ -815,7 +836,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(PerplexityScore));
-  SparsityThetaScoreConfig_descriptor_ = file->message_type(29);
+  SparsityThetaScoreConfig_descriptor_ = file->message_type(30);
   static const int SparsityThetaScoreConfig_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityThetaScoreConfig, field_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityThetaScoreConfig, stream_name_),
@@ -833,7 +854,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SparsityThetaScoreConfig));
-  SparsityThetaScore_descriptor_ = file->message_type(30);
+  SparsityThetaScore_descriptor_ = file->message_type(31);
   static const int SparsityThetaScore_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityThetaScore, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityThetaScore, zero_topics_),
@@ -850,7 +871,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SparsityThetaScore));
-  SparsityPhiScoreConfig_descriptor_ = file->message_type(31);
+  SparsityPhiScoreConfig_descriptor_ = file->message_type(32);
   static const int SparsityPhiScoreConfig_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityPhiScoreConfig, eps_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityPhiScoreConfig, class_id_),
@@ -867,7 +888,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SparsityPhiScoreConfig));
-  SparsityPhiScore_descriptor_ = file->message_type(32);
+  SparsityPhiScore_descriptor_ = file->message_type(33);
   static const int SparsityPhiScore_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityPhiScore, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityPhiScore, zero_tokens_),
@@ -884,7 +905,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SparsityPhiScore));
-  ItemsProcessedScoreConfig_descriptor_ = file->message_type(33);
+  ItemsProcessedScoreConfig_descriptor_ = file->message_type(34);
   static const int ItemsProcessedScoreConfig_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ItemsProcessedScoreConfig, field_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ItemsProcessedScoreConfig, stream_name_),
@@ -900,7 +921,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ItemsProcessedScoreConfig));
-  ItemsProcessedScore_descriptor_ = file->message_type(34);
+  ItemsProcessedScore_descriptor_ = file->message_type(35);
   static const int ItemsProcessedScore_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ItemsProcessedScore, value_),
   };
@@ -915,7 +936,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ItemsProcessedScore));
-  TopTokensScoreConfig_descriptor_ = file->message_type(35);
+  TopTokensScoreConfig_descriptor_ = file->message_type(36);
   static const int TopTokensScoreConfig_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopTokensScoreConfig, num_tokens_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopTokensScoreConfig, class_id_),
@@ -933,7 +954,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopTokensScoreConfig));
-  TopTokensScore_descriptor_ = file->message_type(36);
+  TopTokensScore_descriptor_ = file->message_type(37);
   static const int TopTokensScore_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopTokensScore, num_entries_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopTokensScore, topic_name_),
@@ -954,7 +975,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopTokensScore));
-  ThetaSnippetScoreConfig_descriptor_ = file->message_type(37);
+  ThetaSnippetScoreConfig_descriptor_ = file->message_type(38);
   static const int ThetaSnippetScoreConfig_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaSnippetScoreConfig, field_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaSnippetScoreConfig, stream_name_),
@@ -972,7 +993,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ThetaSnippetScoreConfig));
-  ThetaSnippetScore_descriptor_ = file->message_type(38);
+  ThetaSnippetScore_descriptor_ = file->message_type(39);
   static const int ThetaSnippetScore_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaSnippetScore, item_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaSnippetScore, values_),
@@ -988,7 +1009,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ThetaSnippetScore));
-  TopicKernelScoreConfig_descriptor_ = file->message_type(39);
+  TopicKernelScoreConfig_descriptor_ = file->message_type(40);
   static const int TopicKernelScoreConfig_offsets_[5] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicKernelScoreConfig, eps_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicKernelScoreConfig, class_id_),
@@ -1007,7 +1028,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopicKernelScoreConfig));
-  TopicKernelScore_descriptor_ = file->message_type(40);
+  TopicKernelScore_descriptor_ = file->message_type(41);
   static const int TopicKernelScore_offsets_[10] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicKernelScore, kernel_size_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicKernelScore, kernel_purity_),
@@ -1031,7 +1052,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopicKernelScore));
-  TopicMassPhiScoreConfig_descriptor_ = file->message_type(41);
+  TopicMassPhiScoreConfig_descriptor_ = file->message_type(42);
   static const int TopicMassPhiScoreConfig_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicMassPhiScoreConfig, eps_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicMassPhiScoreConfig, class_id_),
@@ -1048,7 +1069,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopicMassPhiScoreConfig));
-  TopicMassPhiScore_descriptor_ = file->message_type(42);
+  TopicMassPhiScore_descriptor_ = file->message_type(43);
   static const int TopicMassPhiScore_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicMassPhiScore, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicMassPhiScore, topic_name_),
@@ -1066,7 +1087,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopicMassPhiScore));
-  TopicModel_descriptor_ = file->message_type(43);
+  TopicModel_descriptor_ = file->message_type(44);
   static const int TopicModel_offsets_[9] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicModel, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicModel, topics_count_),
@@ -1105,7 +1126,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopicModel_TopicModelInternals));
   TopicModel_OperationType_descriptor_ = TopicModel_descriptor_->enum_type(0);
-  ThetaMatrix_descriptor_ = file->message_type(44);
+  ThetaMatrix_descriptor_ = file->message_type(45);
   static const int ThetaMatrix_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaMatrix, model_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaMatrix, item_id_),
@@ -1126,7 +1147,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ThetaMatrix));
-  CollectionParserConfig_descriptor_ = file->message_type(45);
+  CollectionParserConfig_descriptor_ = file->message_type(46);
   static const int CollectionParserConfig_offsets_[11] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CollectionParserConfig, format_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CollectionParserConfig, docword_file_path_),
@@ -1152,7 +1173,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(CollectionParserConfig));
   CollectionParserConfig_Format_descriptor_ = CollectionParserConfig_descriptor_->enum_type(0);
-  SynchronizeModelArgs_descriptor_ = file->message_type(46);
+  SynchronizeModelArgs_descriptor_ = file->message_type(47);
   static const int SynchronizeModelArgs_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SynchronizeModelArgs, model_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SynchronizeModelArgs, decay_weight_),
@@ -1170,7 +1191,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SynchronizeModelArgs));
-  InitializeModelArgs_descriptor_ = file->message_type(47);
+  InitializeModelArgs_descriptor_ = file->message_type(48);
   static const int InitializeModelArgs_offsets_[8] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, model_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, dictionary_name_),
@@ -1214,7 +1235,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InitializeModelArgs_Filter));
   InitializeModelArgs_SourceType_descriptor_ = InitializeModelArgs_descriptor_->enum_type(0);
-  GetTopicModelArgs_descriptor_ = file->message_type(48);
+  GetTopicModelArgs_descriptor_ = file->message_type(49);
   static const int GetTopicModelArgs_offsets_[8] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetTopicModelArgs, model_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetTopicModelArgs, topic_name_),
@@ -1238,7 +1259,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       sizeof(GetTopicModelArgs));
   GetTopicModelArgs_RequestType_descriptor_ = GetTopicModelArgs_descriptor_->enum_type(0);
   GetTopicModelArgs_MatrixLayout_descriptor_ = GetTopicModelArgs_descriptor_->enum_type(1);
-  GetThetaMatrixArgs_descriptor_ = file->message_type(49);
+  GetThetaMatrixArgs_descriptor_ = file->message_type(50);
   static const int GetThetaMatrixArgs_offsets_[8] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetThetaMatrixArgs, model_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetThetaMatrixArgs, batch_),
@@ -1261,7 +1282,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GetThetaMatrixArgs));
   GetThetaMatrixArgs_MatrixLayout_descriptor_ = GetThetaMatrixArgs_descriptor_->enum_type(0);
-  GetScoreValueArgs_descriptor_ = file->message_type(50);
+  GetScoreValueArgs_descriptor_ = file->message_type(51);
   static const int GetScoreValueArgs_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetScoreValueArgs, model_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetScoreValueArgs, score_name_),
@@ -1278,7 +1299,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GetScoreValueArgs));
-  AddBatchArgs_descriptor_ = file->message_type(51);
+  AddBatchArgs_descriptor_ = file->message_type(52);
   static const int AddBatchArgs_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AddBatchArgs, batch_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AddBatchArgs, timeout_milliseconds_),
@@ -1296,7 +1317,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(AddBatchArgs));
-  InvokeIterationArgs_descriptor_ = file->message_type(52);
+  InvokeIterationArgs_descriptor_ = file->message_type(53);
   static const int InvokeIterationArgs_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InvokeIterationArgs, iterations_count_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InvokeIterationArgs, reset_scores_),
@@ -1313,7 +1334,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InvokeIterationArgs));
-  WaitIdleArgs_descriptor_ = file->message_type(53);
+  WaitIdleArgs_descriptor_ = file->message_type(54);
   static const int WaitIdleArgs_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(WaitIdleArgs, timeout_milliseconds_),
   };
@@ -1328,7 +1349,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(WaitIdleArgs));
-  ExportModelArgs_descriptor_ = file->message_type(54);
+  ExportModelArgs_descriptor_ = file->message_type(55);
   static const int ExportModelArgs_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ExportModelArgs, file_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ExportModelArgs, model_name_),
@@ -1344,7 +1365,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ExportModelArgs));
-  ImportModelArgs_descriptor_ = file->message_type(55);
+  ImportModelArgs_descriptor_ = file->message_type(56);
   static const int ImportModelArgs_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportModelArgs, file_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportModelArgs, model_name_),
@@ -1360,7 +1381,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ImportModelArgs));
-  AttachModelArgs_descriptor_ = file->message_type(56);
+  AttachModelArgs_descriptor_ = file->message_type(57);
   static const int AttachModelArgs_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AttachModelArgs, model_name_),
   };
@@ -1375,8 +1396,8 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(AttachModelArgs));
-  ProcessBatchesArgs_descriptor_ = file->message_type(57);
-  static const int ProcessBatchesArgs_offsets_[16] = {
+  ProcessBatchesArgs_descriptor_ = file->message_type(58);
+  static const int ProcessBatchesArgs_offsets_[15] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesArgs, nwt_target_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesArgs, batch_filename_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesArgs, pwt_source_name_),
@@ -1392,7 +1413,6 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesArgs, reset_scores_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesArgs, theta_matrix_type_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesArgs, batch_weight_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesArgs, use_ptdw_matrix_),
   };
   ProcessBatchesArgs_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -1406,7 +1426,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ProcessBatchesArgs));
   ProcessBatchesArgs_ThetaMatrixType_descriptor_ = ProcessBatchesArgs_descriptor_->enum_type(0);
-  ProcessBatchesResult_descriptor_ = file->message_type(58);
+  ProcessBatchesResult_descriptor_ = file->message_type(59);
   static const int ProcessBatchesResult_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesResult, score_data_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesResult, theta_matrix_),
@@ -1422,7 +1442,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ProcessBatchesResult));
-  MergeModelArgs_descriptor_ = file->message_type(59);
+  MergeModelArgs_descriptor_ = file->message_type(60);
   static const int MergeModelArgs_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeModelArgs, nwt_target_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeModelArgs, nwt_source_name_),
@@ -1440,7 +1460,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(MergeModelArgs));
-  RegularizeModelArgs_descriptor_ = file->message_type(60);
+  RegularizeModelArgs_descriptor_ = file->message_type(61);
   static const int RegularizeModelArgs_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RegularizeModelArgs, rwt_target_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RegularizeModelArgs, pwt_source_name_),
@@ -1458,7 +1478,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RegularizeModelArgs));
-  NormalizeModelArgs_descriptor_ = file->message_type(61);
+  NormalizeModelArgs_descriptor_ = file->message_type(62);
   static const int NormalizeModelArgs_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NormalizeModelArgs, pwt_target_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NormalizeModelArgs, nwt_source_name_),
@@ -1475,7 +1495,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(NormalizeModelArgs));
-  ImportDictionaryArgs_descriptor_ = file->message_type(62);
+  ImportDictionaryArgs_descriptor_ = file->message_type(63);
   static const int ImportDictionaryArgs_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportDictionaryArgs, file_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportDictionaryArgs, dictionary_name_),
@@ -1491,7 +1511,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ImportDictionaryArgs));
-  CopyRequestResultArgs_descriptor_ = file->message_type(63);
+  CopyRequestResultArgs_descriptor_ = file->message_type(64);
   static const int CopyRequestResultArgs_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CopyRequestResultArgs, request_type_),
   };
@@ -1507,7 +1527,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(CopyRequestResultArgs));
   CopyRequestResultArgs_RequestType_descriptor_ = CopyRequestResultArgs_descriptor_->enum_type(0);
-  DuplicateMasterComponentArgs_descriptor_ = file->message_type(64);
+  DuplicateMasterComponentArgs_descriptor_ = file->message_type(65);
   static const int DuplicateMasterComponentArgs_offsets_[1] = {
   };
   DuplicateMasterComponentArgs_reflection_ =
@@ -1521,7 +1541,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(DuplicateMasterComponentArgs));
-  GetMasterComponentInfoArgs_descriptor_ = file->message_type(65);
+  GetMasterComponentInfoArgs_descriptor_ = file->message_type(66);
   static const int GetMasterComponentInfoArgs_offsets_[1] = {
   };
   GetMasterComponentInfoArgs_reflection_ =
@@ -1535,7 +1555,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GetMasterComponentInfoArgs));
-  MasterComponentInfo_descriptor_ = file->message_type(66);
+  MasterComponentInfo_descriptor_ = file->message_type(67);
   static const int MasterComponentInfo_offsets_[10] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, master_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, config_),
@@ -1658,7 +1678,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(MasterComponentInfo_CacheEntryInfo));
-  ImportBatchesArgs_descriptor_ = file->message_type(67);
+  ImportBatchesArgs_descriptor_ = file->message_type(68);
   static const int ImportBatchesArgs_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportBatchesArgs, batch_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportBatchesArgs, batch_),
@@ -1674,7 +1694,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ImportBatchesArgs));
-  DisposeBatchesArgs_descriptor_ = file->message_type(68);
+  DisposeBatchesArgs_descriptor_ = file->message_type(69);
   static const int DisposeBatchesArgs_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DisposeBatchesArgs, batch_name_),
   };
@@ -1741,6 +1761,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
     SpecifiedSparsePhiConfig_descriptor_, &SpecifiedSparsePhiConfig::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     ImproveCoherencePhiConfig_descriptor_, &ImproveCoherencePhiConfig::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    SmoothPtdwConfig_descriptor_, &SmoothPtdwConfig::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     RegularizerInternalState_descriptor_, &RegularizerInternalState::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
@@ -1906,6 +1928,8 @@ void protobuf_ShutdownFile_artm_2fmessages_2eproto() {
   delete SpecifiedSparsePhiConfig::_default_class_id_;
   delete ImproveCoherencePhiConfig::default_instance_;
   delete ImproveCoherencePhiConfig_reflection_;
+  delete SmoothPtdwConfig::default_instance_;
+  delete SmoothPtdwConfig_reflection_;
   delete RegularizerInternalState::default_instance_;
   delete RegularizerInternalState_reflection_;
   delete MultiLanguagePhiInternalState::default_instance_;
@@ -2074,7 +2098,7 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
     "ng\030\r \001(\010:\005false\022\027\n\017disk_cache_path\030\017 \001(\t"
     "\"d\n\023RegularizerSettings\022\014\n\004name\030\001 \001(\t\022\013\n"
     "\003tau\030\002 \001(\001\022#\n\033use_relative_regularizatio"
-    "n\030\003 \001(\010\022\r\n\005gamma\030\004 \001(\001\"\241\004\n\013ModelConfig\022\024"
+    "n\030\003 \001(\010\022\r\n\005gamma\030\004 \001(\001\"\201\004\n\013ModelConfig\022\024"
     "\n\004name\030\001 \001(\t:\006@model\022\030\n\014topics_count\030\002 \001"
     "(\005:\00232\022\022\n\ntopic_name\030\003 \003(\t\022\025\n\007enabled\030\004 "
     "\001(\010:\004true\022\"\n\026inner_iterations_count\030\005 \001("
@@ -2087,251 +2111,254 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
     "andom_theta\030\017 \001(\010:\005false\022\034\n\016use_new_toke"
     "ns\030\020 \001(\010:\004true\022\031\n\013opt_for_avx\030\021 \001(\010:\004tru"
     "e\0227\n\024regularizer_settings\030\022 \003(\0132\031.artm.R"
-    "egularizerSettings\022\036\n\017use_ptdw_matrix\030\023 "
-    "\001(\010:\005false\"\212\002\n\021RegularizerConfig\022\014\n\004name"
-    "\030\001 \001(\t\022*\n\004type\030\002 \001(\0162\034.artm.RegularizerC"
-    "onfig.Type\022\016\n\006config\030\003 \001(\014\"\252\001\n\004Type\022\025\n\021S"
-    "moothSparseTheta\020\000\022\023\n\017SmoothSparsePhi\020\001\022"
-    "\023\n\017DecorrelatorPhi\020\002\022\024\n\020MultiLanguagePhi"
-    "\020\003\022\032\n\026LabelRegularizationPhi\020\004\022\026\n\022Specif"
-    "iedSparsePhi\020\005\022\027\n\023ImproveCoherencePhi\020\006\""
-    "A\n\027SmoothSparseThetaConfig\022\022\n\ntopic_name"
-    "\030\001 \003(\t\022\022\n\nalpha_iter\030\002 \003(\002\"V\n\025SmoothSpar"
-    "sePhiConfig\022\022\n\ntopic_name\030\001 \003(\t\022\020\n\010class"
-    "_id\030\002 \003(\t\022\027\n\017dictionary_name\030\003 \001(\t\"=\n\025De"
-    "correlatorPhiConfig\022\022\n\ntopic_name\030\001 \003(\t\022"
-    "\020\n\010class_id\030\002 \003(\t\"\030\n\026MultiLanguagePhiCon"
-    "fig\"]\n\034LabelRegularizationPhiConfig\022\022\n\nt"
+    "egularizerSettings\"\232\002\n\021RegularizerConfig"
+    "\022\014\n\004name\030\001 \001(\t\022*\n\004type\030\002 \001(\0162\034.artm.Regu"
+    "larizerConfig.Type\022\016\n\006config\030\003 \001(\014\"\272\001\n\004T"
+    "ype\022\025\n\021SmoothSparseTheta\020\000\022\023\n\017SmoothSpar"
+    "sePhi\020\001\022\023\n\017DecorrelatorPhi\020\002\022\024\n\020MultiLan"
+    "guagePhi\020\003\022\032\n\026LabelRegularizationPhi\020\004\022\026"
+    "\n\022SpecifiedSparsePhi\020\005\022\027\n\023ImproveCoheren"
+    "cePhi\020\006\022\016\n\nSmoothPtdw\020\007\"A\n\027SmoothSparseT"
+    "hetaConfig\022\022\n\ntopic_name\030\001 \003(\t\022\022\n\nalpha_"
+    "iter\030\002 \003(\002\"V\n\025SmoothSparsePhiConfig\022\022\n\nt"
     "opic_name\030\001 \003(\t\022\020\n\010class_id\030\002 \003(\t\022\027\n\017dic"
-    "tionary_name\030\003 \001(\t\"\202\002\n\030SpecifiedSparsePh"
-    "iConfig\022\022\n\ntopic_name\030\001 \003(\t\022 \n\010class_id\030"
-    "\002 \001(\t:\016@default_class\022\036\n\022max_elements_co"
-    "unt\030\003 \001(\005:\00220\022#\n\025probability_threshold\030\004"
-    " \001(\002:\0040.99\022\?\n\004mode\030\005 \001(\0162#.artm.Specifie"
-    "dSparsePhiConfig.Mode:\014SparseTopics\"*\n\004M"
-    "ode\022\020\n\014SparseTopics\020\000\022\020\n\014SparseTokens\020\001\""
-    "Z\n\031ImproveCoherencePhiConfig\022\022\n\ntopic_na"
-    "me\030\001 \003(\t\022\020\n\010class_id\030\002 \003(\t\022\027\n\017dictionary"
-    "_name\030\003 \001(\t\"\207\001\n\030RegularizerInternalState"
-    "\022\014\n\004name\030\001 \001(\t\0221\n\004type\030\002 \001(\0162#.artm.Regu"
-    "larizerInternalState.Type\022\014\n\004data\030\003 \001(\014\""
-    "\034\n\004Type\022\024\n\020MultiLanguagePhi\020\003\"C\n\035MultiLa"
-    "nguagePhiInternalState\022\"\n\027no_regularizat"
-    "ion_calls\030\001 \001(\005:\0010\"\321\001\n\020DictionaryConfig\022"
-    "\014\n\004name\030\001 \001(\t\022$\n\005entry\030\002 \003(\0132\025.artm.Dict"
-    "ionaryEntry\022\031\n\021total_token_count\030\003 \001(\005\022\031"
-    "\n\021total_items_count\030\004 \001(\005\0227\n\014cooc_entrie"
-    "s\030\005 \001(\0132!.artm.DictionaryCoocurenceEntri"
-    "es\022\032\n\022total_token_weight\030\006 \001(\002\"\275\001\n\017Dicti"
-    "onaryEntry\022\021\n\tkey_token\030\001 \001(\t\022\020\n\010class_i"
-    "d\030\002 \001(\t\022\r\n\005value\030\003 \001(\002\022\024\n\014value_tokens\030\004"
-    " \003(\t\022 \n\006values\030\005 \001(\0132\020.artm.FloatArray\022\023"
-    "\n\013token_count\030\006 \001(\005\022\023\n\013items_count\030\007 \001(\005"
-    "\022\024\n\014token_weight\030\010 \001(\002\"}\n\033DictionaryCooc"
-    "urenceEntries\022\023\n\013first_index\030\001 \003(\005\022\024\n\014se"
-    "cond_index\030\002 \003(\005\022\r\n\005value\030\003 \003(\002\022$\n\025symme"
-    "tric_cooc_values\030\004 \001(\010:\005false\"\346\001\n\013ScoreC"
-    "onfig\022\014\n\004name\030\001 \001(\t\022$\n\004type\030\002 \001(\0162\026.artm"
-    ".ScoreConfig.Type\022\016\n\006config\030\003 \001(\014\"\222\001\n\004Ty"
-    "pe\022\016\n\nPerplexity\020\000\022\021\n\rSparsityTheta\020\001\022\017\n"
-    "\013SparsityPhi\020\002\022\022\n\016ItemsProcessed\020\003\022\r\n\tTo"
-    "pTokens\020\004\022\020\n\014ThetaSnippet\020\005\022\017\n\013TopicKern"
-    "el\020\006\022\020\n\014TopicMassPhi\020\007\"\340\001\n\tScoreData\022\014\n\004"
-    "name\030\001 \001(\t\022\"\n\004type\030\002 \001(\0162\024.artm.ScoreDat"
-    "a.Type\022\014\n\004data\030\003 \001(\014\"\222\001\n\004Type\022\016\n\nPerplex"
-    "ity\020\000\022\021\n\rSparsityTheta\020\001\022\017\n\013SparsityPhi\020"
-    "\002\022\022\n\016ItemsProcessed\020\003\022\r\n\tTopTokens\020\004\022\020\n\014"
-    "ThetaSnippet\020\005\022\017\n\013TopicKernel\020\006\022\020\n\014Topic"
-    "MassPhi\020\007\"\314\002\n\025PerplexityScoreConfig\022\031\n\nf"
-    "ield_name\030\001 \001(\t:\005@body\022\034\n\013stream_name\030\002 "
-    "\001(\t:\007@global\022J\n\nmodel_type\030\003 \001(\0162 .artm."
-    "PerplexityScoreConfig.Type:\024UnigramDocum"
-    "entModel\022\027\n\017dictionary_name\030\004 \001(\t\022\"\n\022the"
-    "ta_sparsity_eps\030\005 \001(\002:\0061e-037\022!\n\031theta_s"
-    "parsity_topic_name\030\006 \003(\t\022\020\n\010class_id\030\007 \003"
-    "(\t\"<\n\004Type\022\030\n\024UnigramDocumentModel\020\000\022\032\n\026"
-    "UnigramCollectionModel\020\001\"\274\001\n\017PerplexityS"
-    "core\022\r\n\005value\030\001 \001(\001\022\013\n\003raw\030\002 \001(\001\022\022\n\nnorm"
-    "alizer\030\003 \001(\001\022\022\n\nzero_words\030\004 \001(\005\022\034\n\024thet"
-    "a_sparsity_value\030\005 \001(\001\022\"\n\032theta_sparsity"
-    "_zero_topics\030\006 \001(\005\022#\n\033theta_sparsity_tot"
-    "al_topics\030\007 \001(\005\"|\n\030SparsityThetaScoreCon"
-    "fig\022\031\n\nfield_name\030\001 \001(\t:\005@body\022\034\n\013stream"
-    "_name\030\002 \001(\t:\007@global\022\023\n\003eps\030\003 \001(\002:\0061e-03"
-    "7\022\022\n\ntopic_name\030\004 \003(\t\"N\n\022SparsityThetaSc"
-    "ore\022\r\n\005value\030\001 \001(\001\022\023\n\013zero_topics\030\002 \001(\005\022"
-    "\024\n\014total_topics\030\003 \001(\005\"c\n\026SparsityPhiScor"
-    "eConfig\022\023\n\003eps\030\001 \001(\002:\0061e-037\022 \n\010class_id"
-    "\030\002 \001(\t:\016@default_class\022\022\n\ntopic_name\030\003 \003"
-    "(\t\"L\n\020SparsityPhiScore\022\r\n\005value\030\001 \001(\001\022\023\n"
-    "\013zero_tokens\030\002 \001(\005\022\024\n\014total_tokens\030\003 \001(\005"
-    "\"T\n\031ItemsProcessedScoreConfig\022\031\n\nfield_n"
-    "ame\030\001 \001(\t:\005@body\022\034\n\013stream_name\030\002 \001(\t:\007@"
-    "global\"$\n\023ItemsProcessedScore\022\r\n\005value\030\001"
-    " \001(\005\"\212\001\n\024TopTokensScoreConfig\022\026\n\nnum_tok"
-    "ens\030\001 \001(\005:\00210\022 \n\010class_id\030\002 \001(\t:\016@defaul"
-    "t_class\022\022\n\ntopic_name\030\003 \003(\t\022$\n\034cooccurre"
-    "nce_dictionary_name\030\004 \001(\t\"\255\001\n\016TopTokensS"
-    "core\022\023\n\013num_entries\030\001 \001(\005\022\022\n\ntopic_name\030"
-    "\002 \003(\t\022\023\n\013topic_index\030\003 \003(\005\022\r\n\005token\030\004 \003("
-    "\t\022\016\n\006weight\030\005 \003(\002\022#\n\tcoherence\030\006 \001(\0132\020.a"
-    "rtm.FloatArray\022\031\n\021average_coherence\030\007 \001("
-    "\002\"\177\n\027ThetaSnippetScoreConfig\022\031\n\nfield_na"
-    "me\030\001 \001(\t:\005@body\022\034\n\013stream_name\030\002 \001(\t:\007@g"
-    "lobal\022\023\n\007item_id\030\003 \003(\005B\002\020\001\022\026\n\nitem_count"
-    "\030\004 \001(\005:\00210\"F\n\021ThetaSnippetScore\022\017\n\007item_"
-    "id\030\001 \003(\005\022 \n\006values\030\002 \003(\0132\020.artm.FloatArr"
-    "ay\"\262\001\n\026TopicKernelScoreConfig\022\023\n\003eps\030\001 \001"
-    "(\002:\0061e-037\022 \n\010class_id\030\002 \001(\t:\016@default_c"
-    "lass\022\022\n\ntopic_name\030\003 \003(\t\022\'\n\032probability_"
-    "mass_threshold\030\004 \001(\001:\0030.1\022$\n\034cooccurrenc"
-    "e_dictionary_name\030\005 \001(\t\"\377\002\n\020TopicKernelS"
-    "core\022&\n\013kernel_size\030\001 \001(\0132\021.artm.DoubleA"
-    "rray\022(\n\rkernel_purity\030\002 \001(\0132\021.artm.Doubl"
-    "eArray\022*\n\017kernel_contrast\030\003 \001(\0132\021.artm.D"
-    "oubleArray\022\033\n\023average_kernel_size\030\004 \001(\001\022"
-    "\035\n\025average_kernel_purity\030\005 \001(\001\022\037\n\027averag"
-    "e_kernel_contrast\030\006 \001(\001\022$\n\tcoherence\030\007 \001"
-    "(\0132\021.artm.DoubleArray\022\031\n\021average_coheren"
-    "ce\030\010 \001(\002\022(\n\rkernel_tokens\030\t \003(\0132\021.artm.S"
-    "tringArray\022%\n\ntopic_name\030\n \001(\0132\021.artm.St"
-    "ringArray\"d\n\027TopicMassPhiScoreConfig\022\023\n\003"
-    "eps\030\001 \001(\002:\0061e-037\022 \n\010class_id\030\002 \001(\t:\016@de"
-    "fault_class\022\022\n\ntopic_name\030\003 \003(\t\"_\n\021Topic"
-    "MassPhiScore\022\r\n\005value\030\001 \001(\001\022\022\n\ntopic_nam"
-    "e\030\002 \003(\t\022\023\n\013topic_ratio\030\003 \003(\001\022\022\n\ntopic_ma"
-    "ss\030\004 \003(\001\"\224\003\n\nTopicModel\022\024\n\004name\030\001 \001(\t:\006@"
-    "model\022\024\n\014topics_count\030\002 \001(\005\022\022\n\ntopic_nam"
-    "e\030\003 \003(\t\022\r\n\005token\030\004 \003(\t\022\'\n\rtoken_weights\030"
-    "\005 \003(\0132\020.artm.FloatArray\022\020\n\010class_id\030\006 \003("
-    "\t\022\021\n\tinternals\030\007 \001(\014\022#\n\013topic_index\030\010 \003("
-    "\0132\016.artm.IntArray\0226\n\016operation_type\030\t \003("
-    "\0162\036.artm.TopicModel.OperationType\0325\n\023Top"
-    "icModelInternals\022\036\n\004n_wt\030\001 \003(\0132\020.artm.Fl"
-    "oatArray\"U\n\rOperationType\022\016\n\nInitialize\020"
-    "\000\022\r\n\tIncrement\020\001\022\r\n\tOverwrite\020\002\022\n\n\006Remov"
-    "e\020\003\022\n\n\006Ignore\020\004\"\305\001\n\013ThetaMatrix\022\032\n\nmodel"
-    "_name\030\001 \001(\t:\006@model\022\017\n\007item_id\030\002 \003(\005\022&\n\014"
-    "item_weights\030\003 \003(\0132\020.artm.FloatArray\022\022\n\n"
-    "topic_name\030\004 \003(\t\022\024\n\014topics_count\030\005 \001(\005\022\022"
-    "\n\nitem_title\030\006 \003(\t\022#\n\013topic_index\030\007 \003(\0132"
-    "\016.artm.IntArray\"\343\003\n\026CollectionParserConf"
-    "ig\022B\n\006format\030\001 \001(\0162#.artm.CollectionPars"
-    "erConfig.Format:\rBagOfWordsUci\022\031\n\021docwor"
-    "d_file_path\030\002 \001(\t\022\027\n\017vocab_file_path\030\003 \001"
-    "(\t\022\025\n\rtarget_folder\030\004 \001(\t\022\034\n\024dictionary_"
-    "file_name\030\005 \001(\t\022!\n\023num_items_per_batch\030\006"
-    " \001(\005:\0041000\022\032\n\022cooccurrence_token\030\007 \003(\t\022%"
-    "\n\027use_unity_based_indices\030\010 \001(\010:\004true\022\032\n"
-    "\013gather_cooc\030\t \001(\010:\005false\022\035\n\025cooccurrenc"
-    "e_class_id\030\n \003(\t\022(\n\031use_symmetric_cooc_v"
-    "alues\030\013 \001(\010:\005false\"Q\n\006Format\022\021\n\rBagOfWor"
-    "dsUci\020\000\022\020\n\014MatrixMarket\020\001\022\020\n\014VowpalWabbi"
-    "t\020\002\022\020\n\014Cooccurrence\020\003\"\177\n\024SynchronizeMode"
-    "lArgs\022\022\n\nmodel_name\030\001 \001(\t\022\027\n\014decay_weigh"
-    "t\030\002 \001(\002:\0010\022!\n\023invoke_regularizers\030\003 \001(\010:"
-    "\004true\022\027\n\014apply_weight\030\004 \001(\002:\0011\"\343\003\n\023Initi"
-    "alizeModelArgs\022\022\n\nmodel_name\030\001 \001(\t\022\027\n\017di"
-    "ctionary_name\030\002 \001(\t\022E\n\013source_type\030\003 \001(\016"
-    "2$.artm.InitializeModelArgs.SourceType:\n"
-    "Dictionary\022\021\n\tdisk_path\030\004 \001(\t\0220\n\006filter\030"
-    "\005 \003(\0132 .artm.InitializeModelArgs.Filter\022"
-    "\024\n\014topics_count\030\006 \001(\005\022\022\n\ntopic_name\030\007 \003("
-    "\t\022\026\n\016batch_filename\030\010 \003(\t\032\245\001\n\006Filter\022\020\n\010"
-    "class_id\030\001 \001(\t\022\026\n\016min_percentage\030\002 \001(\002\022\026"
-    "\n\016max_percentage\030\003 \001(\002\022\021\n\tmin_items\030\004 \001("
-    "\005\022\021\n\tmax_items\030\005 \001(\005\022\027\n\017min_total_count\030"
-    "\006 \001(\005\022\032\n\022min_one_item_count\030\007 \001(\005\")\n\nSou"
-    "rceType\022\016\n\nDictionary\020\000\022\013\n\007Batches\020\001\"\364\002\n"
-    "\021GetTopicModelArgs\022\022\n\nmodel_name\030\001 \001(\t\022\022"
-    "\n\ntopic_name\030\002 \003(\t\022\r\n\005token\030\003 \003(\t\022\020\n\010cla"
-    "ss_id\030\004 \003(\t\022\031\n\021use_sparse_format\030\005 \001(\010\022\023"
-    "\n\003eps\030\006 \001(\002:\0061e-037\022>\n\014request_type\030\007 \001("
-    "\0162#.artm.GetTopicModelArgs.RequestType:\003"
-    "Pwt\022B\n\rmatrix_layout\030\010 \001(\0162$.artm.GetTop"
-    "icModelArgs.MatrixLayout:\005Dense\";\n\013Reque"
-    "stType\022\007\n\003Pwt\020\000\022\007\n\003Nwt\020\001\022\016\n\nTopicNames\020\002"
-    "\022\n\n\006Tokens\020\003\"%\n\014MatrixLayout\022\t\n\005Dense\020\000\022"
-    "\n\n\006Sparse\020\001\"\245\002\n\022GetThetaMatrixArgs\022\022\n\nmo"
-    "del_name\030\001 \001(\t\022\032\n\005batch\030\002 \001(\0132\013.artm.Bat"
-    "ch\022\022\n\ntopic_name\030\003 \003(\t\022\023\n\013topic_index\030\004 "
-    "\003(\005\022\032\n\013clean_cache\030\005 \001(\010:\005false\022\031\n\021use_s"
-    "parse_format\030\006 \001(\010\022\023\n\003eps\030\007 \001(\002:\0061e-037\022"
-    "C\n\rmatrix_layout\030\010 \001(\0162%.artm.GetThetaMa"
-    "trixArgs.MatrixLayout:\005Dense\"%\n\014MatrixLa"
-    "yout\022\t\n\005Dense\020\000\022\n\n\006Sparse\020\001\"W\n\021GetScoreV"
-    "alueArgs\022\022\n\nmodel_name\030\001 \001(\t\022\022\n\nscore_na"
-    "me\030\002 \001(\t\022\032\n\005batch\030\003 \001(\0132\013.artm.Batch\"\202\001\n"
-    "\014AddBatchArgs\022\032\n\005batch\030\001 \001(\0132\013.artm.Batc"
-    "h\022 \n\024timeout_milliseconds\030\002 \001(\005:\002-1\022\033\n\014r"
-    "eset_scores\030\003 \001(\010:\005false\022\027\n\017batch_file_n"
-    "ame\030\004 \001(\t\"a\n\023InvokeIterationArgs\022\033\n\020iter"
-    "ations_count\030\001 \001(\005:\0011\022\032\n\014reset_scores\030\002 "
-    "\001(\010:\004true\022\021\n\tdisk_path\030\003 \001(\t\"0\n\014WaitIdle"
-    "Args\022 \n\024timeout_milliseconds\030\001 \001(\005:\002-1\"8"
-    "\n\017ExportModelArgs\022\021\n\tfile_name\030\001 \001(\t\022\022\n\n"
-    "model_name\030\002 \001(\t\"8\n\017ImportModelArgs\022\021\n\tf"
-    "ile_name\030\001 \001(\t\022\022\n\nmodel_name\030\002 \001(\t\"%\n\017At"
-    "tachModelArgs\022\022\n\nmodel_name\030\001 \001(\t\"\314\004\n\022Pr"
-    "ocessBatchesArgs\022\027\n\017nwt_target_name\030\001 \001("
-    "\t\022\026\n\016batch_filename\030\002 \003(\t\022\027\n\017pwt_source_"
-    "name\030\003 \001(\t\022\"\n\026inner_iterations_count\030\004 \001"
-    "(\005:\00210\022\034\n\013stream_name\030\005 \001(\t:\007@global\022\030\n\020"
-    "regularizer_name\030\006 \003(\t\022\027\n\017regularizer_ta"
-    "u\030\007 \003(\001\022\020\n\010class_id\030\010 \003(\t\022\024\n\014class_weigh"
-    "t\030\t \003(\002\022\032\n\013reuse_theta\030\n \001(\010:\005false\022\031\n\013o"
-    "pt_for_avx\030\013 \001(\010:\004true\022\034\n\016use_sparse_bow"
-    "\030\014 \001(\010:\004true\022\032\n\014reset_scores\030\r \001(\010:\004true"
-    "\022J\n\021theta_matrix_type\030\016 \001(\0162(.artm.Proce"
-    "ssBatchesArgs.ThetaMatrixType:\005Cache\022\024\n\014"
-    "batch_weight\030\017 \003(\002\022\036\n\017use_ptdw_matrix\030\020 "
-    "\001(\010:\005false\"\\\n\017ThetaMatrixType\022\010\n\004None\020\000\022"
-    "\t\n\005Dense\020\001\022\n\n\006Sparse\020\002\022\t\n\005Cache\020\003\022\r\n\tDen"
-    "sePtdw\020\004\022\016\n\nSparsePtdw\020\005\"d\n\024ProcessBatch"
-    "esResult\022#\n\nscore_data\030\001 \003(\0132\017.artm.Scor"
-    "eData\022\'\n\014theta_matrix\030\002 \001(\0132\021.artm.Theta"
-    "Matrix\"m\n\016MergeModelArgs\022\027\n\017nwt_target_n"
-    "ame\030\001 \001(\t\022\027\n\017nwt_source_name\030\002 \003(\t\022\025\n\rso"
-    "urce_weight\030\003 \003(\002\022\022\n\ntopic_name\030\004 \003(\t\"\231\001"
-    "\n\023RegularizeModelArgs\022\027\n\017rwt_target_name"
-    "\030\001 \001(\t\022\027\n\017pwt_source_name\030\002 \001(\t\022\027\n\017nwt_s"
-    "ource_name\030\003 \001(\t\0227\n\024regularizer_settings"
-    "\030\004 \003(\0132\031.artm.RegularizerSettings\"_\n\022Nor"
-    "malizeModelArgs\022\027\n\017pwt_target_name\030\001 \001(\t"
-    "\022\027\n\017nwt_source_name\030\002 \001(\t\022\027\n\017rwt_source_"
-    "name\030\003 \001(\t\"B\n\024ImportDictionaryArgs\022\021\n\tfi"
-    "le_name\030\001 \001(\t\022\027\n\017dictionary_name\030\002 \001(\t\"\301"
-    "\001\n\025CopyRequestResultArgs\022Q\n\014request_type"
-    "\030\001 \001(\0162\'.artm.CopyRequestResultArgs.Requ"
-    "estType:\022DefaultRequestType\"U\n\013RequestTy"
-    "pe\022\026\n\022DefaultRequestType\020\000\022\026\n\022GetThetaSe"
-    "condPass\020\001\022\026\n\022GetModelSecondPass\020\002\"\036\n\034Du"
-    "plicateMasterComponentArgs\"\034\n\032GetMasterC"
-    "omponentInfoArgs\"\301\006\n\023MasterComponentInfo"
-    "\022\021\n\tmaster_id\030\001 \001(\005\022+\n\006config\030\002 \001(\0132\033.ar"
-    "tm.MasterComponentConfig\022>\n\013regularizer\030"
-    "\003 \003(\0132).artm.MasterComponentInfo.Regular"
-    "izerInfo\0222\n\005score\030\004 \003(\0132#.artm.MasterCom"
-    "ponentInfo.ScoreInfo\022<\n\ndictionary\030\005 \003(\013"
-    "2(.artm.MasterComponentInfo.DictionaryIn"
-    "fo\0222\n\005model\030\006 \003(\0132#.artm.MasterComponent"
-    "Info.ModelInfo\022=\n\013cache_entry\030\007 \003(\0132(.ar"
-    "tm.MasterComponentInfo.CacheEntryInfo\022\031\n"
-    "\021merger_queue_size\030\010 \001(\005\022\034\n\024processor_qu"
-    "eue_size\030\t \001(\005\0222\n\005batch\030\n \003(\0132#.artm.Mas"
-    "terComponentInfo.BatchInfo\032-\n\017Regularize"
-    "rInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\032\'\n\tSco"
-    "reInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\0325\n\016Di"
-    "ctionaryInfo\022\014\n\004name\030\001 \001(\t\022\025\n\rentries_co"
-    "unt\030\002 \001(\003\032C\n\tBatchInfo\022\014\n\004name\030\001 \001(\t\022\023\n\013"
-    "items_count\030\002 \001(\005\022\023\n\013token_count\030\003 \001(\005\032R"
-    "\n\tModelInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022"
-    "\024\n\014topics_count\030\003 \001(\005\022\023\n\013token_count\030\004 \001"
-    "(\005\0320\n\016CacheEntryInfo\022\013\n\003key\030\001 \001(\t\022\021\n\tbyt"
-    "e_size\030\002 \001(\005\"C\n\021ImportBatchesArgs\022\022\n\nbat"
-    "ch_name\030\001 \003(\t\022\032\n\005batch\030\003 \003(\0132\013.artm.Batc"
-    "h\"(\n\022DisposeBatchesArgs\022\022\n\nbatch_name\030\001 "
-    "\003(\t", 11483);
+    "tionary_name\030\003 \001(\t\"=\n\025DecorrelatorPhiCon"
+    "fig\022\022\n\ntopic_name\030\001 \003(\t\022\020\n\010class_id\030\002 \003("
+    "\t\"\030\n\026MultiLanguagePhiConfig\"]\n\034LabelRegu"
+    "larizationPhiConfig\022\022\n\ntopic_name\030\001 \003(\t\022"
+    "\020\n\010class_id\030\002 \003(\t\022\027\n\017dictionary_name\030\003 \001"
+    "(\t\"\202\002\n\030SpecifiedSparsePhiConfig\022\022\n\ntopic"
+    "_name\030\001 \003(\t\022 \n\010class_id\030\002 \001(\t:\016@default_"
+    "class\022\036\n\022max_elements_count\030\003 \001(\005:\00220\022#\n"
+    "\025probability_threshold\030\004 \001(\002:\0040.99\022\?\n\004mo"
+    "de\030\005 \001(\0162#.artm.SpecifiedSparsePhiConfig"
+    ".Mode:\014SparseTopics\"*\n\004Mode\022\020\n\014SparseTop"
+    "ics\020\000\022\020\n\014SparseTokens\020\001\"Z\n\031ImproveCohere"
+    "ncePhiConfig\022\022\n\ntopic_name\030\001 \003(\t\022\020\n\010clas"
+    "s_id\030\002 \003(\t\022\027\n\017dictionary_name\030\003 \001(\t\"\244\001\n\020"
+    "SmoothPtdwConfig\0228\n\004type\030\001 \001(\0162\033.artm.Sm"
+    "oothPtdwConfig.Type:\rMovingAverage\022\022\n\006wi"
+    "ndow\030\003 \001(\005:\00210\022\024\n\tthreshold\030\004 \001(\001:\0011\",\n\004"
+    "Type\022\021\n\rMovingAverage\020\001\022\021\n\rMovingProduct"
+    "\020\002\"\207\001\n\030RegularizerInternalState\022\014\n\004name\030"
+    "\001 \001(\t\0221\n\004type\030\002 \001(\0162#.artm.RegularizerIn"
+    "ternalState.Type\022\014\n\004data\030\003 \001(\014\"\034\n\004Type\022\024"
+    "\n\020MultiLanguagePhi\020\003\"C\n\035MultiLanguagePhi"
+    "InternalState\022\"\n\027no_regularization_calls"
+    "\030\001 \001(\005:\0010\"\321\001\n\020DictionaryConfig\022\014\n\004name\030\001"
+    " \001(\t\022$\n\005entry\030\002 \003(\0132\025.artm.DictionaryEnt"
+    "ry\022\031\n\021total_token_count\030\003 \001(\005\022\031\n\021total_i"
+    "tems_count\030\004 \001(\005\0227\n\014cooc_entries\030\005 \001(\0132!"
+    ".artm.DictionaryCoocurenceEntries\022\032\n\022tot"
+    "al_token_weight\030\006 \001(\002\"\275\001\n\017DictionaryEntr"
+    "y\022\021\n\tkey_token\030\001 \001(\t\022\020\n\010class_id\030\002 \001(\t\022\r"
+    "\n\005value\030\003 \001(\002\022\024\n\014value_tokens\030\004 \003(\t\022 \n\006v"
+    "alues\030\005 \001(\0132\020.artm.FloatArray\022\023\n\013token_c"
+    "ount\030\006 \001(\005\022\023\n\013items_count\030\007 \001(\005\022\024\n\014token"
+    "_weight\030\010 \001(\002\"}\n\033DictionaryCoocurenceEnt"
+    "ries\022\023\n\013first_index\030\001 \003(\005\022\024\n\014second_inde"
+    "x\030\002 \003(\005\022\r\n\005value\030\003 \003(\002\022$\n\025symmetric_cooc"
+    "_values\030\004 \001(\010:\005false\"\346\001\n\013ScoreConfig\022\014\n\004"
+    "name\030\001 \001(\t\022$\n\004type\030\002 \001(\0162\026.artm.ScoreCon"
+    "fig.Type\022\016\n\006config\030\003 \001(\014\"\222\001\n\004Type\022\016\n\nPer"
+    "plexity\020\000\022\021\n\rSparsityTheta\020\001\022\017\n\013Sparsity"
+    "Phi\020\002\022\022\n\016ItemsProcessed\020\003\022\r\n\tTopTokens\020\004"
+    "\022\020\n\014ThetaSnippet\020\005\022\017\n\013TopicKernel\020\006\022\020\n\014T"
+    "opicMassPhi\020\007\"\340\001\n\tScoreData\022\014\n\004name\030\001 \001("
+    "\t\022\"\n\004type\030\002 \001(\0162\024.artm.ScoreData.Type\022\014\n"
+    "\004data\030\003 \001(\014\"\222\001\n\004Type\022\016\n\nPerplexity\020\000\022\021\n\r"
+    "SparsityTheta\020\001\022\017\n\013SparsityPhi\020\002\022\022\n\016Item"
+    "sProcessed\020\003\022\r\n\tTopTokens\020\004\022\020\n\014ThetaSnip"
+    "pet\020\005\022\017\n\013TopicKernel\020\006\022\020\n\014TopicMassPhi\020\007"
+    "\"\314\002\n\025PerplexityScoreConfig\022\031\n\nfield_name"
+    "\030\001 \001(\t:\005@body\022\034\n\013stream_name\030\002 \001(\t:\007@glo"
+    "bal\022J\n\nmodel_type\030\003 \001(\0162 .artm.Perplexit"
+    "yScoreConfig.Type:\024UnigramDocumentModel\022"
+    "\027\n\017dictionary_name\030\004 \001(\t\022\"\n\022theta_sparsi"
+    "ty_eps\030\005 \001(\002:\0061e-037\022!\n\031theta_sparsity_t"
+    "opic_name\030\006 \003(\t\022\020\n\010class_id\030\007 \003(\t\"<\n\004Typ"
+    "e\022\030\n\024UnigramDocumentModel\020\000\022\032\n\026UnigramCo"
+    "llectionModel\020\001\"\274\001\n\017PerplexityScore\022\r\n\005v"
+    "alue\030\001 \001(\001\022\013\n\003raw\030\002 \001(\001\022\022\n\nnormalizer\030\003 "
+    "\001(\001\022\022\n\nzero_words\030\004 \001(\005\022\034\n\024theta_sparsit"
+    "y_value\030\005 \001(\001\022\"\n\032theta_sparsity_zero_top"
+    "ics\030\006 \001(\005\022#\n\033theta_sparsity_total_topics"
+    "\030\007 \001(\005\"|\n\030SparsityThetaScoreConfig\022\031\n\nfi"
+    "eld_name\030\001 \001(\t:\005@body\022\034\n\013stream_name\030\002 \001"
+    "(\t:\007@global\022\023\n\003eps\030\003 \001(\002:\0061e-037\022\022\n\ntopi"
+    "c_name\030\004 \003(\t\"N\n\022SparsityThetaScore\022\r\n\005va"
+    "lue\030\001 \001(\001\022\023\n\013zero_topics\030\002 \001(\005\022\024\n\014total_"
+    "topics\030\003 \001(\005\"c\n\026SparsityPhiScoreConfig\022\023"
+    "\n\003eps\030\001 \001(\002:\0061e-037\022 \n\010class_id\030\002 \001(\t:\016@"
+    "default_class\022\022\n\ntopic_name\030\003 \003(\t\"L\n\020Spa"
+    "rsityPhiScore\022\r\n\005value\030\001 \001(\001\022\023\n\013zero_tok"
+    "ens\030\002 \001(\005\022\024\n\014total_tokens\030\003 \001(\005\"T\n\031Items"
+    "ProcessedScoreConfig\022\031\n\nfield_name\030\001 \001(\t"
+    ":\005@body\022\034\n\013stream_name\030\002 \001(\t:\007@global\"$\n"
+    "\023ItemsProcessedScore\022\r\n\005value\030\001 \001(\005\"\212\001\n\024"
+    "TopTokensScoreConfig\022\026\n\nnum_tokens\030\001 \001(\005"
+    ":\00210\022 \n\010class_id\030\002 \001(\t:\016@default_class\022\022"
+    "\n\ntopic_name\030\003 \003(\t\022$\n\034cooccurrence_dicti"
+    "onary_name\030\004 \001(\t\"\255\001\n\016TopTokensScore\022\023\n\013n"
+    "um_entries\030\001 \001(\005\022\022\n\ntopic_name\030\002 \003(\t\022\023\n\013"
+    "topic_index\030\003 \003(\005\022\r\n\005token\030\004 \003(\t\022\016\n\006weig"
+    "ht\030\005 \003(\002\022#\n\tcoherence\030\006 \001(\0132\020.artm.Float"
+    "Array\022\031\n\021average_coherence\030\007 \001(\002\"\177\n\027Thet"
+    "aSnippetScoreConfig\022\031\n\nfield_name\030\001 \001(\t:"
+    "\005@body\022\034\n\013stream_name\030\002 \001(\t:\007@global\022\023\n\007"
+    "item_id\030\003 \003(\005B\002\020\001\022\026\n\nitem_count\030\004 \001(\005:\0021"
+    "0\"F\n\021ThetaSnippetScore\022\017\n\007item_id\030\001 \003(\005\022"
+    " \n\006values\030\002 \003(\0132\020.artm.FloatArray\"\262\001\n\026To"
+    "picKernelScoreConfig\022\023\n\003eps\030\001 \001(\002:\0061e-03"
+    "7\022 \n\010class_id\030\002 \001(\t:\016@default_class\022\022\n\nt"
+    "opic_name\030\003 \003(\t\022\'\n\032probability_mass_thre"
+    "shold\030\004 \001(\001:\0030.1\022$\n\034cooccurrence_diction"
+    "ary_name\030\005 \001(\t\"\377\002\n\020TopicKernelScore\022&\n\013k"
+    "ernel_size\030\001 \001(\0132\021.artm.DoubleArray\022(\n\rk"
+    "ernel_purity\030\002 \001(\0132\021.artm.DoubleArray\022*\n"
+    "\017kernel_contrast\030\003 \001(\0132\021.artm.DoubleArra"
+    "y\022\033\n\023average_kernel_size\030\004 \001(\001\022\035\n\025averag"
+    "e_kernel_purity\030\005 \001(\001\022\037\n\027average_kernel_"
+    "contrast\030\006 \001(\001\022$\n\tcoherence\030\007 \001(\0132\021.artm"
+    ".DoubleArray\022\031\n\021average_coherence\030\010 \001(\002\022"
+    "(\n\rkernel_tokens\030\t \003(\0132\021.artm.StringArra"
+    "y\022%\n\ntopic_name\030\n \001(\0132\021.artm.StringArray"
+    "\"d\n\027TopicMassPhiScoreConfig\022\023\n\003eps\030\001 \001(\002"
+    ":\0061e-037\022 \n\010class_id\030\002 \001(\t:\016@default_cla"
+    "ss\022\022\n\ntopic_name\030\003 \003(\t\"_\n\021TopicMassPhiSc"
+    "ore\022\r\n\005value\030\001 \001(\001\022\022\n\ntopic_name\030\002 \003(\t\022\023"
+    "\n\013topic_ratio\030\003 \003(\001\022\022\n\ntopic_mass\030\004 \003(\001\""
+    "\224\003\n\nTopicModel\022\024\n\004name\030\001 \001(\t:\006@model\022\024\n\014"
+    "topics_count\030\002 \001(\005\022\022\n\ntopic_name\030\003 \003(\t\022\r"
+    "\n\005token\030\004 \003(\t\022\'\n\rtoken_weights\030\005 \003(\0132\020.a"
+    "rtm.FloatArray\022\020\n\010class_id\030\006 \003(\t\022\021\n\tinte"
+    "rnals\030\007 \001(\014\022#\n\013topic_index\030\010 \003(\0132\016.artm."
+    "IntArray\0226\n\016operation_type\030\t \003(\0162\036.artm."
+    "TopicModel.OperationType\0325\n\023TopicModelIn"
+    "ternals\022\036\n\004n_wt\030\001 \003(\0132\020.artm.FloatArray\""
+    "U\n\rOperationType\022\016\n\nInitialize\020\000\022\r\n\tIncr"
+    "ement\020\001\022\r\n\tOverwrite\020\002\022\n\n\006Remove\020\003\022\n\n\006Ig"
+    "nore\020\004\"\305\001\n\013ThetaMatrix\022\032\n\nmodel_name\030\001 \001"
+    "(\t:\006@model\022\017\n\007item_id\030\002 \003(\005\022&\n\014item_weig"
+    "hts\030\003 \003(\0132\020.artm.FloatArray\022\022\n\ntopic_nam"
+    "e\030\004 \003(\t\022\024\n\014topics_count\030\005 \001(\005\022\022\n\nitem_ti"
+    "tle\030\006 \003(\t\022#\n\013topic_index\030\007 \003(\0132\016.artm.In"
+    "tArray\"\343\003\n\026CollectionParserConfig\022B\n\006for"
+    "mat\030\001 \001(\0162#.artm.CollectionParserConfig."
+    "Format:\rBagOfWordsUci\022\031\n\021docword_file_pa"
+    "th\030\002 \001(\t\022\027\n\017vocab_file_path\030\003 \001(\t\022\025\n\rtar"
+    "get_folder\030\004 \001(\t\022\034\n\024dictionary_file_name"
+    "\030\005 \001(\t\022!\n\023num_items_per_batch\030\006 \001(\005:\004100"
+    "0\022\032\n\022cooccurrence_token\030\007 \003(\t\022%\n\027use_uni"
+    "ty_based_indices\030\010 \001(\010:\004true\022\032\n\013gather_c"
+    "ooc\030\t \001(\010:\005false\022\035\n\025cooccurrence_class_i"
+    "d\030\n \003(\t\022(\n\031use_symmetric_cooc_values\030\013 \001"
+    "(\010:\005false\"Q\n\006Format\022\021\n\rBagOfWordsUci\020\000\022\020"
+    "\n\014MatrixMarket\020\001\022\020\n\014VowpalWabbit\020\002\022\020\n\014Co"
+    "occurrence\020\003\"\177\n\024SynchronizeModelArgs\022\022\n\n"
+    "model_name\030\001 \001(\t\022\027\n\014decay_weight\030\002 \001(\002:\001"
+    "0\022!\n\023invoke_regularizers\030\003 \001(\010:\004true\022\027\n\014"
+    "apply_weight\030\004 \001(\002:\0011\"\343\003\n\023InitializeMode"
+    "lArgs\022\022\n\nmodel_name\030\001 \001(\t\022\027\n\017dictionary_"
+    "name\030\002 \001(\t\022E\n\013source_type\030\003 \001(\0162$.artm.I"
+    "nitializeModelArgs.SourceType:\nDictionar"
+    "y\022\021\n\tdisk_path\030\004 \001(\t\0220\n\006filter\030\005 \003(\0132 .a"
+    "rtm.InitializeModelArgs.Filter\022\024\n\014topics"
+    "_count\030\006 \001(\005\022\022\n\ntopic_name\030\007 \003(\t\022\026\n\016batc"
+    "h_filename\030\010 \003(\t\032\245\001\n\006Filter\022\020\n\010class_id\030"
+    "\001 \001(\t\022\026\n\016min_percentage\030\002 \001(\002\022\026\n\016max_per"
+    "centage\030\003 \001(\002\022\021\n\tmin_items\030\004 \001(\005\022\021\n\tmax_"
+    "items\030\005 \001(\005\022\027\n\017min_total_count\030\006 \001(\005\022\032\n\022"
+    "min_one_item_count\030\007 \001(\005\")\n\nSourceType\022\016"
+    "\n\nDictionary\020\000\022\013\n\007Batches\020\001\"\364\002\n\021GetTopic"
+    "ModelArgs\022\022\n\nmodel_name\030\001 \001(\t\022\022\n\ntopic_n"
+    "ame\030\002 \003(\t\022\r\n\005token\030\003 \003(\t\022\020\n\010class_id\030\004 \003"
+    "(\t\022\031\n\021use_sparse_format\030\005 \001(\010\022\023\n\003eps\030\006 \001"
+    "(\002:\0061e-037\022>\n\014request_type\030\007 \001(\0162#.artm."
+    "GetTopicModelArgs.RequestType:\003Pwt\022B\n\rma"
+    "trix_layout\030\010 \001(\0162$.artm.GetTopicModelAr"
+    "gs.MatrixLayout:\005Dense\";\n\013RequestType\022\007\n"
+    "\003Pwt\020\000\022\007\n\003Nwt\020\001\022\016\n\nTopicNames\020\002\022\n\n\006Token"
+    "s\020\003\"%\n\014MatrixLayout\022\t\n\005Dense\020\000\022\n\n\006Sparse"
+    "\020\001\"\245\002\n\022GetThetaMatrixArgs\022\022\n\nmodel_name\030"
+    "\001 \001(\t\022\032\n\005batch\030\002 \001(\0132\013.artm.Batch\022\022\n\ntop"
+    "ic_name\030\003 \003(\t\022\023\n\013topic_index\030\004 \003(\005\022\032\n\013cl"
+    "ean_cache\030\005 \001(\010:\005false\022\031\n\021use_sparse_for"
+    "mat\030\006 \001(\010\022\023\n\003eps\030\007 \001(\002:\0061e-037\022C\n\rmatrix"
+    "_layout\030\010 \001(\0162%.artm.GetThetaMatrixArgs."
+    "MatrixLayout:\005Dense\"%\n\014MatrixLayout\022\t\n\005D"
+    "ense\020\000\022\n\n\006Sparse\020\001\"W\n\021GetScoreValueArgs\022"
+    "\022\n\nmodel_name\030\001 \001(\t\022\022\n\nscore_name\030\002 \001(\t\022"
+    "\032\n\005batch\030\003 \001(\0132\013.artm.Batch\"\202\001\n\014AddBatch"
+    "Args\022\032\n\005batch\030\001 \001(\0132\013.artm.Batch\022 \n\024time"
+    "out_milliseconds\030\002 \001(\005:\002-1\022\033\n\014reset_scor"
+    "es\030\003 \001(\010:\005false\022\027\n\017batch_file_name\030\004 \001(\t"
+    "\"a\n\023InvokeIterationArgs\022\033\n\020iterations_co"
+    "unt\030\001 \001(\005:\0011\022\032\n\014reset_scores\030\002 \001(\010:\004true"
+    "\022\021\n\tdisk_path\030\003 \001(\t\"0\n\014WaitIdleArgs\022 \n\024t"
+    "imeout_milliseconds\030\001 \001(\005:\002-1\"8\n\017ExportM"
+    "odelArgs\022\021\n\tfile_name\030\001 \001(\t\022\022\n\nmodel_nam"
+    "e\030\002 \001(\t\"8\n\017ImportModelArgs\022\021\n\tfile_name\030"
+    "\001 \001(\t\022\022\n\nmodel_name\030\002 \001(\t\"%\n\017AttachModel"
+    "Args\022\022\n\nmodel_name\030\001 \001(\t\"\254\004\n\022ProcessBatc"
+    "hesArgs\022\027\n\017nwt_target_name\030\001 \001(\t\022\026\n\016batc"
+    "h_filename\030\002 \003(\t\022\027\n\017pwt_source_name\030\003 \001("
+    "\t\022\"\n\026inner_iterations_count\030\004 \001(\005:\00210\022\034\n"
+    "\013stream_name\030\005 \001(\t:\007@global\022\030\n\020regulariz"
+    "er_name\030\006 \003(\t\022\027\n\017regularizer_tau\030\007 \003(\001\022\020"
+    "\n\010class_id\030\010 \003(\t\022\024\n\014class_weight\030\t \003(\002\022\032"
+    "\n\013reuse_theta\030\n \001(\010:\005false\022\031\n\013opt_for_av"
+    "x\030\013 \001(\010:\004true\022\034\n\016use_sparse_bow\030\014 \001(\010:\004t"
+    "rue\022\032\n\014reset_scores\030\r \001(\010:\004true\022J\n\021theta"
+    "_matrix_type\030\016 \001(\0162(.artm.ProcessBatches"
+    "Args.ThetaMatrixType:\005Cache\022\024\n\014batch_wei"
+    "ght\030\017 \003(\002\"\\\n\017ThetaMatrixType\022\010\n\004None\020\000\022\t"
+    "\n\005Dense\020\001\022\n\n\006Sparse\020\002\022\t\n\005Cache\020\003\022\r\n\tDens"
+    "ePtdw\020\004\022\016\n\nSparsePtdw\020\005\"d\n\024ProcessBatche"
+    "sResult\022#\n\nscore_data\030\001 \003(\0132\017.artm.Score"
+    "Data\022\'\n\014theta_matrix\030\002 \001(\0132\021.artm.ThetaM"
+    "atrix\"m\n\016MergeModelArgs\022\027\n\017nwt_target_na"
+    "me\030\001 \001(\t\022\027\n\017nwt_source_name\030\002 \003(\t\022\025\n\rsou"
+    "rce_weight\030\003 \003(\002\022\022\n\ntopic_name\030\004 \003(\t\"\231\001\n"
+    "\023RegularizeModelArgs\022\027\n\017rwt_target_name\030"
+    "\001 \001(\t\022\027\n\017pwt_source_name\030\002 \001(\t\022\027\n\017nwt_so"
+    "urce_name\030\003 \001(\t\0227\n\024regularizer_settings\030"
+    "\004 \003(\0132\031.artm.RegularizerSettings\"_\n\022Norm"
+    "alizeModelArgs\022\027\n\017pwt_target_name\030\001 \001(\t\022"
+    "\027\n\017nwt_source_name\030\002 \001(\t\022\027\n\017rwt_source_n"
+    "ame\030\003 \001(\t\"B\n\024ImportDictionaryArgs\022\021\n\tfil"
+    "e_name\030\001 \001(\t\022\027\n\017dictionary_name\030\002 \001(\t\"\301\001"
+    "\n\025CopyRequestResultArgs\022Q\n\014request_type\030"
+    "\001 \001(\0162\'.artm.CopyRequestResultArgs.Reque"
+    "stType:\022DefaultRequestType\"U\n\013RequestTyp"
+    "e\022\026\n\022DefaultRequestType\020\000\022\026\n\022GetThetaSec"
+    "ondPass\020\001\022\026\n\022GetModelSecondPass\020\002\"\036\n\034Dup"
+    "licateMasterComponentArgs\"\034\n\032GetMasterCo"
+    "mponentInfoArgs\"\301\006\n\023MasterComponentInfo\022"
+    "\021\n\tmaster_id\030\001 \001(\005\022+\n\006config\030\002 \001(\0132\033.art"
+    "m.MasterComponentConfig\022>\n\013regularizer\030\003"
+    " \003(\0132).artm.MasterComponentInfo.Regulari"
+    "zerInfo\0222\n\005score\030\004 \003(\0132#.artm.MasterComp"
+    "onentInfo.ScoreInfo\022<\n\ndictionary\030\005 \003(\0132"
+    "(.artm.MasterComponentInfo.DictionaryInf"
+    "o\0222\n\005model\030\006 \003(\0132#.artm.MasterComponentI"
+    "nfo.ModelInfo\022=\n\013cache_entry\030\007 \003(\0132(.art"
+    "m.MasterComponentInfo.CacheEntryInfo\022\031\n\021"
+    "merger_queue_size\030\010 \001(\005\022\034\n\024processor_que"
+    "ue_size\030\t \001(\005\0222\n\005batch\030\n \003(\0132#.artm.Mast"
+    "erComponentInfo.BatchInfo\032-\n\017Regularizer"
+    "Info\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\032\'\n\tScor"
+    "eInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\0325\n\016Dic"
+    "tionaryInfo\022\014\n\004name\030\001 \001(\t\022\025\n\rentries_cou"
+    "nt\030\002 \001(\003\032C\n\tBatchInfo\022\014\n\004name\030\001 \001(\t\022\023\n\013i"
+    "tems_count\030\002 \001(\005\022\023\n\013token_count\030\003 \001(\005\032R\n"
+    "\tModelInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\024"
+    "\n\014topics_count\030\003 \001(\005\022\023\n\013token_count\030\004 \001("
+    "\005\0320\n\016CacheEntryInfo\022\013\n\003key\030\001 \001(\t\022\021\n\tbyte"
+    "_size\030\002 \001(\005\"C\n\021ImportBatchesArgs\022\022\n\nbatc"
+    "h_name\030\001 \003(\t\022\032\n\005batch\030\003 \003(\0132\013.artm.Batch"
+    "\"(\n\022DisposeBatchesArgs\022\022\n\nbatch_name\030\001 \003"
+    "(\t", 11602);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "artm/messages.proto", &protobuf_RegisterTypes);
   DoubleArray::default_instance_ = new DoubleArray();
@@ -2366,6 +2393,7 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
       new ::std::string("@default_class", 14);
   SpecifiedSparsePhiConfig::default_instance_ = new SpecifiedSparsePhiConfig();
   ImproveCoherencePhiConfig::default_instance_ = new ImproveCoherencePhiConfig();
+  SmoothPtdwConfig::default_instance_ = new SmoothPtdwConfig();
   RegularizerInternalState::default_instance_ = new RegularizerInternalState();
   MultiLanguagePhiInternalState::default_instance_ = new MultiLanguagePhiInternalState();
   DictionaryConfig::default_instance_ = new DictionaryConfig();
@@ -2473,6 +2501,7 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
   LabelRegularizationPhiConfig::default_instance_->InitAsDefaultInstance();
   SpecifiedSparsePhiConfig::default_instance_->InitAsDefaultInstance();
   ImproveCoherencePhiConfig::default_instance_->InitAsDefaultInstance();
+  SmoothPtdwConfig::default_instance_->InitAsDefaultInstance();
   RegularizerInternalState::default_instance_->InitAsDefaultInstance();
   MultiLanguagePhiInternalState::default_instance_->InitAsDefaultInstance();
   DictionaryConfig::default_instance_->InitAsDefaultInstance();
@@ -6520,7 +6549,6 @@ const int ModelConfig::kUseRandomThetaFieldNumber;
 const int ModelConfig::kUseNewTokensFieldNumber;
 const int ModelConfig::kOptForAvxFieldNumber;
 const int ModelConfig::kRegularizerSettingsFieldNumber;
-const int ModelConfig::kUsePtdwMatrixFieldNumber;
 #endif  // !_MSC_VER
 
 ModelConfig::ModelConfig()
@@ -6550,7 +6578,6 @@ void ModelConfig::SharedCtor() {
   use_random_theta_ = false;
   use_new_tokens_ = true;
   opt_for_avx_ = true;
-  use_ptdw_matrix_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -6622,7 +6649,6 @@ void ModelConfig::Clear() {
   }
   if (_has_bits_[16 / 32] & (0xffu << (16 % 32))) {
     opt_for_avx_ = true;
-    use_ptdw_matrix_ = false;
   }
   topic_name_.Clear();
   score_name_.Clear();
@@ -6950,22 +6976,6 @@ bool ModelConfig::MergePartialFromCodedStream(
           goto handle_uninterpreted;
         }
         if (input->ExpectTag(146)) goto parse_regularizer_settings;
-        if (input->ExpectTag(152)) goto parse_use_ptdw_matrix;
-        break;
-      }
-
-      // optional bool use_ptdw_matrix = 19 [default = false];
-      case 19: {
-        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
-            ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
-         parse_use_ptdw_matrix:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
-                 input, &use_ptdw_matrix_)));
-          set_has_use_ptdw_matrix();
-        } else {
-          goto handle_uninterpreted;
-        }
         if (input->ExpectAtEnd()) return true;
         break;
       }
@@ -7109,11 +7119,6 @@ void ModelConfig::SerializeWithCachedSizes(
       18, this->regularizer_settings(i), output);
   }
 
-  // optional bool use_ptdw_matrix = 19 [default = false];
-  if (has_use_ptdw_matrix()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBool(19, this->use_ptdw_matrix(), output);
-  }
-
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -7247,11 +7252,6 @@ void ModelConfig::SerializeWithCachedSizes(
         18, this->regularizer_settings(i), target);
   }
 
-  // optional bool use_ptdw_matrix = 19 [default = false];
-  if (has_use_ptdw_matrix()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(19, this->use_ptdw_matrix(), target);
-  }
-
   if (!unknown_fields().empty()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -7329,11 +7329,6 @@ int ModelConfig::ByteSize() const {
   if (_has_bits_[16 / 32] & (0xffu << (16 % 32))) {
     // optional bool opt_for_avx = 17 [default = true];
     if (has_opt_for_avx()) {
-      total_size += 2 + 1;
-    }
-
-    // optional bool use_ptdw_matrix = 19 [default = false];
-    if (has_use_ptdw_matrix()) {
       total_size += 2 + 1;
     }
 
@@ -7458,9 +7453,6 @@ void ModelConfig::MergeFrom(const ModelConfig& from) {
     if (from.has_opt_for_avx()) {
       set_opt_for_avx(from.opt_for_avx());
     }
-    if (from.has_use_ptdw_matrix()) {
-      set_use_ptdw_matrix(from.use_ptdw_matrix());
-    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -7502,7 +7494,6 @@ void ModelConfig::Swap(ModelConfig* other) {
     std::swap(use_new_tokens_, other->use_new_tokens_);
     std::swap(opt_for_avx_, other->opt_for_avx_);
     regularizer_settings_.Swap(&other->regularizer_settings_);
-    std::swap(use_ptdw_matrix_, other->use_ptdw_matrix_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);
@@ -7533,6 +7524,7 @@ bool RegularizerConfig_Type_IsValid(int value) {
     case 4:
     case 5:
     case 6:
+    case 7:
       return true;
     default:
       return false;
@@ -7547,6 +7539,7 @@ const RegularizerConfig_Type RegularizerConfig::MultiLanguagePhi;
 const RegularizerConfig_Type RegularizerConfig::LabelRegularizationPhi;
 const RegularizerConfig_Type RegularizerConfig::SpecifiedSparsePhi;
 const RegularizerConfig_Type RegularizerConfig::ImproveCoherencePhi;
+const RegularizerConfig_Type RegularizerConfig::SmoothPtdw;
 const RegularizerConfig_Type RegularizerConfig::Type_MIN;
 const RegularizerConfig_Type RegularizerConfig::Type_MAX;
 const int RegularizerConfig::Type_ARRAYSIZE;
@@ -9921,6 +9914,319 @@ void ImproveCoherencePhiConfig::Swap(ImproveCoherencePhiConfig* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = ImproveCoherencePhiConfig_descriptor_;
   metadata.reflection = ImproveCoherencePhiConfig_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+const ::google::protobuf::EnumDescriptor* SmoothPtdwConfig_Type_descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return SmoothPtdwConfig_Type_descriptor_;
+}
+bool SmoothPtdwConfig_Type_IsValid(int value) {
+  switch(value) {
+    case 1:
+    case 2:
+      return true;
+    default:
+      return false;
+  }
+}
+
+#ifndef _MSC_VER
+const SmoothPtdwConfig_Type SmoothPtdwConfig::MovingAverage;
+const SmoothPtdwConfig_Type SmoothPtdwConfig::MovingProduct;
+const SmoothPtdwConfig_Type SmoothPtdwConfig::Type_MIN;
+const SmoothPtdwConfig_Type SmoothPtdwConfig::Type_MAX;
+const int SmoothPtdwConfig::Type_ARRAYSIZE;
+#endif  // _MSC_VER
+#ifndef _MSC_VER
+const int SmoothPtdwConfig::kTypeFieldNumber;
+const int SmoothPtdwConfig::kWindowFieldNumber;
+const int SmoothPtdwConfig::kThresholdFieldNumber;
+#endif  // !_MSC_VER
+
+SmoothPtdwConfig::SmoothPtdwConfig()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+}
+
+void SmoothPtdwConfig::InitAsDefaultInstance() {
+}
+
+SmoothPtdwConfig::SmoothPtdwConfig(const SmoothPtdwConfig& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+}
+
+void SmoothPtdwConfig::SharedCtor() {
+  _cached_size_ = 0;
+  type_ = 1;
+  window_ = 10;
+  threshold_ = 1;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+SmoothPtdwConfig::~SmoothPtdwConfig() {
+  SharedDtor();
+}
+
+void SmoothPtdwConfig::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void SmoothPtdwConfig::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* SmoothPtdwConfig::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return SmoothPtdwConfig_descriptor_;
+}
+
+const SmoothPtdwConfig& SmoothPtdwConfig::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_artm_2fmessages_2eproto();
+  return *default_instance_;
+}
+
+SmoothPtdwConfig* SmoothPtdwConfig::default_instance_ = NULL;
+
+SmoothPtdwConfig* SmoothPtdwConfig::New() const {
+  return new SmoothPtdwConfig;
+}
+
+void SmoothPtdwConfig::Clear() {
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    type_ = 1;
+    window_ = 10;
+    threshold_ = 1;
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool SmoothPtdwConfig::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) return false
+  ::google::protobuf::uint32 tag;
+  while ((tag = input->ReadTag()) != 0) {
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional .artm.SmoothPtdwConfig.Type type = 1 [default = MovingAverage];
+      case 1: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
+          int value;
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
+                 input, &value)));
+          if (::artm::SmoothPtdwConfig_Type_IsValid(value)) {
+            set_type(static_cast< ::artm::SmoothPtdwConfig_Type >(value));
+          } else {
+            mutable_unknown_fields()->AddVarint(1, value);
+          }
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(24)) goto parse_window;
+        break;
+      }
+
+      // optional int32 window = 3 [default = 10];
+      case 3: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
+         parse_window:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &window_)));
+          set_has_window();
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(33)) goto parse_threshold;
+        break;
+      }
+
+      // optional double threshold = 4 [default = 1];
+      case 4: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_FIXED64) {
+         parse_threshold:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, &threshold_)));
+          set_has_threshold();
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectAtEnd()) return true;
+        break;
+      }
+
+      default: {
+      handle_uninterpreted:
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          return true;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+  return true;
+#undef DO_
+}
+
+void SmoothPtdwConfig::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // optional .artm.SmoothPtdwConfig.Type type = 1 [default = MovingAverage];
+  if (has_type()) {
+    ::google::protobuf::internal::WireFormatLite::WriteEnum(
+      1, this->type(), output);
+  }
+
+  // optional int32 window = 3 [default = 10];
+  if (has_window()) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(3, this->window(), output);
+  }
+
+  // optional double threshold = 4 [default = 1];
+  if (has_threshold()) {
+    ::google::protobuf::internal::WireFormatLite::WriteDouble(4, this->threshold(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+}
+
+::google::protobuf::uint8* SmoothPtdwConfig::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // optional .artm.SmoothPtdwConfig.Type type = 1 [default = MovingAverage];
+  if (has_type()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
+      1, this->type(), target);
+  }
+
+  // optional int32 window = 3 [default = 10];
+  if (has_window()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(3, this->window(), target);
+  }
+
+  // optional double threshold = 4 [default = 1];
+  if (has_threshold()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteDoubleToArray(4, this->threshold(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  return target;
+}
+
+int SmoothPtdwConfig::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional .artm.SmoothPtdwConfig.Type type = 1 [default = MovingAverage];
+    if (has_type()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::EnumSize(this->type());
+    }
+
+    // optional int32 window = 3 [default = 10];
+    if (has_window()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+          this->window());
+    }
+
+    // optional double threshold = 4 [default = 1];
+    if (has_threshold()) {
+      total_size += 1 + 8;
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void SmoothPtdwConfig::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const SmoothPtdwConfig* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const SmoothPtdwConfig*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void SmoothPtdwConfig::MergeFrom(const SmoothPtdwConfig& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_type()) {
+      set_type(from.type());
+    }
+    if (from.has_window()) {
+      set_window(from.window());
+    }
+    if (from.has_threshold()) {
+      set_threshold(from.threshold());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void SmoothPtdwConfig::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SmoothPtdwConfig::CopyFrom(const SmoothPtdwConfig& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SmoothPtdwConfig::IsInitialized() const {
+
+  return true;
+}
+
+void SmoothPtdwConfig::Swap(SmoothPtdwConfig* other) {
+  if (other != this) {
+    std::swap(type_, other->type_);
+    std::swap(window_, other->window_);
+    std::swap(threshold_, other->threshold_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata SmoothPtdwConfig::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = SmoothPtdwConfig_descriptor_;
+  metadata.reflection = SmoothPtdwConfig_reflection_;
   return metadata;
 }
 
@@ -24927,7 +25233,6 @@ const int ProcessBatchesArgs::kUseSparseBowFieldNumber;
 const int ProcessBatchesArgs::kResetScoresFieldNumber;
 const int ProcessBatchesArgs::kThetaMatrixTypeFieldNumber;
 const int ProcessBatchesArgs::kBatchWeightFieldNumber;
-const int ProcessBatchesArgs::kUsePtdwMatrixFieldNumber;
 #endif  // !_MSC_VER
 
 ProcessBatchesArgs::ProcessBatchesArgs()
@@ -24955,7 +25260,6 @@ void ProcessBatchesArgs::SharedCtor() {
   use_sparse_bow_ = true;
   reset_scores_ = true;
   theta_matrix_type_ = 3;
-  use_ptdw_matrix_ = false;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -25023,7 +25327,6 @@ void ProcessBatchesArgs::Clear() {
     use_sparse_bow_ = true;
     reset_scores_ = true;
     theta_matrix_type_ = 3;
-    use_ptdw_matrix_ = false;
   }
   batch_filename_.Clear();
   regularizer_name_.Clear();
@@ -25311,22 +25614,6 @@ bool ProcessBatchesArgs::MergePartialFromCodedStream(
           goto handle_uninterpreted;
         }
         if (input->ExpectTag(125)) goto parse_batch_weight;
-        if (input->ExpectTag(128)) goto parse_use_ptdw_matrix;
-        break;
-      }
-
-      // optional bool use_ptdw_matrix = 16 [default = false];
-      case 16: {
-        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
-            ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
-         parse_use_ptdw_matrix:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
-                 input, &use_ptdw_matrix_)));
-          set_has_use_ptdw_matrix();
-        } else {
-          goto handle_uninterpreted;
-        }
         if (input->ExpectAtEnd()) return true;
         break;
       }
@@ -25452,11 +25739,6 @@ void ProcessBatchesArgs::SerializeWithCachedSizes(
       15, this->batch_weight(i), output);
   }
 
-  // optional bool use_ptdw_matrix = 16 [default = false];
-  if (has_use_ptdw_matrix()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBool(16, this->use_ptdw_matrix(), output);
-  }
-
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -25571,11 +25853,6 @@ void ProcessBatchesArgs::SerializeWithCachedSizes(
       WriteFloatToArray(15, this->batch_weight(i), target);
   }
 
-  // optional bool use_ptdw_matrix = 16 [default = false];
-  if (has_use_ptdw_matrix()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(16, this->use_ptdw_matrix(), target);
-  }
-
   if (!unknown_fields().empty()) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         unknown_fields(), target);
@@ -25641,11 +25918,6 @@ int ProcessBatchesArgs::ByteSize() const {
     if (has_theta_matrix_type()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->theta_matrix_type());
-    }
-
-    // optional bool use_ptdw_matrix = 16 [default = false];
-    if (has_use_ptdw_matrix()) {
-      total_size += 2 + 1;
     }
 
   }
@@ -25752,9 +26024,6 @@ void ProcessBatchesArgs::MergeFrom(const ProcessBatchesArgs& from) {
     if (from.has_theta_matrix_type()) {
       set_theta_matrix_type(from.theta_matrix_type());
     }
-    if (from.has_use_ptdw_matrix()) {
-      set_use_ptdw_matrix(from.use_ptdw_matrix());
-    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -25793,7 +26062,6 @@ void ProcessBatchesArgs::Swap(ProcessBatchesArgs* other) {
     std::swap(reset_scores_, other->reset_scores_);
     std::swap(theta_matrix_type_, other->theta_matrix_type_);
     batch_weight_.Swap(&other->batch_weight_);
-    std::swap(use_ptdw_matrix_, other->use_ptdw_matrix_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/src/artm/messages.pb.h
+++ b/src/artm/messages.pb.h
@@ -54,6 +54,7 @@ class MultiLanguagePhiConfig;
 class LabelRegularizationPhiConfig;
 class SpecifiedSparsePhiConfig;
 class ImproveCoherencePhiConfig;
+class SmoothPtdwConfig;
 class RegularizerInternalState;
 class MultiLanguagePhiInternalState;
 class DictionaryConfig;
@@ -138,11 +139,12 @@ enum RegularizerConfig_Type {
   RegularizerConfig_Type_MultiLanguagePhi = 3,
   RegularizerConfig_Type_LabelRegularizationPhi = 4,
   RegularizerConfig_Type_SpecifiedSparsePhi = 5,
-  RegularizerConfig_Type_ImproveCoherencePhi = 6
+  RegularizerConfig_Type_ImproveCoherencePhi = 6,
+  RegularizerConfig_Type_SmoothPtdw = 7
 };
 bool RegularizerConfig_Type_IsValid(int value);
 const RegularizerConfig_Type RegularizerConfig_Type_Type_MIN = RegularizerConfig_Type_SmoothSparseTheta;
-const RegularizerConfig_Type RegularizerConfig_Type_Type_MAX = RegularizerConfig_Type_ImproveCoherencePhi;
+const RegularizerConfig_Type RegularizerConfig_Type_Type_MAX = RegularizerConfig_Type_SmoothPtdw;
 const int RegularizerConfig_Type_Type_ARRAYSIZE = RegularizerConfig_Type_Type_MAX + 1;
 
 const ::google::protobuf::EnumDescriptor* RegularizerConfig_Type_descriptor();
@@ -173,6 +175,25 @@ inline bool SpecifiedSparsePhiConfig_Mode_Parse(
     const ::std::string& name, SpecifiedSparsePhiConfig_Mode* value) {
   return ::google::protobuf::internal::ParseNamedEnum<SpecifiedSparsePhiConfig_Mode>(
     SpecifiedSparsePhiConfig_Mode_descriptor(), name, value);
+}
+enum SmoothPtdwConfig_Type {
+  SmoothPtdwConfig_Type_MovingAverage = 1,
+  SmoothPtdwConfig_Type_MovingProduct = 2
+};
+bool SmoothPtdwConfig_Type_IsValid(int value);
+const SmoothPtdwConfig_Type SmoothPtdwConfig_Type_Type_MIN = SmoothPtdwConfig_Type_MovingAverage;
+const SmoothPtdwConfig_Type SmoothPtdwConfig_Type_Type_MAX = SmoothPtdwConfig_Type_MovingProduct;
+const int SmoothPtdwConfig_Type_Type_ARRAYSIZE = SmoothPtdwConfig_Type_Type_MAX + 1;
+
+const ::google::protobuf::EnumDescriptor* SmoothPtdwConfig_Type_descriptor();
+inline const ::std::string& SmoothPtdwConfig_Type_Name(SmoothPtdwConfig_Type value) {
+  return ::google::protobuf::internal::NameOfEnum(
+    SmoothPtdwConfig_Type_descriptor(), value);
+}
+inline bool SmoothPtdwConfig_Type_Parse(
+    const ::std::string& name, SmoothPtdwConfig_Type* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<SmoothPtdwConfig_Type>(
+    SmoothPtdwConfig_Type_descriptor(), name, value);
 }
 enum RegularizerInternalState_Type {
   RegularizerInternalState_Type_MultiLanguagePhi = 3
@@ -2065,13 +2086,6 @@ class ModelConfig : public ::google::protobuf::Message {
   inline ::google::protobuf::RepeatedPtrField< ::artm::RegularizerSettings >*
       mutable_regularizer_settings();
 
-  // optional bool use_ptdw_matrix = 19 [default = false];
-  inline bool has_use_ptdw_matrix() const;
-  inline void clear_use_ptdw_matrix();
-  static const int kUsePtdwMatrixFieldNumber = 19;
-  inline bool use_ptdw_matrix() const;
-  inline void set_use_ptdw_matrix(bool value);
-
   // @@protoc_insertion_point(class_scope:artm.ModelConfig)
  private:
   inline void set_has_name();
@@ -2096,8 +2110,6 @@ class ModelConfig : public ::google::protobuf::Message {
   inline void clear_has_use_new_tokens();
   inline void set_has_opt_for_avx();
   inline void clear_has_opt_for_avx();
-  inline void set_has_use_ptdw_matrix();
-  inline void clear_has_use_ptdw_matrix();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -2114,18 +2126,17 @@ class ModelConfig : public ::google::protobuf::Message {
   ::google::protobuf::RepeatedPtrField< ::std::string> regularizer_name_;
   ::google::protobuf::RepeatedField< double > regularizer_tau_;
   ::google::protobuf::RepeatedPtrField< ::std::string> class_id_;
-  ::google::protobuf::RepeatedField< float > class_weight_;
   bool enabled_;
   bool reuse_theta_;
   bool use_sparse_bow_;
   bool use_random_theta_;
   bool use_new_tokens_;
   bool opt_for_avx_;
-  bool use_ptdw_matrix_;
+  ::google::protobuf::RepeatedField< float > class_weight_;
   ::google::protobuf::RepeatedPtrField< ::artm::RegularizerSettings > regularizer_settings_;
 
   mutable int _cached_size_;
-  ::google::protobuf::uint32 _has_bits_[(19 + 31) / 32];
+  ::google::protobuf::uint32 _has_bits_[(18 + 31) / 32];
 
   friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
   friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
@@ -2196,6 +2207,7 @@ class RegularizerConfig : public ::google::protobuf::Message {
   static const Type LabelRegularizationPhi = RegularizerConfig_Type_LabelRegularizationPhi;
   static const Type SpecifiedSparsePhi = RegularizerConfig_Type_SpecifiedSparsePhi;
   static const Type ImproveCoherencePhi = RegularizerConfig_Type_ImproveCoherencePhi;
+  static const Type SmoothPtdw = RegularizerConfig_Type_SmoothPtdw;
   static inline bool Type_IsValid(int value) {
     return RegularizerConfig_Type_IsValid(value);
   }
@@ -3076,6 +3088,132 @@ class ImproveCoherencePhiConfig : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static ImproveCoherencePhiConfig* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class SmoothPtdwConfig : public ::google::protobuf::Message {
+ public:
+  SmoothPtdwConfig();
+  virtual ~SmoothPtdwConfig();
+
+  SmoothPtdwConfig(const SmoothPtdwConfig& from);
+
+  inline SmoothPtdwConfig& operator=(const SmoothPtdwConfig& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const SmoothPtdwConfig& default_instance();
+
+  void Swap(SmoothPtdwConfig* other);
+
+  // implements Message ----------------------------------------------
+
+  SmoothPtdwConfig* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const SmoothPtdwConfig& from);
+  void MergeFrom(const SmoothPtdwConfig& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  typedef SmoothPtdwConfig_Type Type;
+  static const Type MovingAverage = SmoothPtdwConfig_Type_MovingAverage;
+  static const Type MovingProduct = SmoothPtdwConfig_Type_MovingProduct;
+  static inline bool Type_IsValid(int value) {
+    return SmoothPtdwConfig_Type_IsValid(value);
+  }
+  static const Type Type_MIN =
+    SmoothPtdwConfig_Type_Type_MIN;
+  static const Type Type_MAX =
+    SmoothPtdwConfig_Type_Type_MAX;
+  static const int Type_ARRAYSIZE =
+    SmoothPtdwConfig_Type_Type_ARRAYSIZE;
+  static inline const ::google::protobuf::EnumDescriptor*
+  Type_descriptor() {
+    return SmoothPtdwConfig_Type_descriptor();
+  }
+  static inline const ::std::string& Type_Name(Type value) {
+    return SmoothPtdwConfig_Type_Name(value);
+  }
+  static inline bool Type_Parse(const ::std::string& name,
+      Type* value) {
+    return SmoothPtdwConfig_Type_Parse(name, value);
+  }
+
+  // accessors -------------------------------------------------------
+
+  // optional .artm.SmoothPtdwConfig.Type type = 1 [default = MovingAverage];
+  inline bool has_type() const;
+  inline void clear_type();
+  static const int kTypeFieldNumber = 1;
+  inline ::artm::SmoothPtdwConfig_Type type() const;
+  inline void set_type(::artm::SmoothPtdwConfig_Type value);
+
+  // optional int32 window = 3 [default = 10];
+  inline bool has_window() const;
+  inline void clear_window();
+  static const int kWindowFieldNumber = 3;
+  inline ::google::protobuf::int32 window() const;
+  inline void set_window(::google::protobuf::int32 value);
+
+  // optional double threshold = 4 [default = 1];
+  inline bool has_threshold() const;
+  inline void clear_threshold();
+  static const int kThresholdFieldNumber = 4;
+  inline double threshold() const;
+  inline void set_threshold(double value);
+
+  // @@protoc_insertion_point(class_scope:artm.SmoothPtdwConfig)
+ private:
+  inline void set_has_type();
+  inline void clear_has_type();
+  inline void set_has_window();
+  inline void clear_has_window();
+  inline void set_has_threshold();
+  inline void clear_has_threshold();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  int type_;
+  ::google::protobuf::int32 window_;
+  double threshold_;
+
+  mutable int _cached_size_;
+  ::google::protobuf::uint32 _has_bits_[(3 + 31) / 32];
+
+  friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
+  friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
+  friend void protobuf_ShutdownFile_artm_2fmessages_2eproto();
+
+  void InitAsDefaultInstance();
+  static SmoothPtdwConfig* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -8654,13 +8792,6 @@ class ProcessBatchesArgs : public ::google::protobuf::Message {
   inline ::google::protobuf::RepeatedField< float >*
       mutable_batch_weight();
 
-  // optional bool use_ptdw_matrix = 16 [default = false];
-  inline bool has_use_ptdw_matrix() const;
-  inline void clear_use_ptdw_matrix();
-  static const int kUsePtdwMatrixFieldNumber = 16;
-  inline bool use_ptdw_matrix() const;
-  inline void set_use_ptdw_matrix(bool value);
-
   // @@protoc_insertion_point(class_scope:artm.ProcessBatchesArgs)
  private:
   inline void set_has_nwt_target_name();
@@ -8681,8 +8812,6 @@ class ProcessBatchesArgs : public ::google::protobuf::Message {
   inline void clear_has_reset_scores();
   inline void set_has_theta_matrix_type();
   inline void clear_has_theta_matrix_type();
-  inline void set_has_use_ptdw_matrix();
-  inline void clear_has_use_ptdw_matrix();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -8702,10 +8831,9 @@ class ProcessBatchesArgs : public ::google::protobuf::Message {
   bool reset_scores_;
   ::google::protobuf::RepeatedField< float > batch_weight_;
   int theta_matrix_type_;
-  bool use_ptdw_matrix_;
 
   mutable int _cached_size_;
-  ::google::protobuf::uint32 _has_bits_[(16 + 31) / 32];
+  ::google::protobuf::uint32 _has_bits_[(15 + 31) / 32];
 
   friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
   friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
@@ -12854,28 +12982,6 @@ ModelConfig::mutable_regularizer_settings() {
   return &regularizer_settings_;
 }
 
-// optional bool use_ptdw_matrix = 19 [default = false];
-inline bool ModelConfig::has_use_ptdw_matrix() const {
-  return (_has_bits_[0] & 0x00040000u) != 0;
-}
-inline void ModelConfig::set_has_use_ptdw_matrix() {
-  _has_bits_[0] |= 0x00040000u;
-}
-inline void ModelConfig::clear_has_use_ptdw_matrix() {
-  _has_bits_[0] &= ~0x00040000u;
-}
-inline void ModelConfig::clear_use_ptdw_matrix() {
-  use_ptdw_matrix_ = false;
-  clear_has_use_ptdw_matrix();
-}
-inline bool ModelConfig::use_ptdw_matrix() const {
-  return use_ptdw_matrix_;
-}
-inline void ModelConfig::set_use_ptdw_matrix(bool value) {
-  set_has_use_ptdw_matrix();
-  use_ptdw_matrix_ = value;
-}
-
 // -------------------------------------------------------------------
 
 // RegularizerConfig
@@ -13881,6 +13987,77 @@ inline void ImproveCoherencePhiConfig::set_allocated_dictionary_name(::std::stri
     clear_has_dictionary_name();
     dictionary_name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyString());
   }
+}
+
+// -------------------------------------------------------------------
+
+// SmoothPtdwConfig
+
+// optional .artm.SmoothPtdwConfig.Type type = 1 [default = MovingAverage];
+inline bool SmoothPtdwConfig::has_type() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void SmoothPtdwConfig::set_has_type() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void SmoothPtdwConfig::clear_has_type() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void SmoothPtdwConfig::clear_type() {
+  type_ = 1;
+  clear_has_type();
+}
+inline ::artm::SmoothPtdwConfig_Type SmoothPtdwConfig::type() const {
+  return static_cast< ::artm::SmoothPtdwConfig_Type >(type_);
+}
+inline void SmoothPtdwConfig::set_type(::artm::SmoothPtdwConfig_Type value) {
+  assert(::artm::SmoothPtdwConfig_Type_IsValid(value));
+  set_has_type();
+  type_ = value;
+}
+
+// optional int32 window = 3 [default = 10];
+inline bool SmoothPtdwConfig::has_window() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void SmoothPtdwConfig::set_has_window() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void SmoothPtdwConfig::clear_has_window() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void SmoothPtdwConfig::clear_window() {
+  window_ = 10;
+  clear_has_window();
+}
+inline ::google::protobuf::int32 SmoothPtdwConfig::window() const {
+  return window_;
+}
+inline void SmoothPtdwConfig::set_window(::google::protobuf::int32 value) {
+  set_has_window();
+  window_ = value;
+}
+
+// optional double threshold = 4 [default = 1];
+inline bool SmoothPtdwConfig::has_threshold() const {
+  return (_has_bits_[0] & 0x00000004u) != 0;
+}
+inline void SmoothPtdwConfig::set_has_threshold() {
+  _has_bits_[0] |= 0x00000004u;
+}
+inline void SmoothPtdwConfig::clear_has_threshold() {
+  _has_bits_[0] &= ~0x00000004u;
+}
+inline void SmoothPtdwConfig::clear_threshold() {
+  threshold_ = 1;
+  clear_has_threshold();
+}
+inline double SmoothPtdwConfig::threshold() const {
+  return threshold_;
+}
+inline void SmoothPtdwConfig::set_threshold(double value) {
+  set_has_threshold();
+  threshold_ = value;
 }
 
 // -------------------------------------------------------------------
@@ -21499,28 +21676,6 @@ ProcessBatchesArgs::mutable_batch_weight() {
   return &batch_weight_;
 }
 
-// optional bool use_ptdw_matrix = 16 [default = false];
-inline bool ProcessBatchesArgs::has_use_ptdw_matrix() const {
-  return (_has_bits_[0] & 0x00008000u) != 0;
-}
-inline void ProcessBatchesArgs::set_has_use_ptdw_matrix() {
-  _has_bits_[0] |= 0x00008000u;
-}
-inline void ProcessBatchesArgs::clear_has_use_ptdw_matrix() {
-  _has_bits_[0] &= ~0x00008000u;
-}
-inline void ProcessBatchesArgs::clear_use_ptdw_matrix() {
-  use_ptdw_matrix_ = false;
-  clear_has_use_ptdw_matrix();
-}
-inline bool ProcessBatchesArgs::use_ptdw_matrix() const {
-  return use_ptdw_matrix_;
-}
-inline void ProcessBatchesArgs::set_use_ptdw_matrix(bool value) {
-  set_has_use_ptdw_matrix();
-  use_ptdw_matrix_ = value;
-}
-
 // -------------------------------------------------------------------
 
 // ProcessBatchesResult
@@ -23592,6 +23747,10 @@ inline const EnumDescriptor* GetEnumDescriptor< ::artm::RegularizerConfig_Type>(
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::artm::SpecifiedSparsePhiConfig_Mode>() {
   return ::artm::SpecifiedSparsePhiConfig_Mode_descriptor();
+}
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::artm::SmoothPtdwConfig_Type>() {
+  return ::artm::SmoothPtdwConfig_Type_descriptor();
 }
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::artm::RegularizerInternalState_Type>() {

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -116,7 +116,6 @@ message ModelConfig {
   optional bool use_new_tokens = 16 [default = true];
   optional bool opt_for_avx = 17 [default = true];
   repeated RegularizerSettings regularizer_settings = 18;
-  optional bool use_ptdw_matrix = 19 [default = false];
 }
 
 // Represents a configuration of a general regularizer
@@ -129,6 +128,7 @@ message RegularizerConfig {
     LabelRegularizationPhi = 4;
     SpecifiedSparsePhi = 5;
     ImproveCoherencePhi = 6;
+    SmoothPtdw = 7;
   }
 
   optional string name = 1;
@@ -183,6 +183,18 @@ message ImproveCoherencePhiConfig {
   repeated string topic_name = 1;
   repeated string class_id = 2;
   optional string dictionary_name = 3;
+}
+
+// Represents a configuration of a Smooth Ptdw regularizer
+message SmoothPtdwConfig {
+  enum Type {
+    MovingAverage = 1;
+    MovingProduct = 2;
+  }
+
+  optional Type type = 1 [default = MovingAverage];
+  optional int32 window = 3 [default = 10];
+  optional double threshold = 4 [default = 1.0];
 }
 
 // Represents an internal state of a general regularizer
@@ -604,7 +616,6 @@ message ProcessBatchesArgs {
   optional bool reset_scores = 13 [default = true];
   optional ThetaMatrixType theta_matrix_type = 14 [default = Cache];
   repeated float batch_weight = 15;
-  optional bool use_ptdw_matrix = 16 [default = false];
 }
 
 message ProcessBatchesResult {

--- a/src/artm/regularizer/smooth_ptdw.cc
+++ b/src/artm/regularizer/smooth_ptdw.cc
@@ -1,0 +1,108 @@
+// Copyright 2015, Additive Regularization of Topic Models.
+
+// Author: Anya Potapenko (anya_potapenko@mail.ru)
+
+#include <vector>
+
+#include "glog/logging.h"
+#include "artm/core/protobuf_helpers.h"
+#include "artm/utility/blas.h"
+
+#include "artm/regularizer/smooth_ptdw.h"
+
+namespace artm {
+namespace regularizer {
+
+void SmoothPtdwAgent::Apply(int item_index, int inner_iter, ::artm::utility::DenseMatrix<float>* ptdw) const {
+  int local_token_size = ptdw->no_rows();
+  int topics_count = ptdw->no_columns();
+  if (config_.type() == SmoothPtdwConfig_Type_MovingAverage) {
+    // 1. evaluate wich tokens are background
+    double threshold = config_.threshold();
+    std::vector<bool> is_background(local_token_size, false);
+    int count_background = 0;
+    for (int i = 0; i < local_token_size; ++i) {
+      const float* local_ptdw_ptr = &(*ptdw)(i, 0);  // NOLINT
+      double sum_background = 0.0;
+      for (int k = 0; k < topics_count; ++k) {
+        char b = 'b';
+        if (model_config_.topic_name(k)[0] == b) {  // background topic
+          sum_background += local_ptdw_ptr[k];
+        }
+      }
+      if (sum_background > threshold) {
+        is_background[i] = true;
+        ++count_background;
+      }
+    }
+    // LOG(WARNING) << 1.0 * count_background / local_token_size;
+
+    // 2. prepare ptdw copy and smoothing profile
+    int h = config_.window() / 2;
+    double tau = tau_;
+    ::artm::utility::DenseMatrix<float> copy_ptdw(*ptdw);
+    ::artm::utility::DenseMatrix<float> smoothed(1, topics_count);
+    smoothed.InitializeZeros();
+    float* smoothed_ptr = &smoothed(0, 0);
+    for (int i = 0; i < h && i < local_token_size; ++i) {
+      if (is_background[i]) continue;
+      const float* copy_ptdw_ptr = &copy_ptdw(i, 0);
+      for (int k = 0; k < topics_count; ++k) {
+        smoothed_ptr[k] += copy_ptdw_ptr[k];
+      }
+    }
+
+    // 3. regularize
+    for (int i = 0; i < local_token_size; ++i) {
+      if (is_background[i]) continue;
+      const float* copy_ptdw_ptr = &copy_ptdw(i, 0);
+      float* local_ptdw_ptr = &(*ptdw)(i, 0);  // NOLINT
+      for (int k = 0; k < topics_count; ++k) {
+        local_ptdw_ptr[k] += tau_ * smoothed_ptr[k];
+        if (i + h < local_token_size && !is_background[i + h])
+          smoothed_ptr[k] += copy_ptdw(i + h, k);
+        if (i - h >= 0 && !is_background[i - h])
+          smoothed_ptr[k] -= copy_ptdw(i - h, k);
+      }
+    }
+  }
+
+  // Multiplying neighbours (mode = 2)
+  if (config_.type() == SmoothPtdwConfig_Type_MovingProduct) {
+    double tau = tau_;  // not used?!
+    ::artm::utility::DenseMatrix<float> copy_ptdw(*ptdw);
+    for (int i = 0; i < local_token_size; ++i) {
+      const float* copy_ptdw_ptr = &copy_ptdw(i, 0);
+      float* local_ptdw_ptr = &(*ptdw)(i, 0);  // NOLINT
+      for (int k = 0; k < topics_count; ++k) {
+        if (i + 1 < local_token_size)
+          local_ptdw_ptr[k] *= copy_ptdw(i + 1, k);
+        if (i - 1 >= 0)
+          local_ptdw_ptr[k] *= copy_ptdw(i - 1, k);
+      }
+    }
+  }
+}
+
+std::shared_ptr<RegularizePtdwAgent>
+SmoothPtdw::CreateRegularizePtdwAgent(const Batch& batch,
+                                      const ModelConfig& model_config, double tau) {
+  SmoothPtdwAgent* agent = new SmoothPtdwAgent(config_, model_config, tau);
+  std::shared_ptr<RegularizePtdwAgent> retval(agent);
+  return retval;
+}
+
+bool SmoothPtdw::Reconfigure(const RegularizerConfig& config) {
+  std::string config_blob = config.config();
+  SmoothPtdwConfig regularizer_config;
+  if (!regularizer_config.ParseFromArray(config_blob.c_str(), config_blob.length())) {
+    BOOST_THROW_EXCEPTION(::artm::core::CorruptedMessageException(
+      "Unable to parse SmoothPtdwConfig from RegularizerConfig.config"));
+  }
+
+  config_.CopyFrom(regularizer_config);
+  return true;
+}
+
+}  // namespace regularizer
+}  // namespace artm

--- a/src/artm/regularizer/smooth_ptdw.h
+++ b/src/artm/regularizer/smooth_ptdw.h
@@ -1,0 +1,48 @@
+// Copyright 2015, Additive Regularization of Topic Models.
+
+// Author: Anya Potapenko (anya_potapenko@mail.ru)
+
+#ifndef SRC_ARTM_REGULARIZER_SMOOTH_PTDW_H_
+#define SRC_ARTM_REGULARIZER_SMOOTH_PTDW_H_
+
+#include <string>
+#include <vector>
+
+#include "artm/messages.pb.h"
+#include "artm/regularizer_interface.h"
+
+namespace artm {
+namespace regularizer {
+
+class SmoothPtdwAgent : public RegularizePtdwAgent {
+ private:
+  friend class SmoothPtdw;
+  SmoothPtdwConfig config_;
+  ModelConfig model_config_;
+  double tau_;
+
+ public:
+  SmoothPtdwAgent(const SmoothPtdwConfig& config, const ModelConfig& model_config, double tau)
+      : config_(config), model_config_(model_config), tau_(tau) {}
+
+  virtual void Apply(int item_index, int inner_iter, ::artm::utility::DenseMatrix<float>* ptdw) const;
+};
+
+class SmoothPtdw : public RegularizerInterface {
+ public:
+  explicit SmoothPtdw(const SmoothPtdwConfig& config)
+    : config_(config) {}
+
+  virtual std::shared_ptr<RegularizePtdwAgent>
+  CreateRegularizePtdwAgent(const Batch& batch, const ModelConfig& model_config, double tau);
+
+  virtual bool Reconfigure(const RegularizerConfig& config);
+
+ private:
+  SmoothPtdwConfig config_;
+};
+
+}  // namespace regularizer
+}  // namespace artm
+
+#endif  // SRC_ARTM_REGULARIZER_SMOOTH_PTDW_H_

--- a/src/artm/regularizer/smooth_sparse_theta.cc
+++ b/src/artm/regularizer/smooth_sparse_theta.cc
@@ -12,7 +12,7 @@
 namespace artm {
 namespace regularizer {
 
-void SmoothSparseThetaAgent::Apply(int item_index, int inner_iter, int topics_size, float* theta) {
+void SmoothSparseThetaAgent::Apply(int item_index, int inner_iter, int topics_size, float* theta) const {
   assert(topics_size == topic_weight.size());
   assert(inner_iter < alpha_weight.size());
   if (topics_size != topic_weight.size()) return;

--- a/src/artm/regularizer/smooth_sparse_theta.h
+++ b/src/artm/regularizer/smooth_sparse_theta.h
@@ -20,7 +20,7 @@ class SmoothSparseThetaAgent : public RegularizeThetaAgent {
   std::vector<float> topic_weight;
   std::vector<float> alpha_weight;
  public:
-  virtual void Apply(int item_index, int inner_iter, int topics_size, float* theta);
+  virtual void Apply(int item_index, int inner_iter, int topics_size, float* theta) const;
 };
 
 class SmoothSparseTheta : public RegularizerInterface {

--- a/src/artm/regularizer_interface.cc
+++ b/src/artm/regularizer_interface.cc
@@ -20,29 +20,4 @@ void RegularizerInterface::set_dictionaries(
   dictionaries_ = dictionaries;
 }
 
-void RegularizeThetaAgentCollection::Apply(int item_index, int inner_iter, int topics_size, float* theta) {
-  for (auto& agent : agents_) {
-    if (agent != nullptr) {
-      agent->Apply(item_index, inner_iter, topics_size, theta);
-    }
-  }
-}
-
-void NormalizeThetaAgent::Apply(int item_index, int inner_iter, int topics_size, float* theta) {
-  float sum = 0.0f;
-  for (int topic_index = 0; topic_index < topics_size; ++topic_index) {
-    float val = theta[topic_index];
-    if (val > 0)
-      sum += val;
-  }
-
-  float sum_inv = sum > 0.0f ? (1.0f / sum) : 0.0f;
-  for (int topic_index = 0; topic_index < topics_size; ++topic_index) {
-    float val = sum_inv * theta[topic_index];
-    if (val < 1e-16f) val = 0.0f;
-    theta[topic_index] = val;
-  }
-}
-
-
 }  // namespace artm

--- a/src/artm/regularizer_interface.h
+++ b/src/artm/regularizer_interface.h
@@ -31,21 +31,13 @@ namespace core {
 class RegularizeThetaAgent {
  public:
   virtual ~RegularizeThetaAgent() {}
-  virtual void Apply(int item_index, int inner_iter, int topics_size, float* theta) { return; }
+  virtual void Apply(int item_index, int inner_iter, int topics_size, float* theta) const = 0;
 };
 
-class RegularizeThetaAgentCollection : public RegularizeThetaAgent {
- private:
-  std::vector<std::shared_ptr<RegularizeThetaAgent>> agents_;
-
+class RegularizePtdwAgent {
  public:
-  void AddAgent(std::shared_ptr<RegularizeThetaAgent> agent) { agents_.push_back(agent); }
-  virtual void Apply(int item_index, int inner_iter, int topics_size, float* theta);
-};
-
-class NormalizeThetaAgent : public RegularizeThetaAgent {
- public:
-  virtual void Apply(int item_index, int inner_iter, int topics_size, float* theta);
+  virtual ~RegularizePtdwAgent() {}
+  virtual void Apply(int item_index, int inner_iter, ::artm::utility::DenseMatrix<float>* ptdw) const = 0;
 };
 
 class RegularizerInterface {
@@ -55,6 +47,11 @@ class RegularizerInterface {
 
   virtual std::shared_ptr<RegularizeThetaAgent>
   CreateRegularizeThetaAgent(const Batch& batch, const ModelConfig& model_config, double tau) {
+    return nullptr;
+  }
+
+  virtual std::shared_ptr<RegularizePtdwAgent>
+  CreateRegularizePtdwAgent(const Batch& batch, const ModelConfig& model_config, double tau) {
     return nullptr;
   }
 

--- a/src/artm_tests/cpp_interface_test.cc
+++ b/src/artm_tests/cpp_interface_test.cc
@@ -73,7 +73,6 @@ void BasicTest() {
   model_config.add_regularizer_name(reg_multilang_name);
   model_config.add_regularizer_tau(1);
   model_config.set_name("model_config1");
-  model_config.set_use_ptdw_matrix(true);  // temporary switch tests into use_ptdw_matrix mode
   artm::Model model(*master_component, model_config);
 
   // Load doc-token matrix
@@ -657,7 +656,6 @@ TEST(CppInterface, ProcessBatchesApi) {
   ASSERT_EQ(rwt->topics_count(), nTopics);
 
   // Test to verify Ptdw extraction
-  process_batches_args.set_use_ptdw_matrix(true);
   process_batches_args.set_theta_matrix_type(artm::ProcessBatchesArgs_ThetaMatrixType_SparsePtdw);
   std::shared_ptr< ::artm::ProcessBatchesResultObject> result_2 = master.ProcessBatches(process_batches_args);
   auto& theta_matrix = result_2->GetThetaMatrix();

--- a/src/artm_tests/multiple_classes_test.cc
+++ b/src/artm_tests/multiple_classes_test.cc
@@ -116,6 +116,15 @@ TEST(MultipleClasses, BasicTest) {
   regularizer_config.set_config(smooth_sparse_theta_config.SerializeAsString());
   ::artm::Regularizer regularizer_smsp_theta(master_component, regularizer_config);
 
+  // Create ptdw-regularizer
+  ::artm::RegularizerConfig regularizer_config2;
+  regularizer_config2.set_name("regularizer_ptdw");
+  regularizer_config2.set_type(::artm::RegularizerConfig_Type_SmoothPtdw);
+  ::artm::SmoothPtdwConfig smooth_ptdw_config;
+  smooth_ptdw_config.set_window(5);
+  regularizer_config2.set_config(smooth_ptdw_config.SerializeAsString());
+  ::artm::Regularizer regularizer_ptdw(master_component, regularizer_config2);
+
   // Generate doc-token matrix
   int nTokens = 60;
   int nDocs = 100;
@@ -143,7 +152,6 @@ TEST(MultipleClasses, BasicTest) {
   artm::ModelConfig model_config1, model_config2, model_config3;
 
   model_config1.set_name("model1"); model_config1.set_topics_count(nTopics);
-  model_config1.set_use_ptdw_matrix(true);   // temporary switch tests into use_ptdw_matrix mode
   model_config2.set_name("model2"); model_config2.set_topics_count(nTopics); model_config2.set_use_sparse_bow(false);
   model_config3.set_name("model3"); model_config3.set_topics_count(nTopics);
   model_config3.add_class_id("@default_class"); model_config3.add_class_weight(0.5f);
@@ -159,6 +167,8 @@ TEST(MultipleClasses, BasicTest) {
   model_config_reg.set_name("model_config_reg");
   model_config_reg.add_regularizer_name("regularizer_smsp_theta");
   model_config_reg.add_regularizer_tau(-1.0);
+  model_config_reg.add_regularizer_name("regularizer_ptdw");
+  model_config_reg.add_regularizer_tau(2.0);
   for (int i = 0; i < nTopics; ++i) {
     std::stringstream ss;
     ss << "Topic" << i;

--- a/utils/cpplint_files.txt
+++ b/utils/cpplint_files.txt
@@ -24,6 +24,7 @@ src/artm/regularizer/label_regularization_phi.cc
 src/artm/regularizer/smooth_sparse_theta.cc
 src/artm/regularizer/specified_sparse_phi.cc
 src/artm/regularizer/improve_coherence_phi.cc
+src/artm/regularizer/smooth_ptdw.cc
 src/artm/score/perplexity.cc
 src/artm/score/sparsity_theta.cc
 src/artm/score/sparsity_phi.cc
@@ -80,6 +81,7 @@ src/artm/regularizer/label_regularization_phi.h
 src/artm/regularizer/smooth_sparse_theta.h
 src/artm/regularizer/specified_sparse_phi.h
 src/artm/regularizer/improve_coherence_phi.h
+src/artm/regularizer/smooth_ptdw.h
 src/artm/score/perplexity.h
 src/artm/score/sparsity_theta.h
 src/artm/score/sparsity_phi.h


### PR DESCRIPTION
This pull request
* implements a framework for ``ptdw`` regularizers, and 
* implements first ``ptdw`` regularizer based on the code from https://github.com/bigartm/bigartm/compare/master...AnyaP:master
* removes ``use_ptdw_matrix`` flag. Now ``ptdw`` matrix will be used automatically if there is at least one ``ptdw`` regularizer, or if user performs ``ptdw`` matrix retrieval.

From user perspective ``ptdw`` regularizers are no different from ``theta`` regularizers. To apply ``ptdw`` regularizers user need to add their names and weights into ``ProcessBatchesArgs.regularizer_name`` and ``ProcessBatchesArgs.regularizer_tau`` lists.

This pull request does not update python APIs. @MelLain , could you please wrap ``SmoothPtdw`` into the corresponding class for Python interface? (eventually I also need to learn how to do this)