### PR TITLE
Excludes static linkage for Mac OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ else()
   message("-- Build type: ${CMAKE_BUILD_TYPE}")
 endif()
 
-option(BUILD_STATIC_BIGARTM "Request build of static executable bigartm" ON)
+option(BUILD_STATIC_BIGARTM "Request build of static executable bigartm (for Linux only)" ON)
+
+if (APPLE)
+  set (BUILD_STATIC_BIGARTM OFF)
+endif (APPLE)
 
 set(BUILD_STATIC_LIBS ON)
 set(BUILD_SHARED_LIBS OFF)


### PR DESCRIPTION
There are many discussions related to static linkage for Mac OS
https://stackoverflow.com/questions/3801011/ld-library-not-found-for-lcrt0-o-on-osx-10-6-with-gcc-clang-static-flag
https://stackoverflow.com/questions/5259249/creating-static-mac-os-x-c-build
It seems that nowadays we cannot build any static executable on Mac OS using GCC.
So, for Mac OS users option "BUILD_STATIC_BIGARTM" is unnecessary.