### PR TITLE
fixed Matrix constructor-related issue

### DIFF
--- a/src/artm/cpp_interface.cc
+++ b/src/artm/cpp_interface.cc
@@ -281,7 +281,7 @@ void MasterModel::DisposeBatch(const std::string& batch_name) {
 Matrix::Matrix() : no_rows_(0), no_columns_(0), data_() {
 }
 
-Matrix::Matrix(int no_rows = 0, int no_columns = 0) : no_rows_(no_rows), no_columns_(no_columns), data_() {
+Matrix::Matrix(int no_rows, int no_columns) : no_rows_(no_rows), no_columns_(no_columns), data_() {
   if (no_rows <= 0 || no_columns <= 0)
     throw ArgumentOutOfRangeException("no_rows and no_columns must be positive");
 


### PR DESCRIPTION
I'm not sure why that gets compiled with gcc and whatever other compilers are used, but Clang surely won't compile this and this actually seems wrong for me.

Clang does output the following diagnostics for this error:

```
error: addition of default argument on redeclaration makes this constructor a default constructor
```

This makes sense if you think about it: which constructor is intended to be called when no arguments are provided?