### PR TITLE
[cleanup] remove loop variables used as const refernces

### DIFF
--- a/src/artm/core/dense_phi_matrix.cc
+++ b/src/artm/core/dense_phi_matrix.cc
@@ -94,7 +94,7 @@ const Token& PhiMatrixFrame::token(int index) const {
 
 google::protobuf::RepeatedPtrField<std::string> PhiMatrixFrame::topic_name() const {
   google::protobuf::RepeatedPtrField<std::string> topic_name;
-  for (auto elem : topic_name_) {
+  for (const auto& elem : topic_name_) {
     std::string* name = topic_name.Add();
     *name = elem;
   }

--- a/src/artm/core/helpers.cc
+++ b/src/artm/core/helpers.cc
@@ -324,7 +324,7 @@ bool BatchHelpers::PopulateThetaMatrixFromCacheEntry(
     theta_matrix->set_model_name(args_model_name);
     theta_matrix->set_topics_count(result_topic_name.size());
     assert(theta_matrix->topic_name_size() == 0);
-    for (TopicName topic_name : result_topic_name)
+    for (const TopicName& topic_name : result_topic_name)
       theta_matrix->add_topic_name(topic_name);
   } else {
     // Verify

--- a/src/artm/core/master_component.cc
+++ b/src/artm/core/master_component.cc
@@ -79,7 +79,7 @@ void MasterComponent::CreateOrReconfigureMasterComponent(const MasterModelConfig
 
   if (reconfigure) {  // remove all regularizers
     auto regularizers_list = instance_->schema()->regularizers_list();
-    for (auto name : *regularizers_list)
+    for (const auto& name : *regularizers_list)
       instance_->DisposeRegularizer(name);
   }
 

--- a/src/artm/core/phi_matrix_operations.cc
+++ b/src/artm/core/phi_matrix_operations.cc
@@ -294,7 +294,7 @@ void PhiMatrixOperations::InvokePhiRegularizers(
         std::vector<core::ClassId> class_ids;
         if (regularizer->class_ids_to_regularize().size() > 0) {
           auto class_ids_to_regularize = regularizer->class_ids_to_regularize();
-          for (auto class_id : class_ids_to_regularize) class_ids.push_back(class_id);
+          for (const auto& class_id : class_ids_to_regularize) class_ids.push_back(class_id);
         } else {
           boost::copy(n_t_all | boost::adaptors::map_keys, std::back_inserter(class_ids));
         }
@@ -304,7 +304,7 @@ void PhiMatrixOperations::InvokePhiRegularizers(
         else
           topics_to_regularize.assign(topic_size, true);
 
-        for (auto class_id : class_ids) {
+        for (const auto& class_id : class_ids) {
           auto iter = n_t_all.find(class_id);
           if (iter != n_t_all.end()) {
             double n = 0.0;


### PR DESCRIPTION
This basic patch introduces few fixes to slightly improve performance and remove redundant copying in for loops where const references can be used.