### PR TITLE
Allow empty Batch.token

### DIFF
--- a/src/artm/core/check_messages.h
+++ b/src/artm/core/check_messages.h
@@ -167,7 +167,13 @@ inline std::string DescribeErrors(const ::artm::Batch& message) {
     return ss.str();
   }
 
-  if (message.class_id_size() != message.token_size()) {
+  const bool has_tokens = (message.token_size() > 0);
+  if (!has_tokens && (message.class_id_size() > 0)) {
+    ss << "Empty Batch.token require that Batch.class_id must also be empty, batch.id = " << message.id();
+    return ss.str();
+  }
+
+  if (has_tokens && (message.class_id_size() != message.token_size())) {
     ss << "Length mismatch in fields Batch.class_id and Batch.token, batch.id = " << message.id();
     return ss.str();
   }
@@ -184,9 +190,9 @@ inline std::string DescribeErrors(const ::artm::Batch& message) {
         break;
       }
 
-      for (int token_index = 0; token_index < field.token_count_size(); token_index++) {
+      for (int token_index = 0; token_index < field.token_id_size(); token_index++) {
         int token_id = field.token_id(token_index);
-        if (token_id < 0 || token_id >= message.token_size()) {
+        if ((token_id < 0) || (has_tokens && (token_id >= message.token_size()))) {
           ss << "Value " << token_id << " in Batch.Item(" << item_id
              << ").token_id is negative or exceeds Batch.token_size";
           return ss.str();

--- a/src/artm/core/dictionary.cc
+++ b/src/artm/core/dictionary.cc
@@ -196,6 +196,10 @@ Dictionary::Gather(const GatherDictionaryArgs& args) {
         continue;
     }
 
+    if (batch_ptr->token_size() == 0)
+      BOOST_THROW_EXCEPTION(InvalidOperation(
+        "Dictionary::Gather() can not process batches with empty Batch.token field."));
+
     const Batch& batch = *batch_ptr;
 
     std::vector<float> token_df(batch.token_size(), 0);

--- a/src/artm/core/helpers.cc
+++ b/src/artm/core/helpers.cc
@@ -151,6 +151,11 @@ boost::uuids::uuid BatchHelpers::SaveBatch(const Batch& batch,
 }
 
 void BatchHelpers::CompactBatch(const Batch& batch, Batch* compacted_batch) {
+  if (batch.token_size() == 0) {
+    compacted_batch->CopyFrom(batch);
+    return;
+  }
+
   if (batch.has_description()) compacted_batch->set_description(batch.description());
   if (batch.has_id()) compacted_batch->set_id(batch.id());
 


### PR DESCRIPTION
In some scenarios users have a global dictionary at the point where they generate batches. The don't want to replicate the global dictionary across all batches, nor they would like to write code that find a set of all distinct tokens present in the batch and re-index them according to batch dictionary. Ideally the users would like to put token IDs from the global dictionary into `Batch.Item.Field.token_id`, and keep field Batch.token empty. Then the global dictionary can be deployed via ArtmCreateDictionary / ArtmInitializeModel, and BigARTM should treat all batches as if their `Batch.token` field matches with `DictionaryData.token`.

Such batches will have limited usage (for example they must be rejected in ArtmGatherDictionary operation). The fix does some cheating - whenever it sees an empty `Batch.token` it populates it with the entire dictionary. This is not good for performance, but we will improve this later after cleaning up the code in ``processor.cc``.