### PR TITLE
eliminating -Wsign-compare warnings

### DIFF
--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -574,7 +574,7 @@ std::shared_ptr<DictionaryConfig> CollectionParser::ParseVowpalWabbit() {
     std::string item_title = strs[0];
 
     ClassId class_id = DefaultClass;
-    for (int elem_index = 1; elem_index < strs.size(); ++elem_index) {
+    for (unsigned elem_index = 1; elem_index < strs.size(); ++elem_index) {
       std::string elem = strs[elem_index];
       if (elem.size() == 0)
         continue;

--- a/src/artm/core/dense_phi_matrix.cc
+++ b/src/artm/core/dense_phi_matrix.cc
@@ -84,7 +84,7 @@ PhiMatrixFrame::PhiMatrixFrame(const PhiMatrixFrame& rhs)
       token_collection_(rhs.token_collection_),
       spin_locks_() {
   spin_locks_.reserve(rhs.spin_locks_.size());
-  for (int i = 0; i < rhs.spin_locks_.size(); ++i)
+  for (unsigned i = 0; i < rhs.spin_locks_.size(); ++i)
     spin_locks_.push_back(std::make_shared<SpinLock>());
 }
 

--- a/src/artm/core/helpers.cc
+++ b/src/artm/core/helpers.cc
@@ -846,13 +846,13 @@ std::vector<float> Helpers::GenerateRandomVector(int size, const Token& token) {
   size_t h = 1125899906842597L;  // prime
 
   if (token.class_id != DefaultClass) {
-    for (int i = 0; i < token.class_id.size(); i++)
+    for (unsigned i = 0; i < token.class_id.size(); i++)
       h = 31 * h + token.class_id[i];
   }
 
   h = 31 * h + 255;  // separate class_id and token
 
-  for (int i = 0; i < token.keyword.size(); i++)
+  for (unsigned i = 0; i < token.keyword.size(); i++)
     h = 31 * h + token.keyword[i];
 
   return GenerateRandomVector(size, h);
@@ -1087,7 +1087,7 @@ bool BatchHelpers::PopulateThetaMatrixFromCacheEntry(
     if (!has_sparse_format) {
       if (sparse_cache) {
         // dense output -- sparse cache
-        for (int index = 0; index < topics_to_use.size(); ++index) {
+        for (unsigned index = 0; index < topics_to_use.size(); ++index) {
           int topic_index = repeated_field_index_of(cache.topic_index(item_index).value(), topics_to_use[index]);
           theta_vec->add_value(topic_index != -1 ? item_theta.value(topic_index) : 0.0f);
         }
@@ -1106,7 +1106,7 @@ bool BatchHelpers::PopulateThetaMatrixFromCacheEntry(
             theta_vec->add_value(item_theta.value(index));
             sparse_topic_index->add_value(topic_index);
           } else {
-            for (int i = 0; i < topics_to_use.size(); ++i) {
+            for (unsigned i = 0; i < topics_to_use.size(); ++i) {
               if (topics_to_use[i] == topic_index) {
                 theta_vec->add_value(item_theta.value(index));
                 sparse_topic_index->add_value(topic_index);
@@ -1117,7 +1117,7 @@ bool BatchHelpers::PopulateThetaMatrixFromCacheEntry(
         }
       } else {
         // sparse output -- dense cache
-        for (int index = 0; index < topics_to_use.size(); index++) {
+        for (unsigned index = 0; index < topics_to_use.size(); index++) {
           int topic_index = topics_to_use[index];
           float value = item_theta.value(topic_index);
           if (value >= get_theta_args.eps()) {

--- a/src/artm/core/master_component.cc
+++ b/src/artm/core/master_component.cc
@@ -351,8 +351,6 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
     case ProcessBatchesArgs_ThetaMatrixType_SparsePtdw:
       ptdw_cache_manager_ptr = &cache_manager;
       return_ptdw = true;
-    default:
-      break;
   }
 
   if (args.reset_scores())
@@ -414,8 +412,6 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
     case ProcessBatchesArgs_ThetaMatrixType_Sparse:
     case ProcessBatchesArgs_ThetaMatrixType_SparsePtdw:
       get_theta_matrix_args.set_matrix_layout(GetThetaMatrixArgs_MatrixLayout_Sparse);
-      break;
-    default:
       break;
   }
 

--- a/src/artm/core/master_component.cc
+++ b/src/artm/core/master_component.cc
@@ -351,6 +351,8 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
     case ProcessBatchesArgs_ThetaMatrixType_SparsePtdw:
       ptdw_cache_manager_ptr = &cache_manager;
       return_ptdw = true;
+    default:
+      break;
   }
 
   if (args.reset_scores())
@@ -412,6 +414,8 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
     case ProcessBatchesArgs_ThetaMatrixType_Sparse:
     case ProcessBatchesArgs_ThetaMatrixType_SparsePtdw:
       get_theta_matrix_args.set_matrix_layout(GetThetaMatrixArgs_MatrixLayout_Sparse);
+      break;
+    default:
       break;
   }
 

--- a/src/artm/core/merger.cc
+++ b/src/artm/core/merger.cc
@@ -358,7 +358,8 @@ void Merger::SynchronizeModel(const ModelName& model_name, float decay_weight,
         PhiMatrixOperations::FindNormalizers(new_ttm->GetNwt(), global_r_wt);
       for (auto iter : new_ttm_normalizers) {
         int bad_topics = 0;
-        for (int topic_index = 0; topic_index < iter.second.size(); ++topic_index) {
+        for (unsigned topic_index = 0; topic_index < iter.second.size();
+             ++topic_index) {
           if (iter.second[topic_index] < 1e-20) {
             bad_topics++;
           }

--- a/src/artm/core/merger.cc
+++ b/src/artm/core/merger.cc
@@ -358,8 +358,7 @@ void Merger::SynchronizeModel(const ModelName& model_name, float decay_weight,
         PhiMatrixOperations::FindNormalizers(new_ttm->GetNwt(), global_r_wt);
       for (auto iter : new_ttm_normalizers) {
         int bad_topics = 0;
-        for (unsigned topic_index = 0; topic_index < iter.second.size();
-             ++topic_index) {
+        for (unsigned topic_index = 0; topic_index < iter.second.size(); ++topic_index) {
           if (iter.second[topic_index] < 1e-20) {
             bad_topics++;
           }

--- a/src/artm/core/phi_matrix_operations.cc
+++ b/src/artm/core/phi_matrix_operations.cc
@@ -121,7 +121,7 @@ void PhiMatrixOperations::RetrieveExternalTopicModel(const PhiMatrix& phi_matrix
         target->add_value(phi_matrix.get(token_index, topic_index));
     } else {
       ::artm::IntArray* sparse_topic_index = topic_model->add_topic_index();
-      for (int topics_to_use_index = 0; topics_to_use_index < topics_to_use.size(); topics_to_use_index++) {
+      for (unsigned topics_to_use_index = 0; topics_to_use_index < topics_to_use.size(); topics_to_use_index++) {
         int topic_index = topics_to_use[topics_to_use_index];
         float value = phi_matrix.get(token_index, topic_index);
         if (fabs(value) > get_model_args.eps()) {
@@ -161,7 +161,8 @@ void PhiMatrixOperations::ApplyTopicModelOperation(const ::artm::TopicModel& top
   bool optimized_execution = false;
   if ((apply_weight == 1.0f) && (target_topic_index.size() == this_topic_size)) {
     bool ok = true;
-    for (int topic_index = 0; topic_index < target_topic_index.size(); ++topic_index) {
+    for (unsigned topic_index = 0; topic_index < target_topic_index.size();
+         ++topic_index) {
       if (target_topic_index[topic_index] != topic_index)
         ok = false;
     }

--- a/src/artm/core/phi_matrix_operations.cc
+++ b/src/artm/core/phi_matrix_operations.cc
@@ -161,8 +161,7 @@ void PhiMatrixOperations::ApplyTopicModelOperation(const ::artm::TopicModel& top
   bool optimized_execution = false;
   if ((apply_weight == 1.0f) && (target_topic_index.size() == this_topic_size)) {
     bool ok = true;
-    for (unsigned topic_index = 0; topic_index < target_topic_index.size();
-         ++topic_index) {
+    for (unsigned topic_index = 0; topic_index < target_topic_index.size(); ++topic_index) {
       if (target_topic_index[topic_index] != topic_index)
         ok = false;
     }

--- a/src/artm/regularizer/specified_sparse_phi.cc
+++ b/src/artm/regularizer/specified_sparse_phi.cc
@@ -88,7 +88,7 @@ bool SpecifiedSparsePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
         break;
       }
     }
-    for (int i = stop_index; i < max_and_indices.size(); ++i) {
+    for (unsigned i = stop_index; i < max_and_indices.size(); ++i) {
       int* ptr = indices_of_max.Add();
       *ptr = max_and_indices[i].first;
     }

--- a/src/artm/score/top_tokens.cc
+++ b/src/artm/score/top_tokens.cc
@@ -58,7 +58,7 @@ std::shared_ptr<Score> TopTokens::CalculateScore(const artm::core::PhiMatrix& p_
 
   float average_coherence = 0.0f;
   auto coherence = top_tokens_score->mutable_coherence();
-  for (int i = 0; i < topic_ids.size(); ++i) {
+  for (unsigned i = 0; i < topic_ids.size(); ++i) {
     std::vector<std::pair<float, int>> p_wt_local;
     p_wt_local.reserve(tokens.size());
 

--- a/src/artm/score/topic_kernel.cc
+++ b/src/artm/score/topic_kernel.cc
@@ -135,7 +135,7 @@ std::shared_ptr<Score> TopicKernel::CalculateScore(const artm::core::PhiMatrix& 
       average_kernel_contrast += kernel_contrast->value(topic_index);
 
       StringArray* tokens = kernel_tokens->Add();
-      for (int token_id = 0; token_id < topic_kernel_tokens[topic_index].size(); ++token_id)
+      for (unsigned token_id = 0; token_id < topic_kernel_tokens[topic_index].size(); ++token_id)
         tokens->add_value(topic_kernel_tokens[topic_index][token_id].keyword);
     }
   }

--- a/src/artm_tests/cache_manager_test.cc
+++ b/src/artm_tests/cache_manager_test.cc
@@ -34,7 +34,7 @@ void RunTest(bool disk_cache) {
   ::artm::Model model(master_component, model_config);
 
   for (int iter = 0; iter < 3; ++iter) {
-    for (int iBatch = 0; iBatch < batches.size(); ++iBatch)
+    for (unsigned iBatch = 0; iBatch < batches.size(); ++iBatch)
       master_component.AddBatch(*batches[iBatch]);
     master_component.WaitIdle();
     model.Synchronize(0.0);
@@ -47,7 +47,7 @@ void RunTest(bool disk_cache) {
   model_config.set_inner_iterations_count(0);
   model.Reconfigure(model_config);
   {
-    for (int iBatch = 0; iBatch < batches.size(); ++iBatch)
+    for (unsigned iBatch = 0; iBatch < batches.size(); ++iBatch)
       master_component.AddBatch(*batches[iBatch]);
     master_component.WaitIdle();
     model.Synchronize(0.0);

--- a/src/artm_tests/cpp_interface_test.cc
+++ b/src/artm_tests/cpp_interface_test.cc
@@ -757,7 +757,7 @@ TEST(CppInterface, AsyncProcessBatches) {
   ASSERT_EQ(all_batches.size(), nBatches);
 
   std::vector<int> operation_ids;
-  for (int i = 0; i < all_batches.size(); ++i) {
+  for (unsigned i = 0; i < all_batches.size(); ++i) {
     std::string& batch_name = all_batches[i];
     artm::ProcessBatchesArgs process_batches_args;
     process_batches_args.add_batch_filename(batch_name);
@@ -767,7 +767,7 @@ TEST(CppInterface, AsyncProcessBatches) {
     operation_ids.push_back(master.AsyncProcessBatches(process_batches_args));
   }
 
-  for (int i = 0; i < operation_ids.size(); ++i) {
+  for (unsigned i = 0; i < operation_ids.size(); ++i) {
     master.AwaitOperation(operation_ids[i]);
 
     ::artm::MergeModelArgs merge_model_args;

--- a/src/artm_tests/repeatable_result_test.cc
+++ b/src/artm_tests/repeatable_result_test.cc
@@ -38,7 +38,7 @@ std::string runOfflineTest() {
   int nTokens = 10;
   ::artm::test::TestMother::GenerateBatches(batches_size, nTokens, &batches);
   for (int iter = 0; iter < 3; ++iter) {
-    for (int iBatch = 0; iBatch < batches.size(); ++iBatch) {
+    for (unsigned iBatch = 0; iBatch < batches.size(); ++iBatch) {
       master_component.AddBatch(*batches[iBatch]);
     }
 
@@ -50,7 +50,7 @@ std::string runOfflineTest() {
   std::stringstream ss;
   ss << "Topic model:\n" << ::artm::test::Helpers::DescribeTopicModel(*topic_model);
   ss << "Theta matrix:\n";
-  for (int i = 0; i < batches.size(); ++i) {
+  for (unsigned i = 0; i < batches.size(); ++i) {
     ::artm::GetThetaMatrixArgs args;
     args.set_model_name(model.name());
     args.mutable_batch()->CopyFrom(*batches[i]);
@@ -130,7 +130,7 @@ void OverwriteTopicModel_internal(::artm::GetTopicModelArgs_RequestType request_
   ::artm::test::TestMother::GenerateBatches(batches_size, nTokens, &batches);
 
   for (int iter = 0; iter < 3; ++iter) {
-    for (int iBatch = 0; iBatch < batches.size(); ++iBatch) {
+    for (unsigned iBatch = 0; iBatch < batches.size(); ++iBatch) {
       master_component.AddBatch(*batches[iBatch]);
     }
 
@@ -196,7 +196,7 @@ void OverwriteTopicModel_internal(::artm::GetTopicModelArgs_RequestType request_
               << ::artm::test::Helpers::DescribeTopicModel(*master_component.GetTopicModel(model.name()));
   }
   ASSERT_TRUE(ok && ok2);
-  for (int iBatch = 0; iBatch < batches.size(); ++iBatch) {
+  for (unsigned iBatch = 0; iBatch < batches.size(); ++iBatch) {
     ::artm::test::Helpers::CompareThetaMatrices(*master2.GetThetaMatrix(model.name(), *batches[iBatch]),
                                                 *master_component.GetThetaMatrix(model.name(), *batches[iBatch]), &ok);
     ::artm::test::Helpers::CompareThetaMatrices(*master3.GetThetaMatrix(model.name(), *batches[iBatch]),
@@ -208,7 +208,7 @@ void OverwriteTopicModel_internal(::artm::GetTopicModelArgs_RequestType request_
     return;  // do not validate further model inference for pwt_request
 
   // Run extra iteration and validate that model is stil still the same
-  for (int iBatch = 0; iBatch < batches.size(); ++iBatch) {
+  for (unsigned iBatch = 0; iBatch < batches.size(); ++iBatch) {
     master_component.AddBatch(*batches[iBatch]);
     master2.AddBatch(*batches[iBatch]);
     master3.AddBatch(*batches[iBatch]);
@@ -225,7 +225,7 @@ void OverwriteTopicModel_internal(::artm::GetTopicModelArgs_RequestType request_
                                             *master_component.GetTopicModel(model.name()), &ok2);
   ASSERT_TRUE(ok2);
 
-  for (int iBatch = 0; iBatch < batches.size(); ++iBatch) {
+  for (unsigned iBatch = 0; iBatch < batches.size(); ++iBatch) {
     ::artm::test::Helpers::CompareThetaMatrices(*master2.GetThetaMatrix(model.name(), *batches[iBatch]),
                                                 *master_component.GetThetaMatrix(model.name(), *batches[iBatch]), &ok);
     ASSERT_TRUE(ok);

--- a/src/artm_tests/test_mother.cc
+++ b/src/artm_tests/test_mother.cc
@@ -143,7 +143,7 @@ void Helpers::CompareThetaMatrices(const ::artm::ThetaMatrix& tm1, const ::artm:
 void TestMother::GenerateBatches(int batches_size, int nTokens, const std::string& target_folder) {
   std::vector<std::shared_ptr< ::artm::Batch>> batches;
   GenerateBatches(batches_size, nTokens, &batches);
-  for (int i = 0; i < batches.size(); ++i)
+  for (unsigned i = 0; i < batches.size(); ++i)
     artm::SaveBatch(*batches[i], target_folder);
 }
 

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -74,7 +74,7 @@ class CsvEscape {
 
     std::stringstream ss;
     ss << "\"";
-    for (int i = 0; i < in.size(); ++i) {
+    for (unsigned i = 0; i < in.size(); ++i) {
       if (in[i] == '"') ss << "\"\"";
       else ss << in[i];
     }
@@ -143,7 +143,7 @@ std::vector<std::pair<std::string, T>> parseKeyValuePairs(const std::string& inp
   // Handle the case when "input" is a set of "group:value" pairs, separated by ; or ,
   std::vector<std::string> strs;
   boost::split(strs, input, boost::is_any_of(";,"));
-  for (int elem_index = 0; elem_index < strs.size(); ++elem_index) {
+  for (unsigned elem_index = 0; elem_index < strs.size(); ++elem_index) {
     std::string elem = strs[elem_index];
     T elem_size = 0;
     size_t split_index = elem.find(':');
@@ -338,7 +338,7 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
   std::vector<std::pair<std::string, float>> class_ids;
   std::vector<std::string> topic_names;
   std::string dictionary_name;
-  for (int i = 2; i < strs.size(); ++i) {
+  for (unsigned i = 2; i < strs.size(); ++i) {
     std::string elem = strs[i];
     if (elem.empty())
       continue;
@@ -422,7 +422,7 @@ class ScoreHelper {
      std::vector<std::pair<std::string, float>> class_ids;
      std::vector<std::string> topic_names;
      std::string dictionary_name;
-     for (int i = 1; i < strs.size(); ++i) {
+     for (unsigned i = 1; i < strs.size(); ++i) {
        std::string elem = strs[i];
        if (elem.empty())
          continue;
@@ -665,7 +665,7 @@ class BatchesIterator {
  private:
   std::vector<std::string> batch_file_names_;
   int update_every_;
-  int current_;
+  unsigned current_;
 
  public:
   BatchesIterator(const std::vector<std::string>& batch_file_names, int update_every)
@@ -675,7 +675,7 @@ class BatchesIterator {
 
   void get(ProcessBatchesArgs* args) {
     args->clear_batch_filename();
-    int last = std::min<int>(current_ + update_every_, batch_file_names_.size());
+    unsigned last = std::min<unsigned>(current_ + update_every_, batch_file_names_.size());
     if (update_every_ <= 0) last = batch_file_names_.size();  // offline algorighm
     for (; current_ < last; current_++)
       args->add_batch_filename(batch_file_names_[current_]);


### PR DESCRIPTION
This patch aims to eliminate most of the `int` <-> `unsigned` comparisons used in `for` loops.

The CMake build system of the project is configured in a way `-Wall` is enabled and hence I expect the warnings to be informative and to show real issues connected with the written code, eliminating "junk" warnings (like described comparisons) seems quite reasonable for me.

Even though Google Code Style [is against using `unsigned` type](https://google.github.io/styleguide/cppguide.html#Integer_Types), it is widely used in many Google's projects. IMO there's nothing bad in using `unsigned`.

Plus, two warnings generated for `case` blocks not handling every item of given `enum` were eliminated via adding `default:`.