### PR TITLE
Remove unnecessary commands in Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,13 @@ install:
   - ./codestyle_checks.sh
   - mkdir build
   - pushd build && cmake .. && make && file ./src/bigartm/bigartm && popd
-  - cp build/3rdparty/protobuf-cmake/protoc/protoc 3rdparty/protobuf/src/
-  - pushd 3rdparty/protobuf/python && python setup.py build && python setup.py install && popd
+  - pushd 3rdparty/protobuf/python && python setup.py install && popd
   - pushd python && python setup.py install && popd
 
 before_script:
   - pushd python/tests/wrapper && ./download_datasets.sh && popd
 
 script:
-  - export PYTHONPATH=`pwd`/python:$PYTHONPATH
   - export ARTM_SHARED_LIBRARY=`pwd`/build/src/artm/libartm.so
   - pushd build/src/artm_tests && ./artm_tests && popd
   - pushd python/tests/wrapper && py.test && popd


### PR DESCRIPTION
1) Now PYTHONPATH variable is unnecessary.
2) python setup.py build for 3rdparty/protobuf/python and copying protoc executable are performed during `make`.