### PR TITLE
Score tracker

### DIFF
--- a/python/artm/model.py
+++ b/python/artm/model.py
@@ -763,6 +763,11 @@ class ARTM(object):
                                      index=use_topic_names)
         return theta_data_frame
 
+    def remove_theta(self):
+        """ARTM.remove_theta() --- removes cached theta matrix
+        """
+        self.master.clear_theta_cache()
+
     def fit_transform(self, topic_names=None):
         """ARTM.fit_transform() --- obsolete way of theta retrieval.
         Use get_theta instead.

--- a/python/artm/wrapper/messages_pb2.py
+++ b/python/artm/wrapper/messages_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import descriptor_pb2
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='artm/messages.proto',
   package='artm',
-  serialized_pb='\n\x13\x61rtm/messages.proto\x12\x04\x61rtm\" \n\x0b\x44oubleArray\x12\x11\n\x05value\x18\x01 \x03(\x01\x42\x02\x10\x01\"\x1f\n\nFloatArray\x12\x11\n\x05value\x18\x01 \x03(\x02\x42\x02\x10\x01\"\x1e\n\tBoolArray\x12\x11\n\x05value\x18\x01 \x03(\x08\x42\x02\x10\x01\"\x1d\n\x08IntArray\x12\x11\n\x05value\x18\x01 \x03(\x05\x42\x02\x10\x01\"\x1c\n\x0bStringArray\x12\r\n\x05value\x18\x01 \x03(\t\"=\n\x04Item\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x05\x66ield\x18\x02 \x03(\x0b\x32\x0b.artm.Field\x12\r\n\x05title\x18\x03 \x01(\t\"\x95\x02\n\x05\x46ield\x12\x13\n\x04name\x18\x01 \x01(\t:\x05@body\x12\x10\n\x08token_id\x18\x02 \x03(\x05\x12\x13\n\x0btoken_count\x18\x03 \x03(\x05\x12\x14\n\x0ctoken_offset\x18\x04 \x03(\x05\x12\x14\n\x0cstring_value\x18\x05 \x01(\t\x12\x11\n\tint_value\x18\x06 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x07 \x01(\x01\x12\x12\n\ndate_value\x18\x08 \x01(\t\x12\x14\n\x0cstring_array\x18\x10 \x03(\t\x12\x11\n\tint_array\x18\x11 \x03(\x03\x12\x14\n\x0c\x64ouble_array\x18\x12 \x03(\x01\x12\x12\n\ndate_array\x18\x13 \x03(\t\x12\x14\n\x0ctoken_weight\x18\x14 \x03(\x02\"c\n\x05\x42\x61tch\x12\r\n\x05token\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x18\n\x04item\x18\x03 \x03(\x0b\x32\n.artm.Item\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\"\x93\x01\n\x06Stream\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x11.artm.Stream.Type:\x06Global\x12\x15\n\x04name\x18\x02 \x01(\t:\x07@global\x12\x0f\n\x07modulus\x18\x03 \x01(\x05\x12\x11\n\tresiduals\x18\x04 \x03(\x05\"%\n\x04Type\x12\n\n\x06Global\x10\x00\x12\x11\n\rItemIdModulus\x10\x01\"\xad\x02\n\x15MasterComponentConfig\x12\x11\n\tdisk_path\x18\x02 \x01(\t\x12\x1c\n\x06stream\x18\x03 \x03(\x0b\x32\x0c.artm.Stream\x12\x1d\n\x0f\x63ompact_batches\x18\x04 \x01(\x08:\x04true\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10processors_count\x18\x06 \x01(\x05\x12$\n\x18processor_queue_max_size\x18\x07 \x01(\x05:\x02\x31\x30\x12\'\n\x0cscore_config\x18\t \x03(\x0b\x32\x11.artm.ScoreConfig\x12&\n\x17online_batch_processing\x18\r \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x64isk_cache_path\x18\x0f \x01(\t\"d\n\x13RegularizerSettings\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03tau\x18\x02 \x01(\x01\x12#\n\x1buse_relative_regularization\x18\x03 \x01(\x08\x12\r\n\x05gamma\x18\x04 \x01(\x01\"\x9b\x04\n\x0bModelConfig\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x18\n\x0ctopics_count\x18\x02 \x01(\x05:\x02\x33\x32\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x15\n\x07\x65nabled\x18\x04 \x01(\x08:\x04true\x12\"\n\x16inner_iterations_count\x18\x05 \x01(\x05:\x02\x31\x30\x12\x19\n\nfield_name\x18\x06 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x07 \x01(\t:\x07@global\x12\x12\n\nscore_name\x18\x08 \x03(\t\x12\x1a\n\x0breuse_theta\x18\t \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10regularizer_name\x18\n \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x0b \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x0c \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\r \x03(\x02\x12\x1c\n\x0euse_sparse_bow\x18\x0e \x01(\x08:\x04true\x12\x1f\n\x10use_random_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\x12\x1c\n\x0euse_new_tokens\x18\x10 \x01(\x08:\x04true\x12\x19\n\x0bopt_for_avx\x18\x11 \x01(\x08:\x04true\x12\x37\n\x14regularizer_settings\x18\x12 \x03(\x0b\x32\x19.artm.RegularizerSettings\x12\x18\n\x10predict_class_id\x18\x14 \x01(\t\"\xc0\x02\n\x11RegularizerConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\x04type\x18\x02 \x01(\x0e\x32\x1c.artm.RegularizerConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\x12\x0b\n\x03tau\x18\x04 \x01(\x02\"\xd3\x01\n\x04Type\x12\x15\n\x11SmoothSparseTheta\x10\x00\x12\x13\n\x0fSmoothSparsePhi\x10\x01\x12\x13\n\x0f\x44\x65\x63orrelatorPhi\x10\x02\x12\x14\n\x10MultiLanguagePhi\x10\x03\x12\x1a\n\x16LabelRegularizationPhi\x10\x04\x12\x16\n\x12SpecifiedSparsePhi\x10\x05\x12\x17\n\x13ImproveCoherencePhi\x10\x06\x12\x0e\n\nSmoothPtdw\x10\x07\x12\x17\n\x13TopicSelectionTheta\x10\x08\"r\n\x17SmoothSparseThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x12\n\nalpha_iter\x18\x02 \x03(\x02\x12/\n\x10transform_config\x18\x03 \x01(\x0b\x32\x15.artm.TransformConfig\"\x87\x01\n\x15SmoothSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\x12/\n\x10transform_config\x18\x04 \x01(\x0b\x32\x15.artm.TransformConfig\"=\n\x15\x44\x65\x63orrelatorPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\"\x18\n\x16MultiLanguagePhiConfig\"]\n\x1cLabelRegularizationPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x82\x02\n\x18SpecifiedSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x1e\n\x12max_elements_count\x18\x03 \x01(\x05:\x02\x32\x30\x12#\n\x15probability_threshold\x18\x04 \x01(\x02:\x04\x30.99\x12?\n\x04mode\x18\x05 \x01(\x0e\x32#.artm.SpecifiedSparsePhiConfig.Mode:\x0cSparseTopics\"*\n\x04Mode\x12\x10\n\x0cSparseTopics\x10\x00\x12\x10\n\x0cSparseTokens\x10\x01\"Z\n\x19ImproveCoherencePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\xa4\x01\n\x10SmoothPtdwConfig\x12\x38\n\x04type\x18\x01 \x01(\x0e\x32\x1b.artm.SmoothPtdwConfig.Type:\rMovingAverage\x12\x12\n\x06window\x18\x03 \x01(\x05:\x02\x31\x30\x12\x14\n\tthreshold\x18\x04 \x01(\x01:\x01\x31\",\n\x04Type\x12\x11\n\rMovingAverage\x10\x01\x12\x11\n\rMovingProduct\x10\x02\"X\n\x19TopicSelectionThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x13\n\x0btopic_value\x18\x02 \x03(\x02\x12\x12\n\nalpha_iter\x18\x03 \x03(\x02\"\xb2\x01\n\x0fTransformConfig\x12\x45\n\x0etransform_type\x18\x01 \x01(\x0e\x32#.artm.TransformConfig.TransformType:\x08\x43onstant\x12\x0c\n\x01n\x18\x02 \x01(\x01:\x01\x31\x12\x0c\n\x01\x61\x18\x03 \x01(\x01:\x01\x31\"<\n\rTransformType\x12\r\n\tLogarithm\x10\x00\x12\x0e\n\nPolynomial\x10\x01\x12\x0c\n\x08\x43onstant\x10\x02\"\x8a\x02\n\x0bScoreConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x04type\x18\x02 \x01(\x0e\x32\x16.artm.ScoreConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\xb6\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\x12\x12\n\x0e\x43lassPrecision\x10\x08\x12\x0e\n\nPeakMemory\x10\t\"\x84\x02\n\tScoreData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x04type\x18\x02 \x01(\x0e\x32\x14.artm.ScoreData.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\xb6\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\x12\x12\n\x0e\x43lassPrecision\x10\x08\x12\x0e\n\nPeakMemory\x10\t\"\xcc\x02\n\x15PerplexityScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12J\n\nmodel_type\x18\x03 \x01(\x0e\x32 .artm.PerplexityScoreConfig.Type:\x14UnigramDocumentModel\x12\x17\n\x0f\x64ictionary_name\x18\x04 \x01(\t\x12\"\n\x12theta_sparsity_eps\x18\x05 \x01(\x02:\x06\x31\x65-037\x12!\n\x19theta_sparsity_topic_name\x18\x06 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x07 \x03(\t\"<\n\x04Type\x12\x18\n\x14UnigramDocumentModel\x10\x00\x12\x1a\n\x16UnigramCollectionModel\x10\x01\"\xbc\x01\n\x0fPerplexityScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x0b\n\x03raw\x18\x02 \x01(\x01\x12\x12\n\nnormalizer\x18\x03 \x01(\x01\x12\x12\n\nzero_words\x18\x04 \x01(\x03\x12\x1c\n\x14theta_sparsity_value\x18\x05 \x01(\x01\x12\"\n\x1atheta_sparsity_zero_topics\x18\x06 \x01(\x05\x12#\n\x1btheta_sparsity_total_topics\x18\x07 \x01(\x05\"|\n\x18SparsityThetaScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x03\x65ps\x18\x03 \x01(\x02:\x06\x31\x65-037\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"N\n\x12SparsityThetaScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_topics\x18\x02 \x01(\x03\x12\x14\n\x0ctotal_topics\x18\x03 \x01(\x03\"c\n\x16SparsityPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"L\n\x10SparsityPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_tokens\x18\x02 \x01(\x03\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x03\"T\n\x19ItemsProcessedScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\"?\n\x13ItemsProcessedScore\x12\x10\n\x05value\x18\x01 \x01(\x05:\x01\x30\x12\x16\n\x0bnum_batches\x18\x02 \x01(\x05:\x01\x30\"\x8a\x01\n\x14TopTokensScoreConfig\x12\x16\n\nnum_tokens\x18\x01 \x01(\x05:\x02\x31\x30\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x04 \x01(\t\"\xad\x01\n\x0eTopTokensScore\x12\x13\n\x0bnum_entries\x18\x01 \x01(\x05\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_index\x18\x03 \x03(\x05\x12\r\n\x05token\x18\x04 \x03(\t\x12\x0e\n\x06weight\x18\x05 \x03(\x02\x12#\n\tcoherence\x18\x06 \x01(\x0b\x32\x10.artm.FloatArray\x12\x19\n\x11\x61verage_coherence\x18\x07 \x01(\x02\"\x7f\n\x17ThetaSnippetScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x07item_id\x18\x03 \x03(\x05\x42\x02\x10\x01\x12\x16\n\nitem_count\x18\x04 \x01(\x05:\x02\x31\x30\"F\n\x11ThetaSnippetScore\x12\x0f\n\x07item_id\x18\x01 \x03(\x05\x12 \n\x06values\x18\x02 \x03(\x0b\x32\x10.artm.FloatArray\"\xb2\x01\n\x16TopicKernelScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\'\n\x1aprobability_mass_threshold\x18\x04 \x01(\x01:\x03\x30.1\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x05 \x01(\t\"\xff\x02\n\x10TopicKernelScore\x12&\n\x0bkernel_size\x18\x01 \x01(\x0b\x32\x11.artm.DoubleArray\x12(\n\rkernel_purity\x18\x02 \x01(\x0b\x32\x11.artm.DoubleArray\x12*\n\x0fkernel_contrast\x18\x03 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x1b\n\x13\x61verage_kernel_size\x18\x04 \x01(\x01\x12\x1d\n\x15\x61verage_kernel_purity\x18\x05 \x01(\x01\x12\x1f\n\x17\x61verage_kernel_contrast\x18\x06 \x01(\x01\x12$\n\tcoherence\x18\x07 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x19\n\x11\x61verage_coherence\x18\x08 \x01(\x02\x12(\n\rkernel_tokens\x18\t \x03(\x0b\x32\x11.artm.StringArray\x12%\n\ntopic_name\x18\n \x01(\x0b\x32\x11.artm.StringArray\"d\n\x17TopicMassPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"_\n\x11TopicMassPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_ratio\x18\x03 \x03(\x01\x12\x12\n\ntopic_mass\x18\x04 \x03(\x01\"9\n\x19\x43lassPrecisionScoreConfig\x12\x1c\n\x0bstream_name\x18\x01 \x01(\t:\x07@global\"B\n\x13\x43lassPrecisionScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\r\n\x05\x65rror\x18\x02 \x01(\x01\x12\r\n\x05total\x18\x03 \x01(\x01\"\x17\n\x15PeakMemoryScoreConfig\" \n\x0fPeakMemoryScore\x12\r\n\x05value\x18\x01 \x01(\x03\"\xa2\x03\n\nTopicModel\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x14\n\x0ctopics_count\x18\x02 \x01(\x05\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\r\n\x05token\x18\x04 \x03(\t\x12\'\n\rtoken_weights\x18\x05 \x03(\x0b\x32\x10.artm.FloatArray\x12\x10\n\x08\x63lass_id\x18\x06 \x03(\t\x12\x11\n\tinternals\x18\x07 \x01(\x0c\x12#\n\x0btopic_index\x18\x08 \x03(\x0b\x32\x0e.artm.IntArray\x12\x36\n\x0eoperation_type\x18\t \x03(\x0e\x32\x1e.artm.TopicModel.OperationType\x12\x0c\n\x04seed\x18\n \x01(\x05\x1a\x35\n\x13TopicModelInternals\x12\x1e\n\x04n_wt\x18\x01 \x03(\x0b\x32\x10.artm.FloatArray\"U\n\rOperationType\x12\x0e\n\nInitialize\x10\x00\x12\r\n\tIncrement\x10\x01\x12\r\n\tOverwrite\x10\x02\x12\n\n\x06Remove\x10\x03\x12\n\n\x06Ignore\x10\x04\"\xa9\x01\n\x0bThetaMatrix\x12\x0f\n\x07item_id\x18\x02 \x03(\x05\x12&\n\x0citem_weights\x18\x03 \x03(\x0b\x32\x10.artm.FloatArray\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x14\n\x0ctopics_count\x18\x05 \x01(\x05\x12\x12\n\nitem_title\x18\x06 \x03(\t\x12#\n\x0btopic_index\x18\x07 \x03(\x0b\x32\x0e.artm.IntArray\"\x8c\x04\n\x16\x43ollectionParserConfig\x12\x42\n\x06\x66ormat\x18\x01 \x01(\x0e\x32#.artm.CollectionParserConfig.Format:\rBagOfWordsUci\x12\x19\n\x11\x64ocword_file_path\x18\x02 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x03 \x01(\t\x12\x15\n\rtarget_folder\x18\x04 \x01(\t\x12!\n\x13num_items_per_batch\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12%\n\x17use_unity_based_indices\x18\x06 \x01(\x08:\x04true\x12>\n\tname_type\x18\x07 \x01(\x0e\x32%.artm.CollectionParserConfig.NameType:\x04Guid\x12\x1a\n\x12\x63ooccurrence_token\x18\x08 \x03(\t\x12\x13\n\x0bgather_cooc\x18\t \x01(\x08\x12\x1d\n\x15\x63ooccurrence_class_id\x18\n \x03(\t\x12(\n\x19use_symmetric_cooc_values\x18\x0b \x01(\x08:\x05\x66\x61lse\"?\n\x06\x46ormat\x12\x11\n\rBagOfWordsUci\x10\x00\x12\x10\n\x0cMatrixMarket\x10\x01\x12\x10\n\x0cVowpalWabbit\x10\x02\"\x1e\n\x08NameType\x12\x08\n\x04Guid\x10\x00\x12\x08\n\x04\x43ode\x10\x01\"\xe9\x03\n\x13InitializeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x10\n\x04seed\x18\x05 \x01(\x05:\x02-1\x12\x39\n\x0bsource_type\x18\x06 \x01(\x0e\x32$.artm.InitializeModelArgs.SourceType\x12\x11\n\tdisk_path\x18\x07 \x01(\t\x12\x30\n\x06\x66ilter\x18\x08 \x03(\x0b\x32 .artm.InitializeModelArgs.Filter\x12\x16\n\x0e\x62\x61tch_filename\x18\t \x03(\t\x1a\xa5\x01\n\x06\x46ilter\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\t\x12\x16\n\x0emin_percentage\x18\x02 \x01(\x02\x12\x16\n\x0emax_percentage\x18\x03 \x01(\x02\x12\x11\n\tmin_items\x18\x04 \x01(\x05\x12\x11\n\tmax_items\x18\x05 \x01(\x05\x12\x17\n\x0fmin_total_count\x18\x06 \x01(\x05\x12\x1a\n\x12min_one_item_count\x18\x07 \x01(\x05\")\n\nSourceType\x12\x0e\n\nDictionary\x10\x00\x12\x0b\n\x07\x42\x61tches\x10\x01\"\xc1\x01\n\x0e\x44ictionaryData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05token\x18\x02 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x03 \x03(\t\x12\x13\n\x0btoken_value\x18\x04 \x03(\x02\x12\x10\n\x08token_tf\x18\x05 \x03(\x02\x12\x10\n\x08token_df\x18\x06 \x03(\x02\x12\x18\n\x10\x63ooc_first_index\x18\x07 \x03(\x05\x12\x19\n\x11\x63ooc_second_index\x18\x08 \x03(\x05\x12\x12\n\ncooc_value\x18\t \x03(\x02\"\xcb\x01\n\x14\x46ilterDictionaryArgs\x12\x17\n\x0f\x64ictionary_name\x18\x01 \x01(\t\x12\x1e\n\x16\x64ictionary_target_name\x18\x02 \x01(\t\x12\x10\n\x08\x63lass_id\x18\x03 \x01(\t\x12\x0e\n\x06min_df\x18\x04 \x01(\x02\x12\x0e\n\x06max_df\x18\x05 \x01(\x02\x12\x13\n\x0bmin_df_rate\x18\x06 \x01(\x02\x12\x13\n\x0bmax_df_rate\x18\x07 \x01(\x02\x12\x0e\n\x06min_tf\x18\x08 \x01(\x02\x12\x0e\n\x06max_tf\x18\t \x01(\x02\"\xb4\x01\n\x14GatherDictionaryArgs\x12\x1e\n\x16\x64ictionary_target_name\x18\x01 \x01(\t\x12\x11\n\tdata_path\x18\x02 \x01(\t\x12\x16\n\x0e\x63ooc_file_path\x18\x03 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x04 \x01(\t\x12$\n\x15symmetric_cooc_values\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x12\n\nbatch_path\x18\x06 \x03(\t\",\n\x11GetDictionaryArgs\x12\x17\n\x0f\x64ictionary_name\x18\x01 \x01(\t\"\xf4\x02\n\x11GetTopicModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\r\n\x05token\x18\x03 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x03(\t\x12\x19\n\x11use_sparse_format\x18\x05 \x01(\x08\x12\x13\n\x03\x65ps\x18\x06 \x01(\x02:\x06\x31\x65-037\x12>\n\x0crequest_type\x18\x07 \x01(\x0e\x32#.artm.GetTopicModelArgs.RequestType:\x03Pwt\x12\x42\n\rmatrix_layout\x18\x08 \x01(\x0e\x32$.artm.GetTopicModelArgs.MatrixLayout:\x05\x44\x65nse\";\n\x0bRequestType\x12\x07\n\x03Pwt\x10\x00\x12\x07\n\x03Nwt\x10\x01\x12\x0e\n\nTopicNames\x10\x02\x12\n\n\x06Tokens\x10\x03\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"\xf5\x01\n\x12GetThetaMatrixArgs\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x13\n\x0btopic_index\x18\x04 \x03(\x05\x12\x1a\n\x0b\x63lean_cache\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x19\n\x11use_sparse_format\x18\x06 \x01(\x08\x12\x13\n\x03\x65ps\x18\x07 \x01(\x02:\x06\x31\x65-037\x12\x43\n\rmatrix_layout\x18\x08 \x01(\x0e\x32%.artm.GetThetaMatrixArgs.MatrixLayout:\x05\x44\x65nse\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\";\n\x11GetScoreValueArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\nscore_name\x18\x02 \x01(\t\"8\n\x0f\x45xportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"8\n\x0fImportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"%\n\x0f\x41ttachModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\"\xc6\x04\n\x12ProcessBatchesArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12\x17\n\x0fpwt_source_name\x18\x03 \x01(\t\x12\"\n\x16inner_iterations_count\x18\x04 \x01(\x05:\x02\x31\x30\x12\x1c\n\x0bstream_name\x18\x05 \x01(\t:\x07@global\x12\x18\n\x10regularizer_name\x18\x06 \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x07 \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x08 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\t \x03(\x02\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12J\n\x11theta_matrix_type\x18\x0e \x01(\x0e\x32(.artm.ProcessBatchesArgs.ThetaMatrixType:\x05\x43\x61\x63he\x12\x14\n\x0c\x62\x61tch_weight\x18\x0f \x03(\x02\x12\x18\n\x10predict_class_id\x18\x11 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x12 \x03(\x0b\x32\x0b.artm.Batch\"\\\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\x12\r\n\tDensePtdw\x10\x04\x12\x0e\n\nSparsePtdw\x10\x05\"d\n\x14ProcessBatchesResult\x12#\n\nscore_data\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\x12\'\n\x0ctheta_matrix\x18\x02 \x01(\x0b\x32\x11.artm.ThetaMatrix\"m\n\x0eMergeModelArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x03(\t\x12\x15\n\rsource_weight\x18\x03 \x03(\x02\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"\x99\x01\n\x13RegularizeModelArgs\x12\x17\n\x0frwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fpwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x03 \x01(\t\x12\x37\n\x14regularizer_settings\x18\x04 \x03(\x0b\x32\x19.artm.RegularizerSettings\"_\n\x12NormalizeModelArgs\x12\x17\n\x0fpwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0frwt_source_name\x18\x03 \x01(\t\"B\n\x14ImportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"B\n\x14\x45xportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"\xc1\x01\n\x15\x43opyRequestResultArgs\x12Q\n\x0crequest_type\x18\x01 \x01(\x0e\x32\'.artm.CopyRequestResultArgs.RequestType:\x12\x44\x65\x66\x61ultRequestType\"U\n\x0bRequestType\x12\x16\n\x12\x44\x65\x66\x61ultRequestType\x10\x00\x12\x16\n\x12GetThetaSecondPass\x10\x01\x12\x16\n\x12GetModelSecondPass\x10\x02\"\x1e\n\x1c\x44uplicateMasterComponentArgs\"\x1c\n\x1aGetMasterComponentInfoArgs\"\xa6\x06\n\x13MasterComponentInfo\x12\x11\n\tmaster_id\x18\x01 \x01(\x05\x12+\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x1b.artm.MasterComponentConfig\x12>\n\x0bregularizer\x18\x03 \x03(\x0b\x32).artm.MasterComponentInfo.RegularizerInfo\x12\x32\n\x05score\x18\x04 \x03(\x0b\x32#.artm.MasterComponentInfo.ScoreInfo\x12<\n\ndictionary\x18\x05 \x03(\x0b\x32(.artm.MasterComponentInfo.DictionaryInfo\x12\x32\n\x05model\x18\x06 \x03(\x0b\x32#.artm.MasterComponentInfo.ModelInfo\x12=\n\x0b\x63\x61\x63he_entry\x18\x07 \x03(\x0b\x32(.artm.MasterComponentInfo.CacheEntryInfo\x12\x1c\n\x14processor_queue_size\x18\t \x01(\x05\x12\x32\n\x05\x62\x61tch\x18\n \x03(\x0b\x32#.artm.MasterComponentInfo.BatchInfo\x1a-\n\x0fRegularizerInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\'\n\tScoreInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\x35\n\x0e\x44ictionaryInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rentries_count\x18\x02 \x01(\x03\x1a\x43\n\tBatchInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0bitems_count\x18\x02 \x01(\x05\x12\x13\n\x0btoken_count\x18\x03 \x01(\x05\x1aR\n\tModelInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x13\n\x0btoken_count\x18\x04 \x01(\x05\x1a\x30\n\x0e\x43\x61\x63heEntryInfo\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tbyte_size\x18\x02 \x01(\x05\"C\n\x11ImportBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x03(\x0b\x32\x0b.artm.Batch\"6\n\x12\x41waitOperationArgs\x12 \n\x14timeout_milliseconds\x18\x01 \x01(\x05:\x02-1\"\x96\x03\n\x11MasterModelConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\x03 \x03(\x02\x12\'\n\x0cscore_config\x18\x04 \x03(\x0b\x32\x11.artm.ScoreConfig\x12\x33\n\x12regularizer_config\x18\x05 \x03(\x0b\x32\x17.artm.RegularizerConfig\x12\x0f\n\x07threads\x18\x06 \x01(\x05\x12\x15\n\x08pwt_name\x18\x07 \x01(\t:\x03pwt\x12\x15\n\x08nwt_name\x18\x08 \x01(\t:\x03nwt\x12\x1e\n\x16inner_iterations_count\x18\t \x01(\x05\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12\x17\n\x0f\x64isk_cache_path\x18\r \x01(\t\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\"r\n\x19\x46itOfflineMasterModelArgs\x12\x16\n\x0e\x62\x61tch_filename\x18\x01 \x03(\t\x12\x14\n\x0c\x62\x61tch_weight\x18\x02 \x03(\x02\x12\x11\n\x06passes\x18\x03 \x01(\x05:\x01\x31\x12\x14\n\x0c\x62\x61tch_folder\x18\x04 \x01(\t\"\xa0\x01\n\x18\x46itOnlineMasterModelArgs\x12\x16\n\x0e\x62\x61tch_filename\x18\x01 \x03(\t\x12\x14\n\x0c\x62\x61tch_weight\x18\x02 \x03(\x02\x12\x14\n\x0cupdate_after\x18\x03 \x03(\x05\x12\x14\n\x0c\x61pply_weight\x18\x04 \x03(\x02\x12\x14\n\x0c\x64\x65\x63\x61y_weight\x18\x05 \x03(\x02\x12\x14\n\x05\x61sync\x18\x06 \x01(\x08:\x05\x66\x61lse\"\x98\x02\n\x18TransformMasterModelArgs\x12\x1a\n\x05\x62\x61tch\x18\x01 \x03(\x0b\x32\x0b.artm.Batch\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12P\n\x11theta_matrix_type\x18\x03 \x01(\x0e\x32..artm.TransformMasterModelArgs.ThetaMatrixType:\x05\x44\x65nse\x12\x18\n\x10predict_class_id\x18\x04 \x01(\t\"\\\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\x12\r\n\tDensePtdw\x10\x04\x12\x0e\n\nSparsePtdw\x10\x05\"\xff\x01\n\x14\x43onfigureLoggingArgs\x12\x0f\n\x07log_dir\x18\x01 \x01(\t\x12\x13\n\x0bminloglevel\x18\x02 \x01(\x05\x12\x17\n\x0fstderrthreshold\x18\x03 \x01(\x05\x12\x13\n\x0blogtostderr\x18\x04 \x01(\x08\x12\x18\n\x10\x63olorlogtostderr\x18\x05 \x01(\x08\x12\x17\n\x0f\x61lsologtostderr\x18\x06 \x01(\x08\x12\x12\n\nlogbufsecs\x18\x07 \x01(\x05\x12\x13\n\x0blogbuflevel\x18\x08 \x01(\x05\x12\x14\n\x0cmax_log_size\x18\t \x01(\x05\x12!\n\x19stop_logging_if_full_disk\x18\n \x01(\x08\"\x15\n\x13\x43learThetaCacheArgs\"\x15\n\x13\x43learScoreCacheArgs')
+  serialized_pb='\n\x13\x61rtm/messages.proto\x12\x04\x61rtm\" \n\x0b\x44oubleArray\x12\x11\n\x05value\x18\x01 \x03(\x01\x42\x02\x10\x01\"\x1f\n\nFloatArray\x12\x11\n\x05value\x18\x01 \x03(\x02\x42\x02\x10\x01\"\x1e\n\tBoolArray\x12\x11\n\x05value\x18\x01 \x03(\x08\x42\x02\x10\x01\"\x1d\n\x08IntArray\x12\x11\n\x05value\x18\x01 \x03(\x05\x42\x02\x10\x01\"\x1c\n\x0bStringArray\x12\r\n\x05value\x18\x01 \x03(\t\"=\n\x04Item\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x05\x66ield\x18\x02 \x03(\x0b\x32\x0b.artm.Field\x12\r\n\x05title\x18\x03 \x01(\t\"\x95\x02\n\x05\x46ield\x12\x13\n\x04name\x18\x01 \x01(\t:\x05@body\x12\x10\n\x08token_id\x18\x02 \x03(\x05\x12\x13\n\x0btoken_count\x18\x03 \x03(\x05\x12\x14\n\x0ctoken_offset\x18\x04 \x03(\x05\x12\x14\n\x0cstring_value\x18\x05 \x01(\t\x12\x11\n\tint_value\x18\x06 \x01(\x03\x12\x14\n\x0c\x64ouble_value\x18\x07 \x01(\x01\x12\x12\n\ndate_value\x18\x08 \x01(\t\x12\x14\n\x0cstring_array\x18\x10 \x03(\t\x12\x11\n\tint_array\x18\x11 \x03(\x03\x12\x14\n\x0c\x64ouble_array\x18\x12 \x03(\x01\x12\x12\n\ndate_array\x18\x13 \x03(\t\x12\x14\n\x0ctoken_weight\x18\x14 \x03(\x02\"c\n\x05\x42\x61tch\x12\r\n\x05token\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x18\n\x04item\x18\x03 \x03(\x0b\x32\n.artm.Item\x12\x13\n\x0b\x64\x65scription\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\"\x93\x01\n\x06Stream\x12\'\n\x04type\x18\x01 \x01(\x0e\x32\x11.artm.Stream.Type:\x06Global\x12\x15\n\x04name\x18\x02 \x01(\t:\x07@global\x12\x0f\n\x07modulus\x18\x03 \x01(\x05\x12\x11\n\tresiduals\x18\x04 \x03(\x05\"%\n\x04Type\x12\n\n\x06Global\x10\x00\x12\x11\n\rItemIdModulus\x10\x01\"\xad\x02\n\x15MasterComponentConfig\x12\x11\n\tdisk_path\x18\x02 \x01(\t\x12\x1c\n\x06stream\x18\x03 \x03(\x0b\x32\x0c.artm.Stream\x12\x1d\n\x0f\x63ompact_batches\x18\x04 \x01(\x08:\x04true\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10processors_count\x18\x06 \x01(\x05\x12$\n\x18processor_queue_max_size\x18\x07 \x01(\x05:\x02\x31\x30\x12\'\n\x0cscore_config\x18\t \x03(\x0b\x32\x11.artm.ScoreConfig\x12&\n\x17online_batch_processing\x18\r \x01(\x08:\x05\x66\x61lse\x12\x17\n\x0f\x64isk_cache_path\x18\x0f \x01(\t\"d\n\x13RegularizerSettings\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03tau\x18\x02 \x01(\x01\x12#\n\x1buse_relative_regularization\x18\x03 \x01(\x08\x12\r\n\x05gamma\x18\x04 \x01(\x01\"\x9b\x04\n\x0bModelConfig\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x18\n\x0ctopics_count\x18\x02 \x01(\x05:\x02\x33\x32\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x15\n\x07\x65nabled\x18\x04 \x01(\x08:\x04true\x12\"\n\x16inner_iterations_count\x18\x05 \x01(\x05:\x02\x31\x30\x12\x19\n\nfield_name\x18\x06 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x07 \x01(\t:\x07@global\x12\x12\n\nscore_name\x18\x08 \x03(\t\x12\x1a\n\x0breuse_theta\x18\t \x01(\x08:\x05\x66\x61lse\x12\x18\n\x10regularizer_name\x18\n \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x0b \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x0c \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\r \x03(\x02\x12\x1c\n\x0euse_sparse_bow\x18\x0e \x01(\x08:\x04true\x12\x1f\n\x10use_random_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\x12\x1c\n\x0euse_new_tokens\x18\x10 \x01(\x08:\x04true\x12\x19\n\x0bopt_for_avx\x18\x11 \x01(\x08:\x04true\x12\x37\n\x14regularizer_settings\x18\x12 \x03(\x0b\x32\x19.artm.RegularizerSettings\x12\x18\n\x10predict_class_id\x18\x14 \x01(\t\"\xc0\x02\n\x11RegularizerConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12*\n\x04type\x18\x02 \x01(\x0e\x32\x1c.artm.RegularizerConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\x12\x0b\n\x03tau\x18\x04 \x01(\x02\"\xd3\x01\n\x04Type\x12\x15\n\x11SmoothSparseTheta\x10\x00\x12\x13\n\x0fSmoothSparsePhi\x10\x01\x12\x13\n\x0f\x44\x65\x63orrelatorPhi\x10\x02\x12\x14\n\x10MultiLanguagePhi\x10\x03\x12\x1a\n\x16LabelRegularizationPhi\x10\x04\x12\x16\n\x12SpecifiedSparsePhi\x10\x05\x12\x17\n\x13ImproveCoherencePhi\x10\x06\x12\x0e\n\nSmoothPtdw\x10\x07\x12\x17\n\x13TopicSelectionTheta\x10\x08\"r\n\x17SmoothSparseThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x12\n\nalpha_iter\x18\x02 \x03(\x02\x12/\n\x10transform_config\x18\x03 \x01(\x0b\x32\x15.artm.TransformConfig\"\x87\x01\n\x15SmoothSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\x12/\n\x10transform_config\x18\x04 \x01(\x0b\x32\x15.artm.TransformConfig\"=\n\x15\x44\x65\x63orrelatorPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\"\x18\n\x16MultiLanguagePhiConfig\"]\n\x1cLabelRegularizationPhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\x82\x02\n\x18SpecifiedSparsePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x1e\n\x12max_elements_count\x18\x03 \x01(\x05:\x02\x32\x30\x12#\n\x15probability_threshold\x18\x04 \x01(\x02:\x04\x30.99\x12?\n\x04mode\x18\x05 \x01(\x0e\x32#.artm.SpecifiedSparsePhiConfig.Mode:\x0cSparseTopics\"*\n\x04Mode\x12\x10\n\x0cSparseTopics\x10\x00\x12\x10\n\x0cSparseTokens\x10\x01\"Z\n\x19ImproveCoherencePhiConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x17\n\x0f\x64ictionary_name\x18\x03 \x01(\t\"\xa4\x01\n\x10SmoothPtdwConfig\x12\x38\n\x04type\x18\x01 \x01(\x0e\x32\x1b.artm.SmoothPtdwConfig.Type:\rMovingAverage\x12\x12\n\x06window\x18\x03 \x01(\x05:\x02\x31\x30\x12\x14\n\tthreshold\x18\x04 \x01(\x01:\x01\x31\",\n\x04Type\x12\x11\n\rMovingAverage\x10\x01\x12\x11\n\rMovingProduct\x10\x02\"X\n\x19TopicSelectionThetaConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x13\n\x0btopic_value\x18\x02 \x03(\x02\x12\x12\n\nalpha_iter\x18\x03 \x03(\x02\"\xb2\x01\n\x0fTransformConfig\x12\x45\n\x0etransform_type\x18\x01 \x01(\x0e\x32#.artm.TransformConfig.TransformType:\x08\x43onstant\x12\x0c\n\x01n\x18\x02 \x01(\x01:\x01\x31\x12\x0c\n\x01\x61\x18\x03 \x01(\x01:\x01\x31\"<\n\rTransformType\x12\r\n\tLogarithm\x10\x00\x12\x0e\n\nPolynomial\x10\x01\x12\x0c\n\x08\x43onstant\x10\x02\"\x8a\x02\n\x0bScoreConfig\x12\x0c\n\x04name\x18\x01 \x01(\t\x12$\n\x04type\x18\x02 \x01(\x0e\x32\x16.artm.ScoreConfig.Type\x12\x0e\n\x06\x63onfig\x18\x03 \x01(\x0c\"\xb6\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\x12\x12\n\x0e\x43lassPrecision\x10\x08\x12\x0e\n\nPeakMemory\x10\t\"\x84\x02\n\tScoreData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\"\n\x04type\x18\x02 \x01(\x0e\x32\x14.artm.ScoreData.Type\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"\xb6\x01\n\x04Type\x12\x0e\n\nPerplexity\x10\x00\x12\x11\n\rSparsityTheta\x10\x01\x12\x0f\n\x0bSparsityPhi\x10\x02\x12\x12\n\x0eItemsProcessed\x10\x03\x12\r\n\tTopTokens\x10\x04\x12\x10\n\x0cThetaSnippet\x10\x05\x12\x0f\n\x0bTopicKernel\x10\x06\x12\x10\n\x0cTopicMassPhi\x10\x07\x12\x12\n\x0e\x43lassPrecision\x10\x08\x12\x0e\n\nPeakMemory\x10\t\"0\n\x0eScoreDataArray\x12\x1e\n\x05score\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\"\xcc\x02\n\x15PerplexityScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12J\n\nmodel_type\x18\x03 \x01(\x0e\x32 .artm.PerplexityScoreConfig.Type:\x14UnigramDocumentModel\x12\x17\n\x0f\x64ictionary_name\x18\x04 \x01(\t\x12\"\n\x12theta_sparsity_eps\x18\x05 \x01(\x02:\x06\x31\x65-037\x12!\n\x19theta_sparsity_topic_name\x18\x06 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x07 \x03(\t\"<\n\x04Type\x12\x18\n\x14UnigramDocumentModel\x10\x00\x12\x1a\n\x16UnigramCollectionModel\x10\x01\"\xbc\x01\n\x0fPerplexityScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x0b\n\x03raw\x18\x02 \x01(\x01\x12\x12\n\nnormalizer\x18\x03 \x01(\x01\x12\x12\n\nzero_words\x18\x04 \x01(\x03\x12\x1c\n\x14theta_sparsity_value\x18\x05 \x01(\x01\x12\"\n\x1atheta_sparsity_zero_topics\x18\x06 \x01(\x05\x12#\n\x1btheta_sparsity_total_topics\x18\x07 \x01(\x05\"|\n\x18SparsityThetaScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x03\x65ps\x18\x03 \x01(\x02:\x06\x31\x65-037\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"N\n\x12SparsityThetaScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_topics\x18\x02 \x01(\x03\x12\x14\n\x0ctotal_topics\x18\x03 \x01(\x03\"c\n\x16SparsityPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"L\n\x10SparsityPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x13\n\x0bzero_tokens\x18\x02 \x01(\x03\x12\x14\n\x0ctotal_tokens\x18\x03 \x01(\x03\"T\n\x19ItemsProcessedScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\"?\n\x13ItemsProcessedScore\x12\x10\n\x05value\x18\x01 \x01(\x05:\x01\x30\x12\x16\n\x0bnum_batches\x18\x02 \x01(\x05:\x01\x30\"\x8a\x01\n\x14TopTokensScoreConfig\x12\x16\n\nnum_tokens\x18\x01 \x01(\x05:\x02\x31\x30\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x04 \x01(\t\"\xad\x01\n\x0eTopTokensScore\x12\x13\n\x0bnum_entries\x18\x01 \x01(\x05\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_index\x18\x03 \x03(\x05\x12\r\n\x05token\x18\x04 \x03(\t\x12\x0e\n\x06weight\x18\x05 \x03(\x02\x12#\n\tcoherence\x18\x06 \x01(\x0b\x32\x10.artm.FloatArray\x12\x19\n\x11\x61verage_coherence\x18\x07 \x01(\x02\"\x7f\n\x17ThetaSnippetScoreConfig\x12\x19\n\nfield_name\x18\x01 \x01(\t:\x05@body\x12\x1c\n\x0bstream_name\x18\x02 \x01(\t:\x07@global\x12\x13\n\x07item_id\x18\x03 \x03(\x05\x42\x02\x10\x01\x12\x16\n\nitem_count\x18\x04 \x01(\x05:\x02\x31\x30\"F\n\x11ThetaSnippetScore\x12\x0f\n\x07item_id\x18\x01 \x03(\x05\x12 \n\x06values\x18\x02 \x03(\x0b\x32\x10.artm.FloatArray\"\xb2\x01\n\x16TopicKernelScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\'\n\x1aprobability_mass_threshold\x18\x04 \x01(\x01:\x03\x30.1\x12$\n\x1c\x63ooccurrence_dictionary_name\x18\x05 \x01(\t\"\xff\x02\n\x10TopicKernelScore\x12&\n\x0bkernel_size\x18\x01 \x01(\x0b\x32\x11.artm.DoubleArray\x12(\n\rkernel_purity\x18\x02 \x01(\x0b\x32\x11.artm.DoubleArray\x12*\n\x0fkernel_contrast\x18\x03 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x1b\n\x13\x61verage_kernel_size\x18\x04 \x01(\x01\x12\x1d\n\x15\x61verage_kernel_purity\x18\x05 \x01(\x01\x12\x1f\n\x17\x61verage_kernel_contrast\x18\x06 \x01(\x01\x12$\n\tcoherence\x18\x07 \x01(\x0b\x32\x11.artm.DoubleArray\x12\x19\n\x11\x61verage_coherence\x18\x08 \x01(\x02\x12(\n\rkernel_tokens\x18\t \x03(\x0b\x32\x11.artm.StringArray\x12%\n\ntopic_name\x18\n \x01(\x0b\x32\x11.artm.StringArray\"d\n\x17TopicMassPhiScoreConfig\x12\x13\n\x03\x65ps\x18\x01 \x01(\x02:\x06\x31\x65-037\x12 \n\x08\x63lass_id\x18\x02 \x01(\t:\x0e@default_class\x12\x12\n\ntopic_name\x18\x03 \x03(\t\"_\n\x11TopicMassPhiScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\x13\n\x0btopic_ratio\x18\x03 \x03(\x01\x12\x12\n\ntopic_mass\x18\x04 \x03(\x01\"9\n\x19\x43lassPrecisionScoreConfig\x12\x1c\n\x0bstream_name\x18\x01 \x01(\t:\x07@global\"B\n\x13\x43lassPrecisionScore\x12\r\n\x05value\x18\x01 \x01(\x01\x12\r\n\x05\x65rror\x18\x02 \x01(\x01\x12\r\n\x05total\x18\x03 \x01(\x01\"\x17\n\x15PeakMemoryScoreConfig\" \n\x0fPeakMemoryScore\x12\r\n\x05value\x18\x01 \x01(\x03\"\xa2\x03\n\nTopicModel\x12\x14\n\x04name\x18\x01 \x01(\t:\x06@model\x12\x14\n\x0ctopics_count\x18\x02 \x01(\x05\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\r\n\x05token\x18\x04 \x03(\t\x12\'\n\rtoken_weights\x18\x05 \x03(\x0b\x32\x10.artm.FloatArray\x12\x10\n\x08\x63lass_id\x18\x06 \x03(\t\x12\x11\n\tinternals\x18\x07 \x01(\x0c\x12#\n\x0btopic_index\x18\x08 \x03(\x0b\x32\x0e.artm.IntArray\x12\x36\n\x0eoperation_type\x18\t \x03(\x0e\x32\x1e.artm.TopicModel.OperationType\x12\x0c\n\x04seed\x18\n \x01(\x05\x1a\x35\n\x13TopicModelInternals\x12\x1e\n\x04n_wt\x18\x01 \x03(\x0b\x32\x10.artm.FloatArray\"U\n\rOperationType\x12\x0e\n\nInitialize\x10\x00\x12\r\n\tIncrement\x10\x01\x12\r\n\tOverwrite\x10\x02\x12\n\n\x06Remove\x10\x03\x12\n\n\x06Ignore\x10\x04\"\xa9\x01\n\x0bThetaMatrix\x12\x0f\n\x07item_id\x18\x02 \x03(\x05\x12&\n\x0citem_weights\x18\x03 \x03(\x0b\x32\x10.artm.FloatArray\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x14\n\x0ctopics_count\x18\x05 \x01(\x05\x12\x12\n\nitem_title\x18\x06 \x03(\t\x12#\n\x0btopic_index\x18\x07 \x03(\x0b\x32\x0e.artm.IntArray\"\x8c\x04\n\x16\x43ollectionParserConfig\x12\x42\n\x06\x66ormat\x18\x01 \x01(\x0e\x32#.artm.CollectionParserConfig.Format:\rBagOfWordsUci\x12\x19\n\x11\x64ocword_file_path\x18\x02 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x03 \x01(\t\x12\x15\n\rtarget_folder\x18\x04 \x01(\t\x12!\n\x13num_items_per_batch\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12%\n\x17use_unity_based_indices\x18\x06 \x01(\x08:\x04true\x12>\n\tname_type\x18\x07 \x01(\x0e\x32%.artm.CollectionParserConfig.NameType:\x04Guid\x12\x1a\n\x12\x63ooccurrence_token\x18\x08 \x03(\t\x12\x13\n\x0bgather_cooc\x18\t \x01(\x08\x12\x1d\n\x15\x63ooccurrence_class_id\x18\n \x03(\t\x12(\n\x19use_symmetric_cooc_values\x18\x0b \x01(\x08:\x05\x66\x61lse\"?\n\x06\x46ormat\x12\x11\n\rBagOfWordsUci\x10\x00\x12\x10\n\x0cMatrixMarket\x10\x01\x12\x10\n\x0cVowpalWabbit\x10\x02\"\x1e\n\x08NameType\x12\x08\n\x04Guid\x10\x00\x12\x08\n\x04\x43ode\x10\x01\"\xe9\x03\n\x13InitializeModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x12\n\ntopic_name\x18\x04 \x03(\t\x12\x10\n\x04seed\x18\x05 \x01(\x05:\x02-1\x12\x39\n\x0bsource_type\x18\x06 \x01(\x0e\x32$.artm.InitializeModelArgs.SourceType\x12\x11\n\tdisk_path\x18\x07 \x01(\t\x12\x30\n\x06\x66ilter\x18\x08 \x03(\x0b\x32 .artm.InitializeModelArgs.Filter\x12\x16\n\x0e\x62\x61tch_filename\x18\t \x03(\t\x1a\xa5\x01\n\x06\x46ilter\x12\x10\n\x08\x63lass_id\x18\x01 \x01(\t\x12\x16\n\x0emin_percentage\x18\x02 \x01(\x02\x12\x16\n\x0emax_percentage\x18\x03 \x01(\x02\x12\x11\n\tmin_items\x18\x04 \x01(\x05\x12\x11\n\tmax_items\x18\x05 \x01(\x05\x12\x17\n\x0fmin_total_count\x18\x06 \x01(\x05\x12\x1a\n\x12min_one_item_count\x18\x07 \x01(\x05\")\n\nSourceType\x12\x0e\n\nDictionary\x10\x00\x12\x0b\n\x07\x42\x61tches\x10\x01\"\xc1\x01\n\x0e\x44ictionaryData\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05token\x18\x02 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x03 \x03(\t\x12\x13\n\x0btoken_value\x18\x04 \x03(\x02\x12\x10\n\x08token_tf\x18\x05 \x03(\x02\x12\x10\n\x08token_df\x18\x06 \x03(\x02\x12\x18\n\x10\x63ooc_first_index\x18\x07 \x03(\x05\x12\x19\n\x11\x63ooc_second_index\x18\x08 \x03(\x05\x12\x12\n\ncooc_value\x18\t \x03(\x02\"\xcb\x01\n\x14\x46ilterDictionaryArgs\x12\x17\n\x0f\x64ictionary_name\x18\x01 \x01(\t\x12\x1e\n\x16\x64ictionary_target_name\x18\x02 \x01(\t\x12\x10\n\x08\x63lass_id\x18\x03 \x01(\t\x12\x0e\n\x06min_df\x18\x04 \x01(\x02\x12\x0e\n\x06max_df\x18\x05 \x01(\x02\x12\x13\n\x0bmin_df_rate\x18\x06 \x01(\x02\x12\x13\n\x0bmax_df_rate\x18\x07 \x01(\x02\x12\x0e\n\x06min_tf\x18\x08 \x01(\x02\x12\x0e\n\x06max_tf\x18\t \x01(\x02\"\xb4\x01\n\x14GatherDictionaryArgs\x12\x1e\n\x16\x64ictionary_target_name\x18\x01 \x01(\t\x12\x11\n\tdata_path\x18\x02 \x01(\t\x12\x16\n\x0e\x63ooc_file_path\x18\x03 \x01(\t\x12\x17\n\x0fvocab_file_path\x18\x04 \x01(\t\x12$\n\x15symmetric_cooc_values\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x12\n\nbatch_path\x18\x06 \x03(\t\",\n\x11GetDictionaryArgs\x12\x17\n\x0f\x64ictionary_name\x18\x01 \x01(\t\"\xf4\x02\n\x11GetTopicModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\ntopic_name\x18\x02 \x03(\t\x12\r\n\x05token\x18\x03 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x04 \x03(\t\x12\x19\n\x11use_sparse_format\x18\x05 \x01(\x08\x12\x13\n\x03\x65ps\x18\x06 \x01(\x02:\x06\x31\x65-037\x12>\n\x0crequest_type\x18\x07 \x01(\x0e\x32#.artm.GetTopicModelArgs.RequestType:\x03Pwt\x12\x42\n\rmatrix_layout\x18\x08 \x01(\x0e\x32$.artm.GetTopicModelArgs.MatrixLayout:\x05\x44\x65nse\";\n\x0bRequestType\x12\x07\n\x03Pwt\x10\x00\x12\x07\n\x03Nwt\x10\x01\x12\x0e\n\nTopicNames\x10\x02\x12\n\n\x06Tokens\x10\x03\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\"\xd9\x01\n\x12GetThetaMatrixArgs\x12\x12\n\ntopic_name\x18\x03 \x03(\t\x12\x13\n\x0btopic_index\x18\x04 \x03(\x05\x12\x19\n\x11use_sparse_format\x18\x06 \x01(\x08\x12\x13\n\x03\x65ps\x18\x07 \x01(\x02:\x06\x31\x65-037\x12\x43\n\rmatrix_layout\x18\x08 \x01(\x0e\x32%.artm.GetThetaMatrixArgs.MatrixLayout:\x05\x44\x65nse\"%\n\x0cMatrixLayout\x12\t\n\x05\x44\x65nse\x10\x00\x12\n\n\x06Sparse\x10\x01\";\n\x11GetScoreValueArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x12\x12\n\nscore_name\x18\x02 \x01(\t\"\'\n\x11GetScoreArrayArgs\x12\x12\n\nscore_name\x18\x02 \x01(\t\"8\n\x0f\x45xportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"8\n\x0fImportModelArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x12\n\nmodel_name\x18\x02 \x01(\t\"%\n\x0f\x41ttachModelArgs\x12\x12\n\nmodel_name\x18\x01 \x01(\t\"\xc6\x04\n\x12ProcessBatchesArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12\x17\n\x0fpwt_source_name\x18\x03 \x01(\t\x12\"\n\x16inner_iterations_count\x18\x04 \x01(\x05:\x02\x31\x30\x12\x1c\n\x0bstream_name\x18\x05 \x01(\t:\x07@global\x12\x18\n\x10regularizer_name\x18\x06 \x03(\t\x12\x17\n\x0fregularizer_tau\x18\x07 \x03(\x01\x12\x10\n\x08\x63lass_id\x18\x08 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\t \x03(\x02\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12J\n\x11theta_matrix_type\x18\x0e \x01(\x0e\x32(.artm.ProcessBatchesArgs.ThetaMatrixType:\x05\x43\x61\x63he\x12\x14\n\x0c\x62\x61tch_weight\x18\x0f \x03(\x02\x12\x18\n\x10predict_class_id\x18\x11 \x01(\t\x12\x1a\n\x05\x62\x61tch\x18\x12 \x03(\x0b\x32\x0b.artm.Batch\"\\\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\x12\r\n\tDensePtdw\x10\x04\x12\x0e\n\nSparsePtdw\x10\x05\"d\n\x14ProcessBatchesResult\x12#\n\nscore_data\x18\x01 \x03(\x0b\x32\x0f.artm.ScoreData\x12\'\n\x0ctheta_matrix\x18\x02 \x01(\x0b\x32\x11.artm.ThetaMatrix\"m\n\x0eMergeModelArgs\x12\x17\n\x0fnwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x03(\t\x12\x15\n\rsource_weight\x18\x03 \x03(\x02\x12\x12\n\ntopic_name\x18\x04 \x03(\t\"\x99\x01\n\x13RegularizeModelArgs\x12\x17\n\x0frwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fpwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x03 \x01(\t\x12\x37\n\x14regularizer_settings\x18\x04 \x03(\x0b\x32\x19.artm.RegularizerSettings\"_\n\x12NormalizeModelArgs\x12\x17\n\x0fpwt_target_name\x18\x01 \x01(\t\x12\x17\n\x0fnwt_source_name\x18\x02 \x01(\t\x12\x17\n\x0frwt_source_name\x18\x03 \x01(\t\"B\n\x14ImportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"B\n\x14\x45xportDictionaryArgs\x12\x11\n\tfile_name\x18\x01 \x01(\t\x12\x17\n\x0f\x64ictionary_name\x18\x02 \x01(\t\"\xc1\x01\n\x15\x43opyRequestResultArgs\x12Q\n\x0crequest_type\x18\x01 \x01(\x0e\x32\'.artm.CopyRequestResultArgs.RequestType:\x12\x44\x65\x66\x61ultRequestType\"U\n\x0bRequestType\x12\x16\n\x12\x44\x65\x66\x61ultRequestType\x10\x00\x12\x16\n\x12GetThetaSecondPass\x10\x01\x12\x16\n\x12GetModelSecondPass\x10\x02\"\x1e\n\x1c\x44uplicateMasterComponentArgs\"\x1c\n\x1aGetMasterComponentInfoArgs\"\xa6\x06\n\x13MasterComponentInfo\x12\x11\n\tmaster_id\x18\x01 \x01(\x05\x12+\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x1b.artm.MasterComponentConfig\x12>\n\x0bregularizer\x18\x03 \x03(\x0b\x32).artm.MasterComponentInfo.RegularizerInfo\x12\x32\n\x05score\x18\x04 \x03(\x0b\x32#.artm.MasterComponentInfo.ScoreInfo\x12<\n\ndictionary\x18\x05 \x03(\x0b\x32(.artm.MasterComponentInfo.DictionaryInfo\x12\x32\n\x05model\x18\x06 \x03(\x0b\x32#.artm.MasterComponentInfo.ModelInfo\x12=\n\x0b\x63\x61\x63he_entry\x18\x07 \x03(\x0b\x32(.artm.MasterComponentInfo.CacheEntryInfo\x12\x1c\n\x14processor_queue_size\x18\t \x01(\x05\x12\x32\n\x05\x62\x61tch\x18\n \x03(\x0b\x32#.artm.MasterComponentInfo.BatchInfo\x1a-\n\x0fRegularizerInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\'\n\tScoreInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x1a\x35\n\x0e\x44ictionaryInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rentries_count\x18\x02 \x01(\x03\x1a\x43\n\tBatchInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0bitems_count\x18\x02 \x01(\x05\x12\x13\n\x0btoken_count\x18\x03 \x01(\x05\x1aR\n\tModelInfo\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12\x14\n\x0ctopics_count\x18\x03 \x01(\x05\x12\x13\n\x0btoken_count\x18\x04 \x01(\x05\x1a\x30\n\x0e\x43\x61\x63heEntryInfo\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tbyte_size\x18\x02 \x01(\x05\"C\n\x11ImportBatchesArgs\x12\x12\n\nbatch_name\x18\x01 \x03(\t\x12\x1a\n\x05\x62\x61tch\x18\x03 \x03(\x0b\x32\x0b.artm.Batch\"6\n\x12\x41waitOperationArgs\x12 \n\x14timeout_milliseconds\x18\x01 \x01(\x05:\x02-1\"\x96\x03\n\x11MasterModelConfig\x12\x12\n\ntopic_name\x18\x01 \x03(\t\x12\x10\n\x08\x63lass_id\x18\x02 \x03(\t\x12\x14\n\x0c\x63lass_weight\x18\x03 \x03(\x02\x12\'\n\x0cscore_config\x18\x04 \x03(\x0b\x32\x11.artm.ScoreConfig\x12\x33\n\x12regularizer_config\x18\x05 \x03(\x0b\x32\x17.artm.RegularizerConfig\x12\x0f\n\x07threads\x18\x06 \x01(\x05\x12\x15\n\x08pwt_name\x18\x07 \x01(\t:\x03pwt\x12\x15\n\x08nwt_name\x18\x08 \x01(\t:\x03nwt\x12\x1e\n\x16inner_iterations_count\x18\t \x01(\x05\x12\x1a\n\x0breuse_theta\x18\n \x01(\x08:\x05\x66\x61lse\x12\x19\n\x0bopt_for_avx\x18\x0b \x01(\x08:\x04true\x12\x1c\n\x0euse_sparse_bow\x18\x0c \x01(\x08:\x04true\x12\x17\n\x0f\x64isk_cache_path\x18\r \x01(\t\x12\x1a\n\x0b\x63\x61\x63he_theta\x18\x0f \x01(\x08:\x05\x66\x61lse\"r\n\x19\x46itOfflineMasterModelArgs\x12\x16\n\x0e\x62\x61tch_filename\x18\x01 \x03(\t\x12\x14\n\x0c\x62\x61tch_weight\x18\x02 \x03(\x02\x12\x11\n\x06passes\x18\x03 \x01(\x05:\x01\x31\x12\x14\n\x0c\x62\x61tch_folder\x18\x04 \x01(\t\"\xa0\x01\n\x18\x46itOnlineMasterModelArgs\x12\x16\n\x0e\x62\x61tch_filename\x18\x01 \x03(\t\x12\x14\n\x0c\x62\x61tch_weight\x18\x02 \x03(\x02\x12\x14\n\x0cupdate_after\x18\x03 \x03(\x05\x12\x14\n\x0c\x61pply_weight\x18\x04 \x03(\x02\x12\x14\n\x0c\x64\x65\x63\x61y_weight\x18\x05 \x03(\x02\x12\x14\n\x05\x61sync\x18\x06 \x01(\x08:\x05\x66\x61lse\"\x98\x02\n\x18TransformMasterModelArgs\x12\x1a\n\x05\x62\x61tch\x18\x01 \x03(\x0b\x32\x0b.artm.Batch\x12\x16\n\x0e\x62\x61tch_filename\x18\x02 \x03(\t\x12P\n\x11theta_matrix_type\x18\x03 \x01(\x0e\x32..artm.TransformMasterModelArgs.ThetaMatrixType:\x05\x44\x65nse\x12\x18\n\x10predict_class_id\x18\x04 \x01(\t\"\\\n\x0fThetaMatrixType\x12\x08\n\x04None\x10\x00\x12\t\n\x05\x44\x65nse\x10\x01\x12\n\n\x06Sparse\x10\x02\x12\t\n\x05\x43\x61\x63he\x10\x03\x12\r\n\tDensePtdw\x10\x04\x12\x0e\n\nSparsePtdw\x10\x05\"\xff\x01\n\x14\x43onfigureLoggingArgs\x12\x0f\n\x07log_dir\x18\x01 \x01(\t\x12\x13\n\x0bminloglevel\x18\x02 \x01(\x05\x12\x17\n\x0fstderrthreshold\x18\x03 \x01(\x05\x12\x13\n\x0blogtostderr\x18\x04 \x01(\x08\x12\x18\n\x10\x63olorlogtostderr\x18\x05 \x01(\x08\x12\x17\n\x0f\x61lsologtostderr\x18\x06 \x01(\x08\x12\x12\n\nlogbufsecs\x18\x07 \x01(\x05\x12\x13\n\x0blogbuflevel\x18\x08 \x01(\x05\x12\x14\n\x0cmax_log_size\x18\t \x01(\x05\x12!\n\x19stop_logging_if_full_disk\x18\n \x01(\x08\"\x15\n\x13\x43learThetaCacheArgs\"\x15\n\x13\x43learScoreCacheArgs\"\x1a\n\x18\x43learScoreArrayCacheArgs')
 
 
 
@@ -277,8 +277,8 @@ _PERPLEXITYSCORECONFIG_TYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=4088,
-  serialized_end=4148,
+  serialized_start=4138,
+  serialized_end=4198,
 )
 
 _TOPICMODEL_OPERATIONTYPE = _descriptor.EnumDescriptor(
@@ -310,8 +310,8 @@ _TOPICMODEL_OPERATIONTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=6681,
-  serialized_end=6766,
+  serialized_start=6731,
+  serialized_end=6816,
 )
 
 _COLLECTIONPARSERCONFIG_FORMAT = _descriptor.EnumDescriptor(
@@ -335,8 +335,8 @@ _COLLECTIONPARSERCONFIG_FORMAT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=7370,
-  serialized_end=7433,
+  serialized_start=7420,
+  serialized_end=7483,
 )
 
 _COLLECTIONPARSERCONFIG_NAMETYPE = _descriptor.EnumDescriptor(
@@ -356,8 +356,8 @@ _COLLECTIONPARSERCONFIG_NAMETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=7435,
-  serialized_end=7465,
+  serialized_start=7485,
+  serialized_end=7515,
 )
 
 _INITIALIZEMODELARGS_SOURCETYPE = _descriptor.EnumDescriptor(
@@ -377,8 +377,8 @@ _INITIALIZEMODELARGS_SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=7916,
-  serialized_end=7957,
+  serialized_start=7966,
+  serialized_end=8007,
 )
 
 _GETTOPICMODELARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
@@ -406,8 +406,8 @@ _GETTOPICMODELARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8865,
-  serialized_end=8924,
+  serialized_start=8915,
+  serialized_end=8974,
 )
 
 _GETTOPICMODELARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
@@ -427,8 +427,8 @@ _GETTOPICMODELARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8926,
-  serialized_end=8963,
+  serialized_start=8976,
+  serialized_end=9013,
 )
 
 _GETTHETAMATRIXARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
@@ -448,8 +448,8 @@ _GETTHETAMATRIXARGS_MATRIXLAYOUT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8926,
-  serialized_end=8963,
+  serialized_start=8976,
+  serialized_end=9013,
 )
 
 _PROCESSBATCHESARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
@@ -485,8 +485,8 @@ _PROCESSBATCHESARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9920,
-  serialized_end=10012,
+  serialized_start=9983,
+  serialized_end=10075,
 )
 
 _COPYREQUESTRESULTARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
@@ -510,8 +510,8 @@ _COPYREQUESTRESULTARGS_REQUESTTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10725,
-  serialized_end=10810,
+  serialized_start=10788,
+  serialized_end=10873,
 )
 
 _TRANSFORMMASTERMODELARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
@@ -547,8 +547,8 @@ _TRANSFORMMASTERMODELARGS_THETAMATRIXTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9920,
-  serialized_end=10012,
+  serialized_start=9983,
+  serialized_end=10075,
 )
 
 
@@ -1791,6 +1791,34 @@ _SCOREDATA = _descriptor.Descriptor(
 )
 
 
+_SCOREDATAARRAY = _descriptor.Descriptor(
+  name='ScoreDataArray',
+  full_name='artm.ScoreDataArray',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='score', full_name='artm.ScoreDataArray.score', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=3815,
+  serialized_end=3863,
+)
+
+
 _PERPLEXITYSCORECONFIG = _descriptor.Descriptor(
   name='PerplexityScoreConfig',
   full_name='artm.PerplexityScoreConfig',
@@ -1857,8 +1885,8 @@ _PERPLEXITYSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=3816,
-  serialized_end=4148,
+  serialized_start=3866,
+  serialized_end=4198,
 )
 
 
@@ -1927,8 +1955,8 @@ _PERPLEXITYSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4151,
-  serialized_end=4339,
+  serialized_start=4201,
+  serialized_end=4389,
 )
 
 
@@ -1976,8 +2004,8 @@ _SPARSITYTHETASCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4341,
-  serialized_end=4465,
+  serialized_start=4391,
+  serialized_end=4515,
 )
 
 
@@ -2018,8 +2046,8 @@ _SPARSITYTHETASCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4467,
-  serialized_end=4545,
+  serialized_start=4517,
+  serialized_end=4595,
 )
 
 
@@ -2060,8 +2088,8 @@ _SPARSITYPHISCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4547,
-  serialized_end=4646,
+  serialized_start=4597,
+  serialized_end=4696,
 )
 
 
@@ -2102,8 +2130,8 @@ _SPARSITYPHISCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4648,
-  serialized_end=4724,
+  serialized_start=4698,
+  serialized_end=4774,
 )
 
 
@@ -2137,8 +2165,8 @@ _ITEMSPROCESSEDSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4726,
-  serialized_end=4810,
+  serialized_start=4776,
+  serialized_end=4860,
 )
 
 
@@ -2172,8 +2200,8 @@ _ITEMSPROCESSEDSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4812,
-  serialized_end=4875,
+  serialized_start=4862,
+  serialized_end=4925,
 )
 
 
@@ -2221,8 +2249,8 @@ _TOPTOKENSSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=4878,
-  serialized_end=5016,
+  serialized_start=4928,
+  serialized_end=5066,
 )
 
 
@@ -2291,8 +2319,8 @@ _TOPTOKENSSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5019,
-  serialized_end=5192,
+  serialized_start=5069,
+  serialized_end=5242,
 )
 
 
@@ -2340,8 +2368,8 @@ _THETASNIPPETSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5194,
-  serialized_end=5321,
+  serialized_start=5244,
+  serialized_end=5371,
 )
 
 
@@ -2375,8 +2403,8 @@ _THETASNIPPETSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5323,
-  serialized_end=5393,
+  serialized_start=5373,
+  serialized_end=5443,
 )
 
 
@@ -2431,8 +2459,8 @@ _TOPICKERNELSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5396,
-  serialized_end=5574,
+  serialized_start=5446,
+  serialized_end=5624,
 )
 
 
@@ -2522,8 +2550,8 @@ _TOPICKERNELSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5577,
-  serialized_end=5960,
+  serialized_start=5627,
+  serialized_end=6010,
 )
 
 
@@ -2564,8 +2592,8 @@ _TOPICMASSPHISCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=5962,
-  serialized_end=6062,
+  serialized_start=6012,
+  serialized_end=6112,
 )
 
 
@@ -2613,8 +2641,8 @@ _TOPICMASSPHISCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6064,
-  serialized_end=6159,
+  serialized_start=6114,
+  serialized_end=6209,
 )
 
 
@@ -2641,8 +2669,8 @@ _CLASSPRECISIONSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6161,
-  serialized_end=6218,
+  serialized_start=6211,
+  serialized_end=6268,
 )
 
 
@@ -2683,8 +2711,8 @@ _CLASSPRECISIONSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6220,
-  serialized_end=6286,
+  serialized_start=6270,
+  serialized_end=6336,
 )
 
 
@@ -2704,8 +2732,8 @@ _PEAKMEMORYSCORECONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6288,
-  serialized_end=6311,
+  serialized_start=6338,
+  serialized_end=6361,
 )
 
 
@@ -2732,8 +2760,8 @@ _PEAKMEMORYSCORE = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6313,
-  serialized_end=6345,
+  serialized_start=6363,
+  serialized_end=6395,
 )
 
 
@@ -2760,8 +2788,8 @@ _TOPICMODEL_TOPICMODELINTERNALS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6626,
-  serialized_end=6679,
+  serialized_start=6676,
+  serialized_end=6729,
 )
 
 _TOPICMODEL = _descriptor.Descriptor(
@@ -2851,8 +2879,8 @@ _TOPICMODEL = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6348,
-  serialized_end=6766,
+  serialized_start=6398,
+  serialized_end=6816,
 )
 
 
@@ -2914,8 +2942,8 @@ _THETAMATRIX = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6769,
-  serialized_end=6938,
+  serialized_start=6819,
+  serialized_end=6988,
 )
 
 
@@ -3014,8 +3042,8 @@ _COLLECTIONPARSERCONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=6941,
-  serialized_end=7465,
+  serialized_start=6991,
+  serialized_end=7515,
 )
 
 
@@ -3084,8 +3112,8 @@ _INITIALIZEMODELARGS_FILTER = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7749,
-  serialized_end=7914,
+  serialized_start=7799,
+  serialized_end=7964,
 )
 
 _INITIALIZEMODELARGS = _descriptor.Descriptor(
@@ -3168,8 +3196,8 @@ _INITIALIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7468,
-  serialized_end=7957,
+  serialized_start=7518,
+  serialized_end=8007,
 )
 
 
@@ -3252,8 +3280,8 @@ _DICTIONARYDATA = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=7960,
-  serialized_end=8153,
+  serialized_start=8010,
+  serialized_end=8203,
 )
 
 
@@ -3336,8 +3364,8 @@ _FILTERDICTIONARYARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8156,
-  serialized_end=8359,
+  serialized_start=8206,
+  serialized_end=8409,
 )
 
 
@@ -3399,8 +3427,8 @@ _GATHERDICTIONARYARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8362,
-  serialized_end=8542,
+  serialized_start=8412,
+  serialized_end=8592,
 )
 
 
@@ -3427,8 +3455,8 @@ _GETDICTIONARYARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8544,
-  serialized_end=8588,
+  serialized_start=8594,
+  serialized_end=8638,
 )
 
 
@@ -3506,8 +3534,8 @@ _GETTOPICMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8591,
-  serialized_end=8963,
+  serialized_start=8641,
+  serialized_end=9013,
 )
 
 
@@ -3533,28 +3561,21 @@ _GETTHETAMATRIXARGS = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='clean_cache', full_name='artm.GetThetaMatrixArgs.clean_cache', index=2,
-      number=5, type=8, cpp_type=7, label=1,
-      has_default_value=True, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='use_sparse_format', full_name='artm.GetThetaMatrixArgs.use_sparse_format', index=3,
+      name='use_sparse_format', full_name='artm.GetThetaMatrixArgs.use_sparse_format', index=2,
       number=6, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='eps', full_name='artm.GetThetaMatrixArgs.eps', index=4,
+      name='eps', full_name='artm.GetThetaMatrixArgs.eps', index=3,
       number=7, type=2, cpp_type=6, label=1,
       has_default_value=True, default_value=1e-037,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='matrix_layout', full_name='artm.GetThetaMatrixArgs.matrix_layout', index=5,
+      name='matrix_layout', full_name='artm.GetThetaMatrixArgs.matrix_layout', index=4,
       number=8, type=14, cpp_type=8, label=1,
       has_default_value=True, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -3570,8 +3591,8 @@ _GETTHETAMATRIXARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=8966,
-  serialized_end=9211,
+  serialized_start=9016,
+  serialized_end=9233,
 )
 
 
@@ -3605,8 +3626,36 @@ _GETSCOREVALUEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9213,
-  serialized_end=9272,
+  serialized_start=9235,
+  serialized_end=9294,
+)
+
+
+_GETSCOREARRAYARGS = _descriptor.Descriptor(
+  name='GetScoreArrayArgs',
+  full_name='artm.GetScoreArrayArgs',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='score_name', full_name='artm.GetScoreArrayArgs.score_name', index=0,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=unicode("", "utf-8"),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=9296,
+  serialized_end=9335,
 )
 
 
@@ -3640,8 +3689,8 @@ _EXPORTMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9274,
-  serialized_end=9330,
+  serialized_start=9337,
+  serialized_end=9393,
 )
 
 
@@ -3675,8 +3724,8 @@ _IMPORTMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9332,
-  serialized_end=9388,
+  serialized_start=9395,
+  serialized_end=9451,
 )
 
 
@@ -3703,8 +3752,8 @@ _ATTACHMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9390,
-  serialized_end=9427,
+  serialized_start=9453,
+  serialized_end=9490,
 )
 
 
@@ -3837,8 +3886,8 @@ _PROCESSBATCHESARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=9430,
-  serialized_end=10012,
+  serialized_start=9493,
+  serialized_end=10075,
 )
 
 
@@ -3872,8 +3921,8 @@ _PROCESSBATCHESRESULT = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10014,
-  serialized_end=10114,
+  serialized_start=10077,
+  serialized_end=10177,
 )
 
 
@@ -3921,8 +3970,8 @@ _MERGEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10116,
-  serialized_end=10225,
+  serialized_start=10179,
+  serialized_end=10288,
 )
 
 
@@ -3970,8 +4019,8 @@ _REGULARIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10228,
-  serialized_end=10381,
+  serialized_start=10291,
+  serialized_end=10444,
 )
 
 
@@ -4012,8 +4061,8 @@ _NORMALIZEMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10383,
-  serialized_end=10478,
+  serialized_start=10446,
+  serialized_end=10541,
 )
 
 
@@ -4047,8 +4096,8 @@ _IMPORTDICTIONARYARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10480,
-  serialized_end=10546,
+  serialized_start=10543,
+  serialized_end=10609,
 )
 
 
@@ -4082,8 +4131,8 @@ _EXPORTDICTIONARYARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10548,
-  serialized_end=10614,
+  serialized_start=10611,
+  serialized_end=10677,
 )
 
 
@@ -4111,8 +4160,8 @@ _COPYREQUESTRESULTARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10617,
-  serialized_end=10810,
+  serialized_start=10680,
+  serialized_end=10873,
 )
 
 
@@ -4132,8 +4181,8 @@ _DUPLICATEMASTERCOMPONENTARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10812,
-  serialized_end=10842,
+  serialized_start=10875,
+  serialized_end=10905,
 )
 
 
@@ -4153,8 +4202,8 @@ _GETMASTERCOMPONENTINFOARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10844,
-  serialized_end=10872,
+  serialized_start=10907,
+  serialized_end=10935,
 )
 
 
@@ -4188,8 +4237,8 @@ _MASTERCOMPONENTINFO_REGULARIZERINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11337,
-  serialized_end=11382,
+  serialized_start=11400,
+  serialized_end=11445,
 )
 
 _MASTERCOMPONENTINFO_SCOREINFO = _descriptor.Descriptor(
@@ -4222,8 +4271,8 @@ _MASTERCOMPONENTINFO_SCOREINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11384,
-  serialized_end=11423,
+  serialized_start=11447,
+  serialized_end=11486,
 )
 
 _MASTERCOMPONENTINFO_DICTIONARYINFO = _descriptor.Descriptor(
@@ -4256,8 +4305,8 @@ _MASTERCOMPONENTINFO_DICTIONARYINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11425,
-  serialized_end=11478,
+  serialized_start=11488,
+  serialized_end=11541,
 )
 
 _MASTERCOMPONENTINFO_BATCHINFO = _descriptor.Descriptor(
@@ -4297,8 +4346,8 @@ _MASTERCOMPONENTINFO_BATCHINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11480,
-  serialized_end=11547,
+  serialized_start=11543,
+  serialized_end=11610,
 )
 
 _MASTERCOMPONENTINFO_MODELINFO = _descriptor.Descriptor(
@@ -4345,8 +4394,8 @@ _MASTERCOMPONENTINFO_MODELINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11549,
-  serialized_end=11631,
+  serialized_start=11612,
+  serialized_end=11694,
 )
 
 _MASTERCOMPONENTINFO_CACHEENTRYINFO = _descriptor.Descriptor(
@@ -4379,8 +4428,8 @@ _MASTERCOMPONENTINFO_CACHEENTRYINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11633,
-  serialized_end=11681,
+  serialized_start=11696,
+  serialized_end=11744,
 )
 
 _MASTERCOMPONENTINFO = _descriptor.Descriptor(
@@ -4462,8 +4511,8 @@ _MASTERCOMPONENTINFO = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=10875,
-  serialized_end=11681,
+  serialized_start=10938,
+  serialized_end=11744,
 )
 
 
@@ -4497,8 +4546,8 @@ _IMPORTBATCHESARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11683,
-  serialized_end=11750,
+  serialized_start=11746,
+  serialized_end=11813,
 )
 
 
@@ -4525,8 +4574,8 @@ _AWAITOPERATIONARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11752,
-  serialized_end=11806,
+  serialized_start=11815,
+  serialized_end=11869,
 )
 
 
@@ -4644,8 +4693,8 @@ _MASTERMODELCONFIG = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=11809,
-  serialized_end=12215,
+  serialized_start=11872,
+  serialized_end=12278,
 )
 
 
@@ -4693,8 +4742,8 @@ _FITOFFLINEMASTERMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=12217,
-  serialized_end=12331,
+  serialized_start=12280,
+  serialized_end=12394,
 )
 
 
@@ -4756,8 +4805,8 @@ _FITONLINEMASTERMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=12334,
-  serialized_end=12494,
+  serialized_start=12397,
+  serialized_end=12557,
 )
 
 
@@ -4806,8 +4855,8 @@ _TRANSFORMMASTERMODELARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=12497,
-  serialized_end=12777,
+  serialized_start=12560,
+  serialized_end=12840,
 )
 
 
@@ -4897,8 +4946,8 @@ _CONFIGURELOGGINGARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=12780,
-  serialized_end=13035,
+  serialized_start=12843,
+  serialized_end=13098,
 )
 
 
@@ -4918,8 +4967,8 @@ _CLEARTHETACACHEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=13037,
-  serialized_end=13058,
+  serialized_start=13100,
+  serialized_end=13121,
 )
 
 
@@ -4939,8 +4988,29 @@ _CLEARSCORECACHEARGS = _descriptor.Descriptor(
   options=None,
   is_extendable=False,
   extension_ranges=[],
-  serialized_start=13060,
-  serialized_end=13081,
+  serialized_start=13123,
+  serialized_end=13144,
+)
+
+
+_CLEARSCOREARRAYCACHEARGS = _descriptor.Descriptor(
+  name='ClearScoreArrayCacheArgs',
+  full_name='artm.ClearScoreArrayCacheArgs',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  extension_ranges=[],
+  serialized_start=13146,
+  serialized_end=13172,
 )
 
 _ITEM.fields_by_name['field'].message_type = _FIELD
@@ -4964,6 +5034,7 @@ _SCORECONFIG.fields_by_name['type'].enum_type = _SCORECONFIG_TYPE
 _SCORECONFIG_TYPE.containing_type = _SCORECONFIG;
 _SCOREDATA.fields_by_name['type'].enum_type = _SCOREDATA_TYPE
 _SCOREDATA_TYPE.containing_type = _SCOREDATA;
+_SCOREDATAARRAY.fields_by_name['score'].message_type = _SCOREDATA
 _PERPLEXITYSCORECONFIG.fields_by_name['model_type'].enum_type = _PERPLEXITYSCORECONFIG_TYPE
 _PERPLEXITYSCORECONFIG_TYPE.containing_type = _PERPLEXITYSCORECONFIG;
 _TOPTOKENSSCORE.fields_by_name['coherence'].message_type = _FLOATARRAY
@@ -5048,6 +5119,7 @@ DESCRIPTOR.message_types_by_name['TopicSelectionThetaConfig'] = _TOPICSELECTIONT
 DESCRIPTOR.message_types_by_name['TransformConfig'] = _TRANSFORMCONFIG
 DESCRIPTOR.message_types_by_name['ScoreConfig'] = _SCORECONFIG
 DESCRIPTOR.message_types_by_name['ScoreData'] = _SCOREDATA
+DESCRIPTOR.message_types_by_name['ScoreDataArray'] = _SCOREDATAARRAY
 DESCRIPTOR.message_types_by_name['PerplexityScoreConfig'] = _PERPLEXITYSCORECONFIG
 DESCRIPTOR.message_types_by_name['PerplexityScore'] = _PERPLEXITYSCORE
 DESCRIPTOR.message_types_by_name['SparsityThetaScoreConfig'] = _SPARSITYTHETASCORECONFIG
@@ -5079,6 +5151,7 @@ DESCRIPTOR.message_types_by_name['GetDictionaryArgs'] = _GETDICTIONARYARGS
 DESCRIPTOR.message_types_by_name['GetTopicModelArgs'] = _GETTOPICMODELARGS
 DESCRIPTOR.message_types_by_name['GetThetaMatrixArgs'] = _GETTHETAMATRIXARGS
 DESCRIPTOR.message_types_by_name['GetScoreValueArgs'] = _GETSCOREVALUEARGS
+DESCRIPTOR.message_types_by_name['GetScoreArrayArgs'] = _GETSCOREARRAYARGS
 DESCRIPTOR.message_types_by_name['ExportModelArgs'] = _EXPORTMODELARGS
 DESCRIPTOR.message_types_by_name['ImportModelArgs'] = _IMPORTMODELARGS
 DESCRIPTOR.message_types_by_name['AttachModelArgs'] = _ATTACHMODELARGS
@@ -5102,6 +5175,7 @@ DESCRIPTOR.message_types_by_name['TransformMasterModelArgs'] = _TRANSFORMMASTERM
 DESCRIPTOR.message_types_by_name['ConfigureLoggingArgs'] = _CONFIGURELOGGINGARGS
 DESCRIPTOR.message_types_by_name['ClearThetaCacheArgs'] = _CLEARTHETACACHEARGS
 DESCRIPTOR.message_types_by_name['ClearScoreCacheArgs'] = _CLEARSCORECACHEARGS
+DESCRIPTOR.message_types_by_name['ClearScoreArrayCacheArgs'] = _CLEARSCOREARRAYCACHEARGS
 
 class DoubleArray(_message.Message):
   __metaclass__ = _reflection.GeneratedProtocolMessageType
@@ -5252,6 +5326,12 @@ class ScoreData(_message.Message):
   DESCRIPTOR = _SCOREDATA
 
   # @@protoc_insertion_point(class_scope:artm.ScoreData)
+
+class ScoreDataArray(_message.Message):
+  __metaclass__ = _reflection.GeneratedProtocolMessageType
+  DESCRIPTOR = _SCOREDATAARRAY
+
+  # @@protoc_insertion_point(class_scope:artm.ScoreDataArray)
 
 class PerplexityScoreConfig(_message.Message):
   __metaclass__ = _reflection.GeneratedProtocolMessageType
@@ -5451,6 +5531,12 @@ class GetScoreValueArgs(_message.Message):
 
   # @@protoc_insertion_point(class_scope:artm.GetScoreValueArgs)
 
+class GetScoreArrayArgs(_message.Message):
+  __metaclass__ = _reflection.GeneratedProtocolMessageType
+  DESCRIPTOR = _GETSCOREARRAYARGS
+
+  # @@protoc_insertion_point(class_scope:artm.GetScoreArrayArgs)
+
 class ExportModelArgs(_message.Message):
   __metaclass__ = _reflection.GeneratedProtocolMessageType
   DESCRIPTOR = _EXPORTMODELARGS
@@ -5624,6 +5710,12 @@ class ClearScoreCacheArgs(_message.Message):
   DESCRIPTOR = _CLEARSCORECACHEARGS
 
   # @@protoc_insertion_point(class_scope:artm.ClearScoreCacheArgs)
+
+class ClearScoreArrayCacheArgs(_message.Message):
+  __metaclass__ = _reflection.GeneratedProtocolMessageType
+  DESCRIPTOR = _CLEARSCOREARRAYCACHEARGS
+
+  # @@protoc_insertion_point(class_scope:artm.ClearScoreArrayCacheArgs)
 
 
 _DOUBLEARRAY.fields_by_name['value'].has_options = True

--- a/src/artm/c_interface.cc
+++ b/src/artm/c_interface.cc
@@ -462,6 +462,11 @@ int ArtmClearScoreCache(int master_id, int length, const char* args) {
   return ArtmExecute< ::artm::ClearScoreCacheArgs>(master_id, length, args, &MasterComponent::ClearScoreCache);
 }
 
+int ArtmClearScoreArrayCache(int master_id, int length, const char* args) {
+  return ArtmExecute< ::artm::ClearScoreArrayCacheArgs>(master_id, length, args,
+                                                        &MasterComponent::ClearScoreArrayCache);
+}
+
 int ArtmDisposeRegularizer(int master_id, const char* name) {
   return ArtmExecute(master_id, name, &MasterComponent::DisposeRegularizer);
 }
@@ -528,6 +533,11 @@ int ArtmRequestExternal(int master_id, int length, const char* args_blob) {
 int ArtmRequestScore(int master_id, int length, const char* args) {
   return ArtmRequest< ::artm::GetScoreValueArgs,
                       ::artm::ScoreData>(master_id, length, args);
+}
+
+int ArtmRequestScoreArray(int master_id, int length, const char* args) {
+  return ArtmRequest< ::artm::GetScoreArrayArgs,
+                      ::artm::ScoreDataArray>(master_id, length, args);
 }
 
 int ArtmRequestDictionary(int master_id, int length, const char* args) {

--- a/src/artm/c_interface.h
+++ b/src/artm/c_interface.h
@@ -28,6 +28,7 @@ extern "C" {
 
   DLL_PUBLIC int ArtmClearThetaCache(int master_id, int length, const char* clear_theta_cache_args);
   DLL_PUBLIC int ArtmClearScoreCache(int master_id, int length, const char* clear_score_cache_args);
+  DLL_PUBLIC int ArtmClearScoreArrayCache(int master_id, int length, const char* clear_score_array_cache_args);
 
   DLL_PUBLIC int ArtmCreateRegularizer(int master_id, int length, const char* regularizer_config);
   DLL_PUBLIC int ArtmReconfigureRegularizer(int master_id, int length, const char* regularizer_config);
@@ -75,6 +76,7 @@ extern "C" {
   DLL_PUBLIC int ArtmRequestTopicModel(int master_id, int length, const char* get_model_args);
   DLL_PUBLIC int ArtmRequestTopicModelExternal(int master_id, int length, const char* get_model_args);
   DLL_PUBLIC int ArtmRequestScore(int master_id, int length, const char* get_score_args);
+  DLL_PUBLIC int ArtmRequestScoreArray(int master_id, int length, const char* get_score_args);
   DLL_PUBLIC int ArtmRequestMasterComponentInfo(int master_id, int length, const char* get_master_info_args);
   DLL_PUBLIC int ArtmRequestLoadBatch(const char* filename);
   DLL_PUBLIC int ArtmCopyRequestResult(int length, char* address);

--- a/src/artm/core/check_messages.h
+++ b/src/artm/core/check_messages.h
@@ -483,6 +483,9 @@ inline std::string DescribeErrors(const ::artm::GetMasterComponentInfoArgs& mess
 inline std::string DescribeErrors(const ::artm::ProcessBatchesResult& message) { return std::string(); }
 inline std::string DescribeErrors(const ::artm::ClearThetaCacheArgs& message) { return std::string(); }
 inline std::string DescribeErrors(const ::artm::ClearScoreCacheArgs& message) { return std::string(); }
+inline std::string DescribeErrors(const ::artm::ClearScoreArrayCacheArgs& message) { return std::string(); }
+inline std::string DescribeErrors(const ::artm::ScoreDataArray& message) { return std::string(); }
+inline std::string DescribeErrors(const ::artm::GetScoreArrayArgs& message) { return std::string(); }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // FixMessage routines (optional)

--- a/src/artm/core/instance.cc
+++ b/src/artm/core/instance.cc
@@ -176,6 +176,10 @@ ScoreManager* Instance::score_manager() {
   return score_manager_.get();
 }
 
+ScoreTracker* Instance::score_tracker() {
+  return score_tracker_.get();
+}
+
 void Instance::DisposeModel(ModelName model_name) {
   auto new_schema = schema_.get_copy();
   new_schema->clear_model_config(model_name);
@@ -391,6 +395,7 @@ void Instance::Reconfigure(const MasterComponentConfig& master_config) {
     cache_manager_.reset(new CacheManager());
     batch_manager_.reset(new BatchManager());
     score_manager_.reset(new ScoreManager());
+    score_tracker_.reset(new ScoreTracker());
 
     is_configured_  = true;
   }

--- a/src/artm/core/instance.h
+++ b/src/artm/core/instance.h
@@ -25,6 +25,8 @@ namespace core {
 
 class BatchManager;
 class CacheManager;
+class ScoreManager;
+class ScoreTracker;
 class Processor;
 class Merger;
 class InstanceSchema;
@@ -53,6 +55,7 @@ class Instance {
   BatchManager* batch_manager();
   CacheManager* cache_manager();
   ScoreManager* score_manager();
+  ScoreTracker* score_tracker();
 
   int processor_size() { return processors_.size(); }
   Processor* processor(int processor_index) { return processors_[processor_index].get(); }
@@ -92,6 +95,7 @@ class Instance {
 
   // Depends on [none]
   std::shared_ptr<ScoreManager> score_manager_;
+  std::shared_ptr<ScoreTracker> score_tracker_;
 
   // Depends on schema_, processor_queue_, and merger_
   std::vector<std::shared_ptr<Processor> > processors_;

--- a/src/artm/core/master_component.h
+++ b/src/artm/core/master_component.h
@@ -28,12 +28,13 @@ class ArtmExecutor;
 class Instance;
 class TopicModel;
 class BatchManager;
+class ScoreManager;
 
 class MasterComponent : boost::noncopyable {
  public:
   ~MasterComponent();
 
-  std::shared_ptr<MasterComponentConfig> config() const;
+  std::shared_ptr<MasterModelConfig> config() const;
 
   explicit MasterComponent(const MasterComponentConfig& config);
   explicit MasterComponent(const MasterModelConfig& config);
@@ -48,6 +49,7 @@ class MasterComponent : boost::noncopyable {
   void Request(const TransformMasterModelArgs& args, ThetaMatrix* result);
   void Request(const TransformMasterModelArgs& args, ThetaMatrix* result, std::string* external);
   void Request(const GetScoreValueArgs& args, ScoreData* result);
+  void Request(const GetScoreArrayArgs& args, ScoreDataArray* result);
   void Request(const ProcessBatchesArgs& args, ProcessBatchesResult* result);
   void Request(const ProcessBatchesArgs& args, ProcessBatchesResult* result, std::string* external);
   void Request(const GetDictionaryArgs& args, DictionaryData* result);
@@ -69,6 +71,7 @@ class MasterComponent : boost::noncopyable {
   void GatherDictionary(const GatherDictionaryArgs& args);
   void ClearThetaCache(const ClearThetaCacheArgs& args);
   void ClearScoreCache(const ClearScoreCacheArgs& args);
+  void ClearScoreArrayCache(const ClearScoreArrayCacheArgs& args);
 
   // DISPOSE functionality
   void DisposeModel(const std::string& name);
@@ -101,7 +104,7 @@ class MasterComponent : boost::noncopyable {
 
   void RequestProcessBatchesImpl(const ProcessBatchesArgs& process_batches_args,
                                  BatchManager* batch_manager, bool async,
-                                 ::google::protobuf::RepeatedPtrField< ::artm::ScoreData>* score_data,
+                                 ScoreManager* score_manager,
                                  ::artm::ThetaMatrix* theta_matrix);
 
   void CreateOrReconfigureMasterComponent(const MasterModelConfig& config, bool reconfigure);

--- a/src/artm/core/processor.cc
+++ b/src/artm/core/processor.cc
@@ -1031,7 +1031,7 @@ void Processor::ThreadFunction() {
             continue;
           }
 
-          if (!score_calc->is_cumulative())
+          if (!score_calc->is_cumulative() || (part->score_manager() == nullptr))
             continue;
 
           CuckooWatch cuckoo2("CalculateScore(" + score_name + ")", &cuckoo, kTimeLoggingThreshold);

--- a/src/artm/core/score_manager.h
+++ b/src/artm/core/score_manager.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "boost/thread/locks.hpp"
 #include "boost/thread/mutex.hpp"
@@ -30,10 +31,24 @@ class ScoreManager : boost::noncopyable {
   void Clear();
   bool RequestScore(std::shared_ptr<InstanceSchema> schema,
                     const ScoreName& score_name, ScoreData *score_data) const;
+  void RequestAllScores(std::shared_ptr<InstanceSchema> schema,
+                        ::google::protobuf::RepeatedPtrField< ::artm::ScoreData>* score_data) const;
 
  private:
   mutable boost::mutex lock_;
   std::map<ScoreName, std::shared_ptr<Score>> score_map_;
+};
+
+class ScoreTracker : boost::noncopyable {
+ public:
+  ScoreTracker() : lock_(), array_() {}
+  void Clear();
+  ScoreData* Add();
+  void RequestScoreArray(const GetScoreArrayArgs& args, ScoreDataArray* score_data_array);
+
+ private:
+  mutable boost::mutex lock_;
+  std::vector<std::shared_ptr<ScoreData>> array_;
 };
 
 }  // namespace core

--- a/src/artm/messages.pb.cc
+++ b/src/artm/messages.pb.cc
@@ -102,6 +102,9 @@ const ::google::protobuf::Descriptor* ScoreData_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ScoreData_reflection_ = NULL;
 const ::google::protobuf::EnumDescriptor* ScoreData_Type_descriptor_ = NULL;
+const ::google::protobuf::Descriptor* ScoreDataArray_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  ScoreDataArray_reflection_ = NULL;
 const ::google::protobuf::Descriptor* PerplexityScoreConfig_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   PerplexityScoreConfig_reflection_ = NULL;
@@ -209,6 +212,9 @@ const ::google::protobuf::EnumDescriptor* GetThetaMatrixArgs_MatrixLayout_descri
 const ::google::protobuf::Descriptor* GetScoreValueArgs_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   GetScoreValueArgs_reflection_ = NULL;
+const ::google::protobuf::Descriptor* GetScoreArrayArgs_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  GetScoreArrayArgs_reflection_ = NULL;
 const ::google::protobuf::Descriptor* ExportModelArgs_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ExportModelArgs_reflection_ = NULL;
@@ -299,6 +305,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* ClearScoreCacheArgs_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   ClearScoreCacheArgs_reflection_ = NULL;
+const ::google::protobuf::Descriptor* ClearScoreArrayCacheArgs_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  ClearScoreArrayCacheArgs_reflection_ = NULL;
 
 }  // namespace
 
@@ -767,7 +776,22 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ScoreData));
   ScoreData_Type_descriptor_ = ScoreData_descriptor_->enum_type(0);
-  PerplexityScoreConfig_descriptor_ = file->message_type(25);
+  ScoreDataArray_descriptor_ = file->message_type(25);
+  static const int ScoreDataArray_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScoreDataArray, score_),
+  };
+  ScoreDataArray_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      ScoreDataArray_descriptor_,
+      ScoreDataArray::default_instance_,
+      ScoreDataArray_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScoreDataArray, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ScoreDataArray, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(ScoreDataArray));
+  PerplexityScoreConfig_descriptor_ = file->message_type(26);
   static const int PerplexityScoreConfig_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PerplexityScoreConfig, field_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PerplexityScoreConfig, stream_name_),
@@ -789,7 +813,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(PerplexityScoreConfig));
   PerplexityScoreConfig_Type_descriptor_ = PerplexityScoreConfig_descriptor_->enum_type(0);
-  PerplexityScore_descriptor_ = file->message_type(26);
+  PerplexityScore_descriptor_ = file->message_type(27);
   static const int PerplexityScore_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PerplexityScore, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PerplexityScore, raw_),
@@ -810,7 +834,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(PerplexityScore));
-  SparsityThetaScoreConfig_descriptor_ = file->message_type(27);
+  SparsityThetaScoreConfig_descriptor_ = file->message_type(28);
   static const int SparsityThetaScoreConfig_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityThetaScoreConfig, field_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityThetaScoreConfig, stream_name_),
@@ -828,7 +852,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SparsityThetaScoreConfig));
-  SparsityThetaScore_descriptor_ = file->message_type(28);
+  SparsityThetaScore_descriptor_ = file->message_type(29);
   static const int SparsityThetaScore_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityThetaScore, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityThetaScore, zero_topics_),
@@ -845,7 +869,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SparsityThetaScore));
-  SparsityPhiScoreConfig_descriptor_ = file->message_type(29);
+  SparsityPhiScoreConfig_descriptor_ = file->message_type(30);
   static const int SparsityPhiScoreConfig_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityPhiScoreConfig, eps_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityPhiScoreConfig, class_id_),
@@ -862,7 +886,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SparsityPhiScoreConfig));
-  SparsityPhiScore_descriptor_ = file->message_type(30);
+  SparsityPhiScore_descriptor_ = file->message_type(31);
   static const int SparsityPhiScore_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityPhiScore, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(SparsityPhiScore, zero_tokens_),
@@ -879,7 +903,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(SparsityPhiScore));
-  ItemsProcessedScoreConfig_descriptor_ = file->message_type(31);
+  ItemsProcessedScoreConfig_descriptor_ = file->message_type(32);
   static const int ItemsProcessedScoreConfig_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ItemsProcessedScoreConfig, field_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ItemsProcessedScoreConfig, stream_name_),
@@ -895,7 +919,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ItemsProcessedScoreConfig));
-  ItemsProcessedScore_descriptor_ = file->message_type(32);
+  ItemsProcessedScore_descriptor_ = file->message_type(33);
   static const int ItemsProcessedScore_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ItemsProcessedScore, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ItemsProcessedScore, num_batches_),
@@ -911,7 +935,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ItemsProcessedScore));
-  TopTokensScoreConfig_descriptor_ = file->message_type(33);
+  TopTokensScoreConfig_descriptor_ = file->message_type(34);
   static const int TopTokensScoreConfig_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopTokensScoreConfig, num_tokens_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopTokensScoreConfig, class_id_),
@@ -929,7 +953,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopTokensScoreConfig));
-  TopTokensScore_descriptor_ = file->message_type(34);
+  TopTokensScore_descriptor_ = file->message_type(35);
   static const int TopTokensScore_offsets_[7] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopTokensScore, num_entries_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopTokensScore, topic_name_),
@@ -950,7 +974,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopTokensScore));
-  ThetaSnippetScoreConfig_descriptor_ = file->message_type(35);
+  ThetaSnippetScoreConfig_descriptor_ = file->message_type(36);
   static const int ThetaSnippetScoreConfig_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaSnippetScoreConfig, field_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaSnippetScoreConfig, stream_name_),
@@ -968,7 +992,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ThetaSnippetScoreConfig));
-  ThetaSnippetScore_descriptor_ = file->message_type(36);
+  ThetaSnippetScore_descriptor_ = file->message_type(37);
   static const int ThetaSnippetScore_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaSnippetScore, item_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaSnippetScore, values_),
@@ -984,7 +1008,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ThetaSnippetScore));
-  TopicKernelScoreConfig_descriptor_ = file->message_type(37);
+  TopicKernelScoreConfig_descriptor_ = file->message_type(38);
   static const int TopicKernelScoreConfig_offsets_[5] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicKernelScoreConfig, eps_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicKernelScoreConfig, class_id_),
@@ -1003,7 +1027,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopicKernelScoreConfig));
-  TopicKernelScore_descriptor_ = file->message_type(38);
+  TopicKernelScore_descriptor_ = file->message_type(39);
   static const int TopicKernelScore_offsets_[10] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicKernelScore, kernel_size_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicKernelScore, kernel_purity_),
@@ -1027,7 +1051,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopicKernelScore));
-  TopicMassPhiScoreConfig_descriptor_ = file->message_type(39);
+  TopicMassPhiScoreConfig_descriptor_ = file->message_type(40);
   static const int TopicMassPhiScoreConfig_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicMassPhiScoreConfig, eps_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicMassPhiScoreConfig, class_id_),
@@ -1044,7 +1068,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopicMassPhiScoreConfig));
-  TopicMassPhiScore_descriptor_ = file->message_type(40);
+  TopicMassPhiScore_descriptor_ = file->message_type(41);
   static const int TopicMassPhiScore_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicMassPhiScore, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicMassPhiScore, topic_name_),
@@ -1062,7 +1086,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopicMassPhiScore));
-  ClassPrecisionScoreConfig_descriptor_ = file->message_type(41);
+  ClassPrecisionScoreConfig_descriptor_ = file->message_type(42);
   static const int ClassPrecisionScoreConfig_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClassPrecisionScoreConfig, stream_name_),
   };
@@ -1077,7 +1101,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ClassPrecisionScoreConfig));
-  ClassPrecisionScore_descriptor_ = file->message_type(42);
+  ClassPrecisionScore_descriptor_ = file->message_type(43);
   static const int ClassPrecisionScore_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClassPrecisionScore, value_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClassPrecisionScore, error_),
@@ -1094,7 +1118,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ClassPrecisionScore));
-  PeakMemoryScoreConfig_descriptor_ = file->message_type(43);
+  PeakMemoryScoreConfig_descriptor_ = file->message_type(44);
   static const int PeakMemoryScoreConfig_offsets_[1] = {
   };
   PeakMemoryScoreConfig_reflection_ =
@@ -1108,7 +1132,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(PeakMemoryScoreConfig));
-  PeakMemoryScore_descriptor_ = file->message_type(44);
+  PeakMemoryScore_descriptor_ = file->message_type(45);
   static const int PeakMemoryScore_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(PeakMemoryScore, value_),
   };
@@ -1123,7 +1147,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(PeakMemoryScore));
-  TopicModel_descriptor_ = file->message_type(45);
+  TopicModel_descriptor_ = file->message_type(46);
   static const int TopicModel_offsets_[10] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicModel, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TopicModel, topics_count_),
@@ -1163,7 +1187,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TopicModel_TopicModelInternals));
   TopicModel_OperationType_descriptor_ = TopicModel_descriptor_->enum_type(0);
-  ThetaMatrix_descriptor_ = file->message_type(46);
+  ThetaMatrix_descriptor_ = file->message_type(47);
   static const int ThetaMatrix_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaMatrix, item_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ThetaMatrix, item_weights_),
@@ -1183,7 +1207,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ThetaMatrix));
-  CollectionParserConfig_descriptor_ = file->message_type(47);
+  CollectionParserConfig_descriptor_ = file->message_type(48);
   static const int CollectionParserConfig_offsets_[11] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CollectionParserConfig, format_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CollectionParserConfig, docword_file_path_),
@@ -1210,7 +1234,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       sizeof(CollectionParserConfig));
   CollectionParserConfig_Format_descriptor_ = CollectionParserConfig_descriptor_->enum_type(0);
   CollectionParserConfig_NameType_descriptor_ = CollectionParserConfig_descriptor_->enum_type(1);
-  InitializeModelArgs_descriptor_ = file->message_type(48);
+  InitializeModelArgs_descriptor_ = file->message_type(49);
   static const int InitializeModelArgs_offsets_[9] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, model_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(InitializeModelArgs, dictionary_name_),
@@ -1255,7 +1279,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(InitializeModelArgs_Filter));
   InitializeModelArgs_SourceType_descriptor_ = InitializeModelArgs_descriptor_->enum_type(0);
-  DictionaryData_descriptor_ = file->message_type(49);
+  DictionaryData_descriptor_ = file->message_type(50);
   static const int DictionaryData_offsets_[9] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DictionaryData, name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(DictionaryData, token_),
@@ -1278,7 +1302,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(DictionaryData));
-  FilterDictionaryArgs_descriptor_ = file->message_type(50);
+  FilterDictionaryArgs_descriptor_ = file->message_type(51);
   static const int FilterDictionaryArgs_offsets_[9] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(FilterDictionaryArgs, dictionary_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(FilterDictionaryArgs, dictionary_target_name_),
@@ -1301,7 +1325,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(FilterDictionaryArgs));
-  GatherDictionaryArgs_descriptor_ = file->message_type(51);
+  GatherDictionaryArgs_descriptor_ = file->message_type(52);
   static const int GatherDictionaryArgs_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GatherDictionaryArgs, dictionary_target_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GatherDictionaryArgs, data_path_),
@@ -1321,7 +1345,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GatherDictionaryArgs));
-  GetDictionaryArgs_descriptor_ = file->message_type(52);
+  GetDictionaryArgs_descriptor_ = file->message_type(53);
   static const int GetDictionaryArgs_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetDictionaryArgs, dictionary_name_),
   };
@@ -1336,7 +1360,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GetDictionaryArgs));
-  GetTopicModelArgs_descriptor_ = file->message_type(53);
+  GetTopicModelArgs_descriptor_ = file->message_type(54);
   static const int GetTopicModelArgs_offsets_[8] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetTopicModelArgs, model_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetTopicModelArgs, topic_name_),
@@ -1360,11 +1384,10 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       sizeof(GetTopicModelArgs));
   GetTopicModelArgs_RequestType_descriptor_ = GetTopicModelArgs_descriptor_->enum_type(0);
   GetTopicModelArgs_MatrixLayout_descriptor_ = GetTopicModelArgs_descriptor_->enum_type(1);
-  GetThetaMatrixArgs_descriptor_ = file->message_type(54);
-  static const int GetThetaMatrixArgs_offsets_[6] = {
+  GetThetaMatrixArgs_descriptor_ = file->message_type(55);
+  static const int GetThetaMatrixArgs_offsets_[5] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetThetaMatrixArgs, topic_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetThetaMatrixArgs, topic_index_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetThetaMatrixArgs, clean_cache_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetThetaMatrixArgs, use_sparse_format_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetThetaMatrixArgs, eps_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetThetaMatrixArgs, matrix_layout_),
@@ -1381,7 +1404,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GetThetaMatrixArgs));
   GetThetaMatrixArgs_MatrixLayout_descriptor_ = GetThetaMatrixArgs_descriptor_->enum_type(0);
-  GetScoreValueArgs_descriptor_ = file->message_type(55);
+  GetScoreValueArgs_descriptor_ = file->message_type(56);
   static const int GetScoreValueArgs_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetScoreValueArgs, model_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetScoreValueArgs, score_name_),
@@ -1397,7 +1420,22 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GetScoreValueArgs));
-  ExportModelArgs_descriptor_ = file->message_type(56);
+  GetScoreArrayArgs_descriptor_ = file->message_type(57);
+  static const int GetScoreArrayArgs_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetScoreArrayArgs, score_name_),
+  };
+  GetScoreArrayArgs_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      GetScoreArrayArgs_descriptor_,
+      GetScoreArrayArgs::default_instance_,
+      GetScoreArrayArgs_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetScoreArrayArgs, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(GetScoreArrayArgs, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(GetScoreArrayArgs));
+  ExportModelArgs_descriptor_ = file->message_type(58);
   static const int ExportModelArgs_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ExportModelArgs, file_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ExportModelArgs, model_name_),
@@ -1413,7 +1451,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ExportModelArgs));
-  ImportModelArgs_descriptor_ = file->message_type(57);
+  ImportModelArgs_descriptor_ = file->message_type(59);
   static const int ImportModelArgs_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportModelArgs, file_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportModelArgs, model_name_),
@@ -1429,7 +1467,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ImportModelArgs));
-  AttachModelArgs_descriptor_ = file->message_type(58);
+  AttachModelArgs_descriptor_ = file->message_type(60);
   static const int AttachModelArgs_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AttachModelArgs, model_name_),
   };
@@ -1444,7 +1482,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(AttachModelArgs));
-  ProcessBatchesArgs_descriptor_ = file->message_type(59);
+  ProcessBatchesArgs_descriptor_ = file->message_type(61);
   static const int ProcessBatchesArgs_offsets_[16] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesArgs, nwt_target_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesArgs, batch_filename_),
@@ -1475,7 +1513,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ProcessBatchesArgs));
   ProcessBatchesArgs_ThetaMatrixType_descriptor_ = ProcessBatchesArgs_descriptor_->enum_type(0);
-  ProcessBatchesResult_descriptor_ = file->message_type(60);
+  ProcessBatchesResult_descriptor_ = file->message_type(62);
   static const int ProcessBatchesResult_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesResult, score_data_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ProcessBatchesResult, theta_matrix_),
@@ -1491,7 +1529,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ProcessBatchesResult));
-  MergeModelArgs_descriptor_ = file->message_type(61);
+  MergeModelArgs_descriptor_ = file->message_type(63);
   static const int MergeModelArgs_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeModelArgs, nwt_target_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MergeModelArgs, nwt_source_name_),
@@ -1509,7 +1547,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(MergeModelArgs));
-  RegularizeModelArgs_descriptor_ = file->message_type(62);
+  RegularizeModelArgs_descriptor_ = file->message_type(64);
   static const int RegularizeModelArgs_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RegularizeModelArgs, rwt_target_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(RegularizeModelArgs, pwt_source_name_),
@@ -1527,7 +1565,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(RegularizeModelArgs));
-  NormalizeModelArgs_descriptor_ = file->message_type(63);
+  NormalizeModelArgs_descriptor_ = file->message_type(65);
   static const int NormalizeModelArgs_offsets_[3] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NormalizeModelArgs, pwt_target_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(NormalizeModelArgs, nwt_source_name_),
@@ -1544,7 +1582,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(NormalizeModelArgs));
-  ImportDictionaryArgs_descriptor_ = file->message_type(64);
+  ImportDictionaryArgs_descriptor_ = file->message_type(66);
   static const int ImportDictionaryArgs_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportDictionaryArgs, file_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportDictionaryArgs, dictionary_name_),
@@ -1560,7 +1598,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ImportDictionaryArgs));
-  ExportDictionaryArgs_descriptor_ = file->message_type(65);
+  ExportDictionaryArgs_descriptor_ = file->message_type(67);
   static const int ExportDictionaryArgs_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ExportDictionaryArgs, file_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ExportDictionaryArgs, dictionary_name_),
@@ -1576,7 +1614,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ExportDictionaryArgs));
-  CopyRequestResultArgs_descriptor_ = file->message_type(66);
+  CopyRequestResultArgs_descriptor_ = file->message_type(68);
   static const int CopyRequestResultArgs_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CopyRequestResultArgs, request_type_),
   };
@@ -1592,7 +1630,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(CopyRequestResultArgs));
   CopyRequestResultArgs_RequestType_descriptor_ = CopyRequestResultArgs_descriptor_->enum_type(0);
-  DuplicateMasterComponentArgs_descriptor_ = file->message_type(67);
+  DuplicateMasterComponentArgs_descriptor_ = file->message_type(69);
   static const int DuplicateMasterComponentArgs_offsets_[1] = {
   };
   DuplicateMasterComponentArgs_reflection_ =
@@ -1606,7 +1644,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(DuplicateMasterComponentArgs));
-  GetMasterComponentInfoArgs_descriptor_ = file->message_type(68);
+  GetMasterComponentInfoArgs_descriptor_ = file->message_type(70);
   static const int GetMasterComponentInfoArgs_offsets_[1] = {
   };
   GetMasterComponentInfoArgs_reflection_ =
@@ -1620,7 +1658,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(GetMasterComponentInfoArgs));
-  MasterComponentInfo_descriptor_ = file->message_type(69);
+  MasterComponentInfo_descriptor_ = file->message_type(71);
   static const int MasterComponentInfo_offsets_[9] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, master_id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterComponentInfo, config_),
@@ -1742,7 +1780,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(MasterComponentInfo_CacheEntryInfo));
-  ImportBatchesArgs_descriptor_ = file->message_type(70);
+  ImportBatchesArgs_descriptor_ = file->message_type(72);
   static const int ImportBatchesArgs_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportBatchesArgs, batch_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ImportBatchesArgs, batch_),
@@ -1758,7 +1796,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ImportBatchesArgs));
-  AwaitOperationArgs_descriptor_ = file->message_type(71);
+  AwaitOperationArgs_descriptor_ = file->message_type(73);
   static const int AwaitOperationArgs_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(AwaitOperationArgs, timeout_milliseconds_),
   };
@@ -1773,7 +1811,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(AwaitOperationArgs));
-  MasterModelConfig_descriptor_ = file->message_type(72);
+  MasterModelConfig_descriptor_ = file->message_type(74);
   static const int MasterModelConfig_offsets_[14] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterModelConfig, topic_name_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(MasterModelConfig, class_id_),
@@ -1801,7 +1839,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(MasterModelConfig));
-  FitOfflineMasterModelArgs_descriptor_ = file->message_type(73);
+  FitOfflineMasterModelArgs_descriptor_ = file->message_type(75);
   static const int FitOfflineMasterModelArgs_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(FitOfflineMasterModelArgs, batch_filename_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(FitOfflineMasterModelArgs, batch_weight_),
@@ -1819,7 +1857,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(FitOfflineMasterModelArgs));
-  FitOnlineMasterModelArgs_descriptor_ = file->message_type(74);
+  FitOnlineMasterModelArgs_descriptor_ = file->message_type(76);
   static const int FitOnlineMasterModelArgs_offsets_[6] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(FitOnlineMasterModelArgs, batch_filename_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(FitOnlineMasterModelArgs, batch_weight_),
@@ -1839,7 +1877,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(FitOnlineMasterModelArgs));
-  TransformMasterModelArgs_descriptor_ = file->message_type(75);
+  TransformMasterModelArgs_descriptor_ = file->message_type(77);
   static const int TransformMasterModelArgs_offsets_[4] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TransformMasterModelArgs, batch_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TransformMasterModelArgs, batch_filename_),
@@ -1858,7 +1896,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(TransformMasterModelArgs));
   TransformMasterModelArgs_ThetaMatrixType_descriptor_ = TransformMasterModelArgs_descriptor_->enum_type(0);
-  ConfigureLoggingArgs_descriptor_ = file->message_type(76);
+  ConfigureLoggingArgs_descriptor_ = file->message_type(78);
   static const int ConfigureLoggingArgs_offsets_[10] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConfigureLoggingArgs, log_dir_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ConfigureLoggingArgs, minloglevel_),
@@ -1882,7 +1920,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ConfigureLoggingArgs));
-  ClearThetaCacheArgs_descriptor_ = file->message_type(77);
+  ClearThetaCacheArgs_descriptor_ = file->message_type(79);
   static const int ClearThetaCacheArgs_offsets_[1] = {
   };
   ClearThetaCacheArgs_reflection_ =
@@ -1896,7 +1934,7 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ClearThetaCacheArgs));
-  ClearScoreCacheArgs_descriptor_ = file->message_type(78);
+  ClearScoreCacheArgs_descriptor_ = file->message_type(80);
   static const int ClearScoreCacheArgs_offsets_[1] = {
   };
   ClearScoreCacheArgs_reflection_ =
@@ -1910,6 +1948,20 @@ void protobuf_AssignDesc_artm_2fmessages_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(ClearScoreCacheArgs));
+  ClearScoreArrayCacheArgs_descriptor_ = file->message_type(81);
+  static const int ClearScoreArrayCacheArgs_offsets_[1] = {
+  };
+  ClearScoreArrayCacheArgs_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      ClearScoreArrayCacheArgs_descriptor_,
+      ClearScoreArrayCacheArgs::default_instance_,
+      ClearScoreArrayCacheArgs_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClearScoreArrayCacheArgs, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ClearScoreArrayCacheArgs, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(ClearScoreArrayCacheArgs));
 }
 
 namespace {
@@ -1972,6 +2024,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
     ScoreConfig_descriptor_, &ScoreConfig::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     ScoreData_descriptor_, &ScoreData::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    ScoreDataArray_descriptor_, &ScoreDataArray::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     PerplexityScoreConfig_descriptor_, &PerplexityScoreConfig::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
@@ -2039,6 +2093,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     GetScoreValueArgs_descriptor_, &GetScoreValueArgs::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    GetScoreArrayArgs_descriptor_, &GetScoreArrayArgs::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     ExportModelArgs_descriptor_, &ExportModelArgs::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     ImportModelArgs_descriptor_, &ImportModelArgs::default_instance());
@@ -2096,6 +2152,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
     ClearThetaCacheArgs_descriptor_, &ClearThetaCacheArgs::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     ClearScoreCacheArgs_descriptor_, &ClearScoreCacheArgs::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    ClearScoreArrayCacheArgs_descriptor_, &ClearScoreArrayCacheArgs::default_instance());
 }
 
 }  // namespace
@@ -2157,6 +2215,8 @@ void protobuf_ShutdownFile_artm_2fmessages_2eproto() {
   delete ScoreConfig_reflection_;
   delete ScoreData::default_instance_;
   delete ScoreData_reflection_;
+  delete ScoreDataArray::default_instance_;
+  delete ScoreDataArray_reflection_;
   delete PerplexityScoreConfig::default_instance_;
   delete PerplexityScoreConfig_reflection_;
   delete PerplexityScoreConfig::_default_field_name_;
@@ -2237,6 +2297,8 @@ void protobuf_ShutdownFile_artm_2fmessages_2eproto() {
   delete GetThetaMatrixArgs_reflection_;
   delete GetScoreValueArgs::default_instance_;
   delete GetScoreValueArgs_reflection_;
+  delete GetScoreArrayArgs::default_instance_;
+  delete GetScoreArrayArgs_reflection_;
   delete ExportModelArgs::default_instance_;
   delete ExportModelArgs_reflection_;
   delete ImportModelArgs::default_instance_;
@@ -2298,6 +2360,8 @@ void protobuf_ShutdownFile_artm_2fmessages_2eproto() {
   delete ClearThetaCacheArgs_reflection_;
   delete ClearScoreCacheArgs::default_instance_;
   delete ClearScoreCacheArgs_reflection_;
+  delete ClearScoreArrayCacheArgs::default_instance_;
+  delete ClearScoreArrayCacheArgs_reflection_;
 }
 
 void protobuf_AddDesc_artm_2fmessages_2eproto() {
@@ -2402,239 +2466,241 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
     "sityPhi\020\002\022\022\n\016ItemsProcessed\020\003\022\r\n\tTopToke"
     "ns\020\004\022\020\n\014ThetaSnippet\020\005\022\017\n\013TopicKernel\020\006\022"
     "\020\n\014TopicMassPhi\020\007\022\022\n\016ClassPrecision\020\010\022\016\n"
-    "\nPeakMemory\020\t\"\314\002\n\025PerplexityScoreConfig\022"
-    "\031\n\nfield_name\030\001 \001(\t:\005@body\022\034\n\013stream_nam"
-    "e\030\002 \001(\t:\007@global\022J\n\nmodel_type\030\003 \001(\0162 .a"
-    "rtm.PerplexityScoreConfig.Type:\024UnigramD"
-    "ocumentModel\022\027\n\017dictionary_name\030\004 \001(\t\022\"\n"
-    "\022theta_sparsity_eps\030\005 \001(\002:\0061e-037\022!\n\031the"
-    "ta_sparsity_topic_name\030\006 \003(\t\022\020\n\010class_id"
-    "\030\007 \003(\t\"<\n\004Type\022\030\n\024UnigramDocumentModel\020\000"
-    "\022\032\n\026UnigramCollectionModel\020\001\"\274\001\n\017Perplex"
-    "ityScore\022\r\n\005value\030\001 \001(\001\022\013\n\003raw\030\002 \001(\001\022\022\n\n"
-    "normalizer\030\003 \001(\001\022\022\n\nzero_words\030\004 \001(\003\022\034\n\024"
-    "theta_sparsity_value\030\005 \001(\001\022\"\n\032theta_spar"
-    "sity_zero_topics\030\006 \001(\005\022#\n\033theta_sparsity"
-    "_total_topics\030\007 \001(\005\"|\n\030SparsityThetaScor"
-    "eConfig\022\031\n\nfield_name\030\001 \001(\t:\005@body\022\034\n\013st"
-    "ream_name\030\002 \001(\t:\007@global\022\023\n\003eps\030\003 \001(\002:\0061"
-    "e-037\022\022\n\ntopic_name\030\004 \003(\t\"N\n\022SparsityThe"
-    "taScore\022\r\n\005value\030\001 \001(\001\022\023\n\013zero_topics\030\002 "
-    "\001(\003\022\024\n\014total_topics\030\003 \001(\003\"c\n\026SparsityPhi"
-    "ScoreConfig\022\023\n\003eps\030\001 \001(\002:\0061e-037\022 \n\010clas"
-    "s_id\030\002 \001(\t:\016@default_class\022\022\n\ntopic_name"
-    "\030\003 \003(\t\"L\n\020SparsityPhiScore\022\r\n\005value\030\001 \001("
-    "\001\022\023\n\013zero_tokens\030\002 \001(\003\022\024\n\014total_tokens\030\003"
-    " \001(\003\"T\n\031ItemsProcessedScoreConfig\022\031\n\nfie"
-    "ld_name\030\001 \001(\t:\005@body\022\034\n\013stream_name\030\002 \001("
-    "\t:\007@global\"\?\n\023ItemsProcessedScore\022\020\n\005val"
-    "ue\030\001 \001(\005:\0010\022\026\n\013num_batches\030\002 \001(\005:\0010\"\212\001\n\024"
-    "TopTokensScoreConfig\022\026\n\nnum_tokens\030\001 \001(\005"
-    ":\00210\022 \n\010class_id\030\002 \001(\t:\016@default_class\022\022"
-    "\n\ntopic_name\030\003 \003(\t\022$\n\034cooccurrence_dicti"
-    "onary_name\030\004 \001(\t\"\255\001\n\016TopTokensScore\022\023\n\013n"
-    "um_entries\030\001 \001(\005\022\022\n\ntopic_name\030\002 \003(\t\022\023\n\013"
-    "topic_index\030\003 \003(\005\022\r\n\005token\030\004 \003(\t\022\016\n\006weig"
-    "ht\030\005 \003(\002\022#\n\tcoherence\030\006 \001(\0132\020.artm.Float"
-    "Array\022\031\n\021average_coherence\030\007 \001(\002\"\177\n\027Thet"
-    "aSnippetScoreConfig\022\031\n\nfield_name\030\001 \001(\t:"
-    "\005@body\022\034\n\013stream_name\030\002 \001(\t:\007@global\022\023\n\007"
-    "item_id\030\003 \003(\005B\002\020\001\022\026\n\nitem_count\030\004 \001(\005:\0021"
-    "0\"F\n\021ThetaSnippetScore\022\017\n\007item_id\030\001 \003(\005\022"
-    " \n\006values\030\002 \003(\0132\020.artm.FloatArray\"\262\001\n\026To"
-    "picKernelScoreConfig\022\023\n\003eps\030\001 \001(\002:\0061e-03"
-    "7\022 \n\010class_id\030\002 \001(\t:\016@default_class\022\022\n\nt"
-    "opic_name\030\003 \003(\t\022\'\n\032probability_mass_thre"
-    "shold\030\004 \001(\001:\0030.1\022$\n\034cooccurrence_diction"
-    "ary_name\030\005 \001(\t\"\377\002\n\020TopicKernelScore\022&\n\013k"
-    "ernel_size\030\001 \001(\0132\021.artm.DoubleArray\022(\n\rk"
-    "ernel_purity\030\002 \001(\0132\021.artm.DoubleArray\022*\n"
-    "\017kernel_contrast\030\003 \001(\0132\021.artm.DoubleArra"
-    "y\022\033\n\023average_kernel_size\030\004 \001(\001\022\035\n\025averag"
-    "e_kernel_purity\030\005 \001(\001\022\037\n\027average_kernel_"
-    "contrast\030\006 \001(\001\022$\n\tcoherence\030\007 \001(\0132\021.artm"
-    ".DoubleArray\022\031\n\021average_coherence\030\010 \001(\002\022"
-    "(\n\rkernel_tokens\030\t \003(\0132\021.artm.StringArra"
-    "y\022%\n\ntopic_name\030\n \001(\0132\021.artm.StringArray"
-    "\"d\n\027TopicMassPhiScoreConfig\022\023\n\003eps\030\001 \001(\002"
-    ":\0061e-037\022 \n\010class_id\030\002 \001(\t:\016@default_cla"
-    "ss\022\022\n\ntopic_name\030\003 \003(\t\"_\n\021TopicMassPhiSc"
-    "ore\022\r\n\005value\030\001 \001(\001\022\022\n\ntopic_name\030\002 \003(\t\022\023"
-    "\n\013topic_ratio\030\003 \003(\001\022\022\n\ntopic_mass\030\004 \003(\001\""
-    "9\n\031ClassPrecisionScoreConfig\022\034\n\013stream_n"
-    "ame\030\001 \001(\t:\007@global\"B\n\023ClassPrecisionScor"
-    "e\022\r\n\005value\030\001 \001(\001\022\r\n\005error\030\002 \001(\001\022\r\n\005total"
-    "\030\003 \001(\001\"\027\n\025PeakMemoryScoreConfig\" \n\017PeakM"
-    "emoryScore\022\r\n\005value\030\001 \001(\003\"\242\003\n\nTopicModel"
-    "\022\024\n\004name\030\001 \001(\t:\006@model\022\024\n\014topics_count\030\002"
-    " \001(\005\022\022\n\ntopic_name\030\003 \003(\t\022\r\n\005token\030\004 \003(\t\022"
-    "\'\n\rtoken_weights\030\005 \003(\0132\020.artm.FloatArray"
-    "\022\020\n\010class_id\030\006 \003(\t\022\021\n\tinternals\030\007 \001(\014\022#\n"
-    "\013topic_index\030\010 \003(\0132\016.artm.IntArray\0226\n\016op"
-    "eration_type\030\t \003(\0162\036.artm.TopicModel.Ope"
-    "rationType\022\014\n\004seed\030\n \001(\005\0325\n\023TopicModelIn"
-    "ternals\022\036\n\004n_wt\030\001 \003(\0132\020.artm.FloatArray\""
-    "U\n\rOperationType\022\016\n\nInitialize\020\000\022\r\n\tIncr"
-    "ement\020\001\022\r\n\tOverwrite\020\002\022\n\n\006Remove\020\003\022\n\n\006Ig"
-    "nore\020\004\"\251\001\n\013ThetaMatrix\022\017\n\007item_id\030\002 \003(\005\022"
-    "&\n\014item_weights\030\003 \003(\0132\020.artm.FloatArray\022"
-    "\022\n\ntopic_name\030\004 \003(\t\022\024\n\014topics_count\030\005 \001("
-    "\005\022\022\n\nitem_title\030\006 \003(\t\022#\n\013topic_index\030\007 \003"
-    "(\0132\016.artm.IntArray\"\214\004\n\026CollectionParserC"
-    "onfig\022B\n\006format\030\001 \001(\0162#.artm.CollectionP"
-    "arserConfig.Format:\rBagOfWordsUci\022\031\n\021doc"
-    "word_file_path\030\002 \001(\t\022\027\n\017vocab_file_path\030"
-    "\003 \001(\t\022\025\n\rtarget_folder\030\004 \001(\t\022!\n\023num_item"
-    "s_per_batch\030\005 \001(\005:\0041000\022%\n\027use_unity_bas"
-    "ed_indices\030\006 \001(\010:\004true\022>\n\tname_type\030\007 \001("
-    "\0162%.artm.CollectionParserConfig.NameType"
-    ":\004Guid\022\032\n\022cooccurrence_token\030\010 \003(\t\022\023\n\013ga"
-    "ther_cooc\030\t \001(\010\022\035\n\025cooccurrence_class_id"
-    "\030\n \003(\t\022(\n\031use_symmetric_cooc_values\030\013 \001("
-    "\010:\005false\"\?\n\006Format\022\021\n\rBagOfWordsUci\020\000\022\020\n"
-    "\014MatrixMarket\020\001\022\020\n\014VowpalWabbit\020\002\"\036\n\010Nam"
-    "eType\022\010\n\004Guid\020\000\022\010\n\004Code\020\001\"\351\003\n\023Initialize"
-    "ModelArgs\022\022\n\nmodel_name\030\001 \001(\t\022\027\n\017diction"
-    "ary_name\030\002 \001(\t\022\024\n\014topics_count\030\003 \001(\005\022\022\n\n"
-    "topic_name\030\004 \003(\t\022\020\n\004seed\030\005 \001(\005:\002-1\0229\n\013so"
-    "urce_type\030\006 \001(\0162$.artm.InitializeModelAr"
-    "gs.SourceType\022\021\n\tdisk_path\030\007 \001(\t\0220\n\006filt"
-    "er\030\010 \003(\0132 .artm.InitializeModelArgs.Filt"
-    "er\022\026\n\016batch_filename\030\t \003(\t\032\245\001\n\006Filter\022\020\n"
-    "\010class_id\030\001 \001(\t\022\026\n\016min_percentage\030\002 \001(\002\022"
-    "\026\n\016max_percentage\030\003 \001(\002\022\021\n\tmin_items\030\004 \001"
-    "(\005\022\021\n\tmax_items\030\005 \001(\005\022\027\n\017min_total_count"
-    "\030\006 \001(\005\022\032\n\022min_one_item_count\030\007 \001(\005\")\n\nSo"
-    "urceType\022\016\n\nDictionary\020\000\022\013\n\007Batches\020\001\"\301\001"
-    "\n\016DictionaryData\022\014\n\004name\030\001 \001(\t\022\r\n\005token\030"
-    "\002 \003(\t\022\020\n\010class_id\030\003 \003(\t\022\023\n\013token_value\030\004"
-    " \003(\002\022\020\n\010token_tf\030\005 \003(\002\022\020\n\010token_df\030\006 \003(\002"
-    "\022\030\n\020cooc_first_index\030\007 \003(\005\022\031\n\021cooc_secon"
-    "d_index\030\010 \003(\005\022\022\n\ncooc_value\030\t \003(\002\"\313\001\n\024Fi"
-    "lterDictionaryArgs\022\027\n\017dictionary_name\030\001 "
-    "\001(\t\022\036\n\026dictionary_target_name\030\002 \001(\t\022\020\n\010c"
-    "lass_id\030\003 \001(\t\022\016\n\006min_df\030\004 \001(\002\022\016\n\006max_df\030"
-    "\005 \001(\002\022\023\n\013min_df_rate\030\006 \001(\002\022\023\n\013max_df_rat"
-    "e\030\007 \001(\002\022\016\n\006min_tf\030\010 \001(\002\022\016\n\006max_tf\030\t \001(\002\""
-    "\264\001\n\024GatherDictionaryArgs\022\036\n\026dictionary_t"
-    "arget_name\030\001 \001(\t\022\021\n\tdata_path\030\002 \001(\t\022\026\n\016c"
-    "ooc_file_path\030\003 \001(\t\022\027\n\017vocab_file_path\030\004"
-    " \001(\t\022$\n\025symmetric_cooc_values\030\005 \001(\010:\005fal"
-    "se\022\022\n\nbatch_path\030\006 \003(\t\",\n\021GetDictionaryA"
-    "rgs\022\027\n\017dictionary_name\030\001 \001(\t\"\364\002\n\021GetTopi"
-    "cModelArgs\022\022\n\nmodel_name\030\001 \001(\t\022\022\n\ntopic_"
-    "name\030\002 \003(\t\022\r\n\005token\030\003 \003(\t\022\020\n\010class_id\030\004 "
-    "\003(\t\022\031\n\021use_sparse_format\030\005 \001(\010\022\023\n\003eps\030\006 "
-    "\001(\002:\0061e-037\022>\n\014request_type\030\007 \001(\0162#.artm"
-    ".GetTopicModelArgs.RequestType:\003Pwt\022B\n\rm"
-    "atrix_layout\030\010 \001(\0162$.artm.GetTopicModelA"
-    "rgs.MatrixLayout:\005Dense\";\n\013RequestType\022\007"
-    "\n\003Pwt\020\000\022\007\n\003Nwt\020\001\022\016\n\nTopicNames\020\002\022\n\n\006Toke"
-    "ns\020\003\"%\n\014MatrixLayout\022\t\n\005Dense\020\000\022\n\n\006Spars"
-    "e\020\001\"\365\001\n\022GetThetaMatrixArgs\022\022\n\ntopic_name"
-    "\030\003 \003(\t\022\023\n\013topic_index\030\004 \003(\005\022\032\n\013clean_cac"
-    "he\030\005 \001(\010:\005false\022\031\n\021use_sparse_format\030\006 \001"
-    "(\010\022\023\n\003eps\030\007 \001(\002:\0061e-037\022C\n\rmatrix_layout"
-    "\030\010 \001(\0162%.artm.GetThetaMatrixArgs.MatrixL"
-    "ayout:\005Dense\"%\n\014MatrixLayout\022\t\n\005Dense\020\000\022"
-    "\n\n\006Sparse\020\001\";\n\021GetScoreValueArgs\022\022\n\nmode"
-    "l_name\030\001 \001(\t\022\022\n\nscore_name\030\002 \001(\t\"8\n\017Expo"
-    "rtModelArgs\022\021\n\tfile_name\030\001 \001(\t\022\022\n\nmodel_"
-    "name\030\002 \001(\t\"8\n\017ImportModelArgs\022\021\n\tfile_na"
-    "me\030\001 \001(\t\022\022\n\nmodel_name\030\002 \001(\t\"%\n\017AttachMo"
-    "delArgs\022\022\n\nmodel_name\030\001 \001(\t\"\306\004\n\022ProcessB"
-    "atchesArgs\022\027\n\017nwt_target_name\030\001 \001(\t\022\026\n\016b"
-    "atch_filename\030\002 \003(\t\022\027\n\017pwt_source_name\030\003"
-    " \001(\t\022\"\n\026inner_iterations_count\030\004 \001(\005:\00210"
-    "\022\034\n\013stream_name\030\005 \001(\t:\007@global\022\030\n\020regula"
-    "rizer_name\030\006 \003(\t\022\027\n\017regularizer_tau\030\007 \003("
-    "\001\022\020\n\010class_id\030\010 \003(\t\022\024\n\014class_weight\030\t \003("
-    "\002\022\032\n\013reuse_theta\030\n \001(\010:\005false\022\031\n\013opt_for"
-    "_avx\030\013 \001(\010:\004true\022\034\n\016use_sparse_bow\030\014 \001(\010"
-    ":\004true\022J\n\021theta_matrix_type\030\016 \001(\0162(.artm"
-    ".ProcessBatchesArgs.ThetaMatrixType:\005Cac"
-    "he\022\024\n\014batch_weight\030\017 \003(\002\022\030\n\020predict_clas"
-    "s_id\030\021 \001(\t\022\032\n\005batch\030\022 \003(\0132\013.artm.Batch\"\\"
-    "\n\017ThetaMatrixType\022\010\n\004None\020\000\022\t\n\005Dense\020\001\022\n"
-    "\n\006Sparse\020\002\022\t\n\005Cache\020\003\022\r\n\tDensePtdw\020\004\022\016\n\n"
-    "SparsePtdw\020\005\"d\n\024ProcessBatchesResult\022#\n\n"
-    "score_data\030\001 \003(\0132\017.artm.ScoreData\022\'\n\014the"
-    "ta_matrix\030\002 \001(\0132\021.artm.ThetaMatrix\"m\n\016Me"
-    "rgeModelArgs\022\027\n\017nwt_target_name\030\001 \001(\t\022\027\n"
-    "\017nwt_source_name\030\002 \003(\t\022\025\n\rsource_weight\030"
-    "\003 \003(\002\022\022\n\ntopic_name\030\004 \003(\t\"\231\001\n\023Regularize"
-    "ModelArgs\022\027\n\017rwt_target_name\030\001 \001(\t\022\027\n\017pw"
-    "t_source_name\030\002 \001(\t\022\027\n\017nwt_source_name\030\003"
-    " \001(\t\0227\n\024regularizer_settings\030\004 \003(\0132\031.art"
-    "m.RegularizerSettings\"_\n\022NormalizeModelA"
-    "rgs\022\027\n\017pwt_target_name\030\001 \001(\t\022\027\n\017nwt_sour"
-    "ce_name\030\002 \001(\t\022\027\n\017rwt_source_name\030\003 \001(\t\"B"
-    "\n\024ImportDictionaryArgs\022\021\n\tfile_name\030\001 \001("
-    "\t\022\027\n\017dictionary_name\030\002 \001(\t\"B\n\024ExportDict"
-    "ionaryArgs\022\021\n\tfile_name\030\001 \001(\t\022\027\n\017diction"
-    "ary_name\030\002 \001(\t\"\301\001\n\025CopyRequestResultArgs"
-    "\022Q\n\014request_type\030\001 \001(\0162\'.artm.CopyReques"
-    "tResultArgs.RequestType:\022DefaultRequestT"
-    "ype\"U\n\013RequestType\022\026\n\022DefaultRequestType"
-    "\020\000\022\026\n\022GetThetaSecondPass\020\001\022\026\n\022GetModelSe"
-    "condPass\020\002\"\036\n\034DuplicateMasterComponentAr"
-    "gs\"\034\n\032GetMasterComponentInfoArgs\"\246\006\n\023Mas"
-    "terComponentInfo\022\021\n\tmaster_id\030\001 \001(\005\022+\n\006c"
-    "onfig\030\002 \001(\0132\033.artm.MasterComponentConfig"
-    "\022>\n\013regularizer\030\003 \003(\0132).artm.MasterCompo"
-    "nentInfo.RegularizerInfo\0222\n\005score\030\004 \003(\0132"
-    "#.artm.MasterComponentInfo.ScoreInfo\022<\n\n"
-    "dictionary\030\005 \003(\0132(.artm.MasterComponentI"
-    "nfo.DictionaryInfo\0222\n\005model\030\006 \003(\0132#.artm"
-    ".MasterComponentInfo.ModelInfo\022=\n\013cache_"
-    "entry\030\007 \003(\0132(.artm.MasterComponentInfo.C"
-    "acheEntryInfo\022\034\n\024processor_queue_size\030\t "
-    "\001(\005\0222\n\005batch\030\n \003(\0132#.artm.MasterComponen"
-    "tInfo.BatchInfo\032-\n\017RegularizerInfo\022\014\n\004na"
-    "me\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\032\'\n\tScoreInfo\022\014\n\004n"
-    "ame\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\0325\n\016DictionaryInf"
-    "o\022\014\n\004name\030\001 \001(\t\022\025\n\rentries_count\030\002 \001(\003\032C"
-    "\n\tBatchInfo\022\014\n\004name\030\001 \001(\t\022\023\n\013items_count"
-    "\030\002 \001(\005\022\023\n\013token_count\030\003 \001(\005\032R\n\tModelInfo"
-    "\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\024\n\014topics_c"
-    "ount\030\003 \001(\005\022\023\n\013token_count\030\004 \001(\005\0320\n\016Cache"
-    "EntryInfo\022\013\n\003key\030\001 \001(\t\022\021\n\tbyte_size\030\002 \001("
-    "\005\"C\n\021ImportBatchesArgs\022\022\n\nbatch_name\030\001 \003"
-    "(\t\022\032\n\005batch\030\003 \003(\0132\013.artm.Batch\"6\n\022AwaitO"
-    "perationArgs\022 \n\024timeout_milliseconds\030\001 \001"
-    "(\005:\002-1\"\226\003\n\021MasterModelConfig\022\022\n\ntopic_na"
-    "me\030\001 \003(\t\022\020\n\010class_id\030\002 \003(\t\022\024\n\014class_weig"
-    "ht\030\003 \003(\002\022\'\n\014score_config\030\004 \003(\0132\021.artm.Sc"
-    "oreConfig\0223\n\022regularizer_config\030\005 \003(\0132\027."
-    "artm.RegularizerConfig\022\017\n\007threads\030\006 \001(\005\022"
-    "\025\n\010pwt_name\030\007 \001(\t:\003pwt\022\025\n\010nwt_name\030\010 \001(\t"
-    ":\003nwt\022\036\n\026inner_iterations_count\030\t \001(\005\022\032\n"
-    "\013reuse_theta\030\n \001(\010:\005false\022\031\n\013opt_for_avx"
-    "\030\013 \001(\010:\004true\022\034\n\016use_sparse_bow\030\014 \001(\010:\004tr"
-    "ue\022\027\n\017disk_cache_path\030\r \001(\t\022\032\n\013cache_the"
-    "ta\030\017 \001(\010:\005false\"r\n\031FitOfflineMasterModel"
-    "Args\022\026\n\016batch_filename\030\001 \003(\t\022\024\n\014batch_we"
-    "ight\030\002 \003(\002\022\021\n\006passes\030\003 \001(\005:\0011\022\024\n\014batch_f"
-    "older\030\004 \001(\t\"\240\001\n\030FitOnlineMasterModelArgs"
-    "\022\026\n\016batch_filename\030\001 \003(\t\022\024\n\014batch_weight"
-    "\030\002 \003(\002\022\024\n\014update_after\030\003 \003(\005\022\024\n\014apply_we"
-    "ight\030\004 \003(\002\022\024\n\014decay_weight\030\005 \003(\002\022\024\n\005asyn"
-    "c\030\006 \001(\010:\005false\"\230\002\n\030TransformMasterModelA"
-    "rgs\022\032\n\005batch\030\001 \003(\0132\013.artm.Batch\022\026\n\016batch"
-    "_filename\030\002 \003(\t\022P\n\021theta_matrix_type\030\003 \001"
-    "(\0162..artm.TransformMasterModelArgs.Theta"
-    "MatrixType:\005Dense\022\030\n\020predict_class_id\030\004 "
-    "\001(\t\"\\\n\017ThetaMatrixType\022\010\n\004None\020\000\022\t\n\005Dens"
-    "e\020\001\022\n\n\006Sparse\020\002\022\t\n\005Cache\020\003\022\r\n\tDensePtdw\020"
-    "\004\022\016\n\nSparsePtdw\020\005\"\377\001\n\024ConfigureLoggingAr"
-    "gs\022\017\n\007log_dir\030\001 \001(\t\022\023\n\013minloglevel\030\002 \001(\005"
-    "\022\027\n\017stderrthreshold\030\003 \001(\005\022\023\n\013logtostderr"
-    "\030\004 \001(\010\022\030\n\020colorlogtostderr\030\005 \001(\010\022\027\n\017also"
-    "logtostderr\030\006 \001(\010\022\022\n\nlogbufsecs\030\007 \001(\005\022\023\n"
-    "\013logbuflevel\030\010 \001(\005\022\024\n\014max_log_size\030\t \001(\005"
-    "\022!\n\031stop_logging_if_full_disk\030\n \001(\010\"\025\n\023C"
-    "learThetaCacheArgs\"\025\n\023ClearScoreCacheArg"
-    "s", 13081);
+    "\nPeakMemory\020\t\"0\n\016ScoreDataArray\022\036\n\005score"
+    "\030\001 \003(\0132\017.artm.ScoreData\"\314\002\n\025PerplexitySc"
+    "oreConfig\022\031\n\nfield_name\030\001 \001(\t:\005@body\022\034\n\013"
+    "stream_name\030\002 \001(\t:\007@global\022J\n\nmodel_type"
+    "\030\003 \001(\0162 .artm.PerplexityScoreConfig.Type"
+    ":\024UnigramDocumentModel\022\027\n\017dictionary_nam"
+    "e\030\004 \001(\t\022\"\n\022theta_sparsity_eps\030\005 \001(\002:\0061e-"
+    "037\022!\n\031theta_sparsity_topic_name\030\006 \003(\t\022\020"
+    "\n\010class_id\030\007 \003(\t\"<\n\004Type\022\030\n\024UnigramDocum"
+    "entModel\020\000\022\032\n\026UnigramCollectionModel\020\001\"\274"
+    "\001\n\017PerplexityScore\022\r\n\005value\030\001 \001(\001\022\013\n\003raw"
+    "\030\002 \001(\001\022\022\n\nnormalizer\030\003 \001(\001\022\022\n\nzero_words"
+    "\030\004 \001(\003\022\034\n\024theta_sparsity_value\030\005 \001(\001\022\"\n\032"
+    "theta_sparsity_zero_topics\030\006 \001(\005\022#\n\033thet"
+    "a_sparsity_total_topics\030\007 \001(\005\"|\n\030Sparsit"
+    "yThetaScoreConfig\022\031\n\nfield_name\030\001 \001(\t:\005@"
+    "body\022\034\n\013stream_name\030\002 \001(\t:\007@global\022\023\n\003ep"
+    "s\030\003 \001(\002:\0061e-037\022\022\n\ntopic_name\030\004 \003(\t\"N\n\022S"
+    "parsityThetaScore\022\r\n\005value\030\001 \001(\001\022\023\n\013zero"
+    "_topics\030\002 \001(\003\022\024\n\014total_topics\030\003 \001(\003\"c\n\026S"
+    "parsityPhiScoreConfig\022\023\n\003eps\030\001 \001(\002:\0061e-0"
+    "37\022 \n\010class_id\030\002 \001(\t:\016@default_class\022\022\n\n"
+    "topic_name\030\003 \003(\t\"L\n\020SparsityPhiScore\022\r\n\005"
+    "value\030\001 \001(\001\022\023\n\013zero_tokens\030\002 \001(\003\022\024\n\014tota"
+    "l_tokens\030\003 \001(\003\"T\n\031ItemsProcessedScoreCon"
+    "fig\022\031\n\nfield_name\030\001 \001(\t:\005@body\022\034\n\013stream"
+    "_name\030\002 \001(\t:\007@global\"\?\n\023ItemsProcessedSc"
+    "ore\022\020\n\005value\030\001 \001(\005:\0010\022\026\n\013num_batches\030\002 \001"
+    "(\005:\0010\"\212\001\n\024TopTokensScoreConfig\022\026\n\nnum_to"
+    "kens\030\001 \001(\005:\00210\022 \n\010class_id\030\002 \001(\t:\016@defau"
+    "lt_class\022\022\n\ntopic_name\030\003 \003(\t\022$\n\034cooccurr"
+    "ence_dictionary_name\030\004 \001(\t\"\255\001\n\016TopTokens"
+    "Score\022\023\n\013num_entries\030\001 \001(\005\022\022\n\ntopic_name"
+    "\030\002 \003(\t\022\023\n\013topic_index\030\003 \003(\005\022\r\n\005token\030\004 \003"
+    "(\t\022\016\n\006weight\030\005 \003(\002\022#\n\tcoherence\030\006 \001(\0132\020."
+    "artm.FloatArray\022\031\n\021average_coherence\030\007 \001"
+    "(\002\"\177\n\027ThetaSnippetScoreConfig\022\031\n\nfield_n"
+    "ame\030\001 \001(\t:\005@body\022\034\n\013stream_name\030\002 \001(\t:\007@"
+    "global\022\023\n\007item_id\030\003 \003(\005B\002\020\001\022\026\n\nitem_coun"
+    "t\030\004 \001(\005:\00210\"F\n\021ThetaSnippetScore\022\017\n\007item"
+    "_id\030\001 \003(\005\022 \n\006values\030\002 \003(\0132\020.artm.FloatAr"
+    "ray\"\262\001\n\026TopicKernelScoreConfig\022\023\n\003eps\030\001 "
+    "\001(\002:\0061e-037\022 \n\010class_id\030\002 \001(\t:\016@default_"
+    "class\022\022\n\ntopic_name\030\003 \003(\t\022\'\n\032probability"
+    "_mass_threshold\030\004 \001(\001:\0030.1\022$\n\034cooccurren"
+    "ce_dictionary_name\030\005 \001(\t\"\377\002\n\020TopicKernel"
+    "Score\022&\n\013kernel_size\030\001 \001(\0132\021.artm.Double"
+    "Array\022(\n\rkernel_purity\030\002 \001(\0132\021.artm.Doub"
+    "leArray\022*\n\017kernel_contrast\030\003 \001(\0132\021.artm."
+    "DoubleArray\022\033\n\023average_kernel_size\030\004 \001(\001"
+    "\022\035\n\025average_kernel_purity\030\005 \001(\001\022\037\n\027avera"
+    "ge_kernel_contrast\030\006 \001(\001\022$\n\tcoherence\030\007 "
+    "\001(\0132\021.artm.DoubleArray\022\031\n\021average_cohere"
+    "nce\030\010 \001(\002\022(\n\rkernel_tokens\030\t \003(\0132\021.artm."
+    "StringArray\022%\n\ntopic_name\030\n \001(\0132\021.artm.S"
+    "tringArray\"d\n\027TopicMassPhiScoreConfig\022\023\n"
+    "\003eps\030\001 \001(\002:\0061e-037\022 \n\010class_id\030\002 \001(\t:\016@d"
+    "efault_class\022\022\n\ntopic_name\030\003 \003(\t\"_\n\021Topi"
+    "cMassPhiScore\022\r\n\005value\030\001 \001(\001\022\022\n\ntopic_na"
+    "me\030\002 \003(\t\022\023\n\013topic_ratio\030\003 \003(\001\022\022\n\ntopic_m"
+    "ass\030\004 \003(\001\"9\n\031ClassPrecisionScoreConfig\022\034"
+    "\n\013stream_name\030\001 \001(\t:\007@global\"B\n\023ClassPre"
+    "cisionScore\022\r\n\005value\030\001 \001(\001\022\r\n\005error\030\002 \001("
+    "\001\022\r\n\005total\030\003 \001(\001\"\027\n\025PeakMemoryScoreConfi"
+    "g\" \n\017PeakMemoryScore\022\r\n\005value\030\001 \001(\003\"\242\003\n\n"
+    "TopicModel\022\024\n\004name\030\001 \001(\t:\006@model\022\024\n\014topi"
+    "cs_count\030\002 \001(\005\022\022\n\ntopic_name\030\003 \003(\t\022\r\n\005to"
+    "ken\030\004 \003(\t\022\'\n\rtoken_weights\030\005 \003(\0132\020.artm."
+    "FloatArray\022\020\n\010class_id\030\006 \003(\t\022\021\n\tinternal"
+    "s\030\007 \001(\014\022#\n\013topic_index\030\010 \003(\0132\016.artm.IntA"
+    "rray\0226\n\016operation_type\030\t \003(\0162\036.artm.Topi"
+    "cModel.OperationType\022\014\n\004seed\030\n \001(\005\0325\n\023To"
+    "picModelInternals\022\036\n\004n_wt\030\001 \003(\0132\020.artm.F"
+    "loatArray\"U\n\rOperationType\022\016\n\nInitialize"
+    "\020\000\022\r\n\tIncrement\020\001\022\r\n\tOverwrite\020\002\022\n\n\006Remo"
+    "ve\020\003\022\n\n\006Ignore\020\004\"\251\001\n\013ThetaMatrix\022\017\n\007item"
+    "_id\030\002 \003(\005\022&\n\014item_weights\030\003 \003(\0132\020.artm.F"
+    "loatArray\022\022\n\ntopic_name\030\004 \003(\t\022\024\n\014topics_"
+    "count\030\005 \001(\005\022\022\n\nitem_title\030\006 \003(\t\022#\n\013topic"
+    "_index\030\007 \003(\0132\016.artm.IntArray\"\214\004\n\026Collect"
+    "ionParserConfig\022B\n\006format\030\001 \001(\0162#.artm.C"
+    "ollectionParserConfig.Format:\rBagOfWords"
+    "Uci\022\031\n\021docword_file_path\030\002 \001(\t\022\027\n\017vocab_"
+    "file_path\030\003 \001(\t\022\025\n\rtarget_folder\030\004 \001(\t\022!"
+    "\n\023num_items_per_batch\030\005 \001(\005:\0041000\022%\n\027use"
+    "_unity_based_indices\030\006 \001(\010:\004true\022>\n\tname"
+    "_type\030\007 \001(\0162%.artm.CollectionParserConfi"
+    "g.NameType:\004Guid\022\032\n\022cooccurrence_token\030\010"
+    " \003(\t\022\023\n\013gather_cooc\030\t \001(\010\022\035\n\025cooccurrenc"
+    "e_class_id\030\n \003(\t\022(\n\031use_symmetric_cooc_v"
+    "alues\030\013 \001(\010:\005false\"\?\n\006Format\022\021\n\rBagOfWor"
+    "dsUci\020\000\022\020\n\014MatrixMarket\020\001\022\020\n\014VowpalWabbi"
+    "t\020\002\"\036\n\010NameType\022\010\n\004Guid\020\000\022\010\n\004Code\020\001\"\351\003\n\023"
+    "InitializeModelArgs\022\022\n\nmodel_name\030\001 \001(\t\022"
+    "\027\n\017dictionary_name\030\002 \001(\t\022\024\n\014topics_count"
+    "\030\003 \001(\005\022\022\n\ntopic_name\030\004 \003(\t\022\020\n\004seed\030\005 \001(\005"
+    ":\002-1\0229\n\013source_type\030\006 \001(\0162$.artm.Initial"
+    "izeModelArgs.SourceType\022\021\n\tdisk_path\030\007 \001"
+    "(\t\0220\n\006filter\030\010 \003(\0132 .artm.InitializeMode"
+    "lArgs.Filter\022\026\n\016batch_filename\030\t \003(\t\032\245\001\n"
+    "\006Filter\022\020\n\010class_id\030\001 \001(\t\022\026\n\016min_percent"
+    "age\030\002 \001(\002\022\026\n\016max_percentage\030\003 \001(\002\022\021\n\tmin"
+    "_items\030\004 \001(\005\022\021\n\tmax_items\030\005 \001(\005\022\027\n\017min_t"
+    "otal_count\030\006 \001(\005\022\032\n\022min_one_item_count\030\007"
+    " \001(\005\")\n\nSourceType\022\016\n\nDictionary\020\000\022\013\n\007Ba"
+    "tches\020\001\"\301\001\n\016DictionaryData\022\014\n\004name\030\001 \001(\t"
+    "\022\r\n\005token\030\002 \003(\t\022\020\n\010class_id\030\003 \003(\t\022\023\n\013tok"
+    "en_value\030\004 \003(\002\022\020\n\010token_tf\030\005 \003(\002\022\020\n\010toke"
+    "n_df\030\006 \003(\002\022\030\n\020cooc_first_index\030\007 \003(\005\022\031\n\021"
+    "cooc_second_index\030\010 \003(\005\022\022\n\ncooc_value\030\t "
+    "\003(\002\"\313\001\n\024FilterDictionaryArgs\022\027\n\017dictiona"
+    "ry_name\030\001 \001(\t\022\036\n\026dictionary_target_name\030"
+    "\002 \001(\t\022\020\n\010class_id\030\003 \001(\t\022\016\n\006min_df\030\004 \001(\002\022"
+    "\016\n\006max_df\030\005 \001(\002\022\023\n\013min_df_rate\030\006 \001(\002\022\023\n\013"
+    "max_df_rate\030\007 \001(\002\022\016\n\006min_tf\030\010 \001(\002\022\016\n\006max"
+    "_tf\030\t \001(\002\"\264\001\n\024GatherDictionaryArgs\022\036\n\026di"
+    "ctionary_target_name\030\001 \001(\t\022\021\n\tdata_path\030"
+    "\002 \001(\t\022\026\n\016cooc_file_path\030\003 \001(\t\022\027\n\017vocab_f"
+    "ile_path\030\004 \001(\t\022$\n\025symmetric_cooc_values\030"
+    "\005 \001(\010:\005false\022\022\n\nbatch_path\030\006 \003(\t\",\n\021GetD"
+    "ictionaryArgs\022\027\n\017dictionary_name\030\001 \001(\t\"\364"
+    "\002\n\021GetTopicModelArgs\022\022\n\nmodel_name\030\001 \001(\t"
+    "\022\022\n\ntopic_name\030\002 \003(\t\022\r\n\005token\030\003 \003(\t\022\020\n\010c"
+    "lass_id\030\004 \003(\t\022\031\n\021use_sparse_format\030\005 \001(\010"
+    "\022\023\n\003eps\030\006 \001(\002:\0061e-037\022>\n\014request_type\030\007 "
+    "\001(\0162#.artm.GetTopicModelArgs.RequestType"
+    ":\003Pwt\022B\n\rmatrix_layout\030\010 \001(\0162$.artm.GetT"
+    "opicModelArgs.MatrixLayout:\005Dense\";\n\013Req"
+    "uestType\022\007\n\003Pwt\020\000\022\007\n\003Nwt\020\001\022\016\n\nTopicNames"
+    "\020\002\022\n\n\006Tokens\020\003\"%\n\014MatrixLayout\022\t\n\005Dense\020"
+    "\000\022\n\n\006Sparse\020\001\"\331\001\n\022GetThetaMatrixArgs\022\022\n\n"
+    "topic_name\030\003 \003(\t\022\023\n\013topic_index\030\004 \003(\005\022\031\n"
+    "\021use_sparse_format\030\006 \001(\010\022\023\n\003eps\030\007 \001(\002:\0061"
+    "e-037\022C\n\rmatrix_layout\030\010 \001(\0162%.artm.GetT"
+    "hetaMatrixArgs.MatrixLayout:\005Dense\"%\n\014Ma"
+    "trixLayout\022\t\n\005Dense\020\000\022\n\n\006Sparse\020\001\";\n\021Get"
+    "ScoreValueArgs\022\022\n\nmodel_name\030\001 \001(\t\022\022\n\nsc"
+    "ore_name\030\002 \001(\t\"\'\n\021GetScoreArrayArgs\022\022\n\ns"
+    "core_name\030\002 \001(\t\"8\n\017ExportModelArgs\022\021\n\tfi"
+    "le_name\030\001 \001(\t\022\022\n\nmodel_name\030\002 \001(\t\"8\n\017Imp"
+    "ortModelArgs\022\021\n\tfile_name\030\001 \001(\t\022\022\n\nmodel"
+    "_name\030\002 \001(\t\"%\n\017AttachModelArgs\022\022\n\nmodel_"
+    "name\030\001 \001(\t\"\306\004\n\022ProcessBatchesArgs\022\027\n\017nwt"
+    "_target_name\030\001 \001(\t\022\026\n\016batch_filename\030\002 \003"
+    "(\t\022\027\n\017pwt_source_name\030\003 \001(\t\022\"\n\026inner_ite"
+    "rations_count\030\004 \001(\005:\00210\022\034\n\013stream_name\030\005"
+    " \001(\t:\007@global\022\030\n\020regularizer_name\030\006 \003(\t\022"
+    "\027\n\017regularizer_tau\030\007 \003(\001\022\020\n\010class_id\030\010 \003"
+    "(\t\022\024\n\014class_weight\030\t \003(\002\022\032\n\013reuse_theta\030"
+    "\n \001(\010:\005false\022\031\n\013opt_for_avx\030\013 \001(\010:\004true\022"
+    "\034\n\016use_sparse_bow\030\014 \001(\010:\004true\022J\n\021theta_m"
+    "atrix_type\030\016 \001(\0162(.artm.ProcessBatchesAr"
+    "gs.ThetaMatrixType:\005Cache\022\024\n\014batch_weigh"
+    "t\030\017 \003(\002\022\030\n\020predict_class_id\030\021 \001(\t\022\032\n\005bat"
+    "ch\030\022 \003(\0132\013.artm.Batch\"\\\n\017ThetaMatrixType"
+    "\022\010\n\004None\020\000\022\t\n\005Dense\020\001\022\n\n\006Sparse\020\002\022\t\n\005Cac"
+    "he\020\003\022\r\n\tDensePtdw\020\004\022\016\n\nSparsePtdw\020\005\"d\n\024P"
+    "rocessBatchesResult\022#\n\nscore_data\030\001 \003(\0132"
+    "\017.artm.ScoreData\022\'\n\014theta_matrix\030\002 \001(\0132\021"
+    ".artm.ThetaMatrix\"m\n\016MergeModelArgs\022\027\n\017n"
+    "wt_target_name\030\001 \001(\t\022\027\n\017nwt_source_name\030"
+    "\002 \003(\t\022\025\n\rsource_weight\030\003 \003(\002\022\022\n\ntopic_na"
+    "me\030\004 \003(\t\"\231\001\n\023RegularizeModelArgs\022\027\n\017rwt_"
+    "target_name\030\001 \001(\t\022\027\n\017pwt_source_name\030\002 \001"
+    "(\t\022\027\n\017nwt_source_name\030\003 \001(\t\0227\n\024regulariz"
+    "er_settings\030\004 \003(\0132\031.artm.RegularizerSett"
+    "ings\"_\n\022NormalizeModelArgs\022\027\n\017pwt_target"
+    "_name\030\001 \001(\t\022\027\n\017nwt_source_name\030\002 \001(\t\022\027\n\017"
+    "rwt_source_name\030\003 \001(\t\"B\n\024ImportDictionar"
+    "yArgs\022\021\n\tfile_name\030\001 \001(\t\022\027\n\017dictionary_n"
+    "ame\030\002 \001(\t\"B\n\024ExportDictionaryArgs\022\021\n\tfil"
+    "e_name\030\001 \001(\t\022\027\n\017dictionary_name\030\002 \001(\t\"\301\001"
+    "\n\025CopyRequestResultArgs\022Q\n\014request_type\030"
+    "\001 \001(\0162\'.artm.CopyRequestResultArgs.Reque"
+    "stType:\022DefaultRequestType\"U\n\013RequestTyp"
+    "e\022\026\n\022DefaultRequestType\020\000\022\026\n\022GetThetaSec"
+    "ondPass\020\001\022\026\n\022GetModelSecondPass\020\002\"\036\n\034Dup"
+    "licateMasterComponentArgs\"\034\n\032GetMasterCo"
+    "mponentInfoArgs\"\246\006\n\023MasterComponentInfo\022"
+    "\021\n\tmaster_id\030\001 \001(\005\022+\n\006config\030\002 \001(\0132\033.art"
+    "m.MasterComponentConfig\022>\n\013regularizer\030\003"
+    " \003(\0132).artm.MasterComponentInfo.Regulari"
+    "zerInfo\0222\n\005score\030\004 \003(\0132#.artm.MasterComp"
+    "onentInfo.ScoreInfo\022<\n\ndictionary\030\005 \003(\0132"
+    "(.artm.MasterComponentInfo.DictionaryInf"
+    "o\0222\n\005model\030\006 \003(\0132#.artm.MasterComponentI"
+    "nfo.ModelInfo\022=\n\013cache_entry\030\007 \003(\0132(.art"
+    "m.MasterComponentInfo.CacheEntryInfo\022\034\n\024"
+    "processor_queue_size\030\t \001(\005\0222\n\005batch\030\n \003("
+    "\0132#.artm.MasterComponentInfo.BatchInfo\032-"
+    "\n\017RegularizerInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030"
+    "\002 \001(\t\032\'\n\tScoreInfo\022\014\n\004name\030\001 \001(\t\022\014\n\004type"
+    "\030\002 \001(\t\0325\n\016DictionaryInfo\022\014\n\004name\030\001 \001(\t\022\025"
+    "\n\rentries_count\030\002 \001(\003\032C\n\tBatchInfo\022\014\n\004na"
+    "me\030\001 \001(\t\022\023\n\013items_count\030\002 \001(\005\022\023\n\013token_c"
+    "ount\030\003 \001(\005\032R\n\tModelInfo\022\014\n\004name\030\001 \001(\t\022\014\n"
+    "\004type\030\002 \001(\t\022\024\n\014topics_count\030\003 \001(\005\022\023\n\013tok"
+    "en_count\030\004 \001(\005\0320\n\016CacheEntryInfo\022\013\n\003key\030"
+    "\001 \001(\t\022\021\n\tbyte_size\030\002 \001(\005\"C\n\021ImportBatche"
+    "sArgs\022\022\n\nbatch_name\030\001 \003(\t\022\032\n\005batch\030\003 \003(\013"
+    "2\013.artm.Batch\"6\n\022AwaitOperationArgs\022 \n\024t"
+    "imeout_milliseconds\030\001 \001(\005:\002-1\"\226\003\n\021Master"
+    "ModelConfig\022\022\n\ntopic_name\030\001 \003(\t\022\020\n\010class"
+    "_id\030\002 \003(\t\022\024\n\014class_weight\030\003 \003(\002\022\'\n\014score"
+    "_config\030\004 \003(\0132\021.artm.ScoreConfig\0223\n\022regu"
+    "larizer_config\030\005 \003(\0132\027.artm.RegularizerC"
+    "onfig\022\017\n\007threads\030\006 \001(\005\022\025\n\010pwt_name\030\007 \001(\t"
+    ":\003pwt\022\025\n\010nwt_name\030\010 \001(\t:\003nwt\022\036\n\026inner_it"
+    "erations_count\030\t \001(\005\022\032\n\013reuse_theta\030\n \001("
+    "\010:\005false\022\031\n\013opt_for_avx\030\013 \001(\010:\004true\022\034\n\016u"
+    "se_sparse_bow\030\014 \001(\010:\004true\022\027\n\017disk_cache_"
+    "path\030\r \001(\t\022\032\n\013cache_theta\030\017 \001(\010:\005false\"r"
+    "\n\031FitOfflineMasterModelArgs\022\026\n\016batch_fil"
+    "ename\030\001 \003(\t\022\024\n\014batch_weight\030\002 \003(\002\022\021\n\006pas"
+    "ses\030\003 \001(\005:\0011\022\024\n\014batch_folder\030\004 \001(\t\"\240\001\n\030F"
+    "itOnlineMasterModelArgs\022\026\n\016batch_filenam"
+    "e\030\001 \003(\t\022\024\n\014batch_weight\030\002 \003(\002\022\024\n\014update_"
+    "after\030\003 \003(\005\022\024\n\014apply_weight\030\004 \003(\002\022\024\n\014dec"
+    "ay_weight\030\005 \003(\002\022\024\n\005async\030\006 \001(\010:\005false\"\230\002"
+    "\n\030TransformMasterModelArgs\022\032\n\005batch\030\001 \003("
+    "\0132\013.artm.Batch\022\026\n\016batch_filename\030\002 \003(\t\022P"
+    "\n\021theta_matrix_type\030\003 \001(\0162..artm.Transfo"
+    "rmMasterModelArgs.ThetaMatrixType:\005Dense"
+    "\022\030\n\020predict_class_id\030\004 \001(\t\"\\\n\017ThetaMatri"
+    "xType\022\010\n\004None\020\000\022\t\n\005Dense\020\001\022\n\n\006Sparse\020\002\022\t"
+    "\n\005Cache\020\003\022\r\n\tDensePtdw\020\004\022\016\n\nSparsePtdw\020\005"
+    "\"\377\001\n\024ConfigureLoggingArgs\022\017\n\007log_dir\030\001 \001"
+    "(\t\022\023\n\013minloglevel\030\002 \001(\005\022\027\n\017stderrthresho"
+    "ld\030\003 \001(\005\022\023\n\013logtostderr\030\004 \001(\010\022\030\n\020colorlo"
+    "gtostderr\030\005 \001(\010\022\027\n\017alsologtostderr\030\006 \001(\010"
+    "\022\022\n\nlogbufsecs\030\007 \001(\005\022\023\n\013logbuflevel\030\010 \001("
+    "\005\022\024\n\014max_log_size\030\t \001(\005\022!\n\031stop_logging_"
+    "if_full_disk\030\n \001(\010\"\025\n\023ClearThetaCacheArg"
+    "s\"\025\n\023ClearScoreCacheArgs\"\032\n\030ClearScoreAr"
+    "rayCacheArgs", 13172);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "artm/messages.proto", &protobuf_RegisterTypes);
   DoubleArray::default_instance_ = new DoubleArray();
@@ -2674,6 +2740,7 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
   TransformConfig::default_instance_ = new TransformConfig();
   ScoreConfig::default_instance_ = new ScoreConfig();
   ScoreData::default_instance_ = new ScoreData();
+  ScoreDataArray::default_instance_ = new ScoreDataArray();
   PerplexityScoreConfig::_default_field_name_ =
       new ::std::string("@body", 5);
   PerplexityScoreConfig::_default_stream_name_ =
@@ -2735,6 +2802,7 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
   GetTopicModelArgs::default_instance_ = new GetTopicModelArgs();
   GetThetaMatrixArgs::default_instance_ = new GetThetaMatrixArgs();
   GetScoreValueArgs::default_instance_ = new GetScoreValueArgs();
+  GetScoreArrayArgs::default_instance_ = new GetScoreArrayArgs();
   ExportModelArgs::default_instance_ = new ExportModelArgs();
   ImportModelArgs::default_instance_ = new ImportModelArgs();
   AttachModelArgs::default_instance_ = new AttachModelArgs();
@@ -2770,6 +2838,7 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
   ConfigureLoggingArgs::default_instance_ = new ConfigureLoggingArgs();
   ClearThetaCacheArgs::default_instance_ = new ClearThetaCacheArgs();
   ClearScoreCacheArgs::default_instance_ = new ClearScoreCacheArgs();
+  ClearScoreArrayCacheArgs::default_instance_ = new ClearScoreArrayCacheArgs();
   DoubleArray::default_instance_->InitAsDefaultInstance();
   FloatArray::default_instance_->InitAsDefaultInstance();
   BoolArray::default_instance_->InitAsDefaultInstance();
@@ -2795,6 +2864,7 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
   TransformConfig::default_instance_->InitAsDefaultInstance();
   ScoreConfig::default_instance_->InitAsDefaultInstance();
   ScoreData::default_instance_->InitAsDefaultInstance();
+  ScoreDataArray::default_instance_->InitAsDefaultInstance();
   PerplexityScoreConfig::default_instance_->InitAsDefaultInstance();
   PerplexityScore::default_instance_->InitAsDefaultInstance();
   SparsityThetaScoreConfig::default_instance_->InitAsDefaultInstance();
@@ -2828,6 +2898,7 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
   GetTopicModelArgs::default_instance_->InitAsDefaultInstance();
   GetThetaMatrixArgs::default_instance_->InitAsDefaultInstance();
   GetScoreValueArgs::default_instance_->InitAsDefaultInstance();
+  GetScoreArrayArgs::default_instance_->InitAsDefaultInstance();
   ExportModelArgs::default_instance_->InitAsDefaultInstance();
   ImportModelArgs::default_instance_->InitAsDefaultInstance();
   AttachModelArgs::default_instance_->InitAsDefaultInstance();
@@ -2857,6 +2928,7 @@ void protobuf_AddDesc_artm_2fmessages_2eproto() {
   ConfigureLoggingArgs::default_instance_->InitAsDefaultInstance();
   ClearThetaCacheArgs::default_instance_->InitAsDefaultInstance();
   ClearScoreCacheArgs::default_instance_->InitAsDefaultInstance();
+  ClearScoreArrayCacheArgs::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_artm_2fmessages_2eproto);
 }
 
@@ -12004,6 +12076,209 @@ void ScoreData::Swap(ScoreData* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = ScoreData_descriptor_;
   metadata.reflection = ScoreData_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int ScoreDataArray::kScoreFieldNumber;
+#endif  // !_MSC_VER
+
+ScoreDataArray::ScoreDataArray()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+}
+
+void ScoreDataArray::InitAsDefaultInstance() {
+}
+
+ScoreDataArray::ScoreDataArray(const ScoreDataArray& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+}
+
+void ScoreDataArray::SharedCtor() {
+  _cached_size_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+ScoreDataArray::~ScoreDataArray() {
+  SharedDtor();
+}
+
+void ScoreDataArray::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void ScoreDataArray::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* ScoreDataArray::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return ScoreDataArray_descriptor_;
+}
+
+const ScoreDataArray& ScoreDataArray::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_artm_2fmessages_2eproto();
+  return *default_instance_;
+}
+
+ScoreDataArray* ScoreDataArray::default_instance_ = NULL;
+
+ScoreDataArray* ScoreDataArray::New() const {
+  return new ScoreDataArray;
+}
+
+void ScoreDataArray::Clear() {
+  score_.Clear();
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool ScoreDataArray::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) return false
+  ::google::protobuf::uint32 tag;
+  while ((tag = input->ReadTag()) != 0) {
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // repeated .artm.ScoreData score = 1;
+      case 1: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+         parse_score:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+                input, add_score()));
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(10)) goto parse_score;
+        if (input->ExpectAtEnd()) return true;
+        break;
+      }
+
+      default: {
+      handle_uninterpreted:
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          return true;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+  return true;
+#undef DO_
+}
+
+void ScoreDataArray::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // repeated .artm.ScoreData score = 1;
+  for (int i = 0; i < this->score_size(); i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, this->score(i), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+}
+
+::google::protobuf::uint8* ScoreDataArray::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // repeated .artm.ScoreData score = 1;
+  for (int i = 0; i < this->score_size(); i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        1, this->score(i), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  return target;
+}
+
+int ScoreDataArray::ByteSize() const {
+  int total_size = 0;
+
+  // repeated .artm.ScoreData score = 1;
+  total_size += 1 * this->score_size();
+  for (int i = 0; i < this->score_size(); i++) {
+    total_size +=
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        this->score(i));
+  }
+
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void ScoreDataArray::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const ScoreDataArray* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const ScoreDataArray*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void ScoreDataArray::MergeFrom(const ScoreDataArray& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  score_.MergeFrom(from.score_);
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void ScoreDataArray::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ScoreDataArray::CopyFrom(const ScoreDataArray& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ScoreDataArray::IsInitialized() const {
+
+  return true;
+}
+
+void ScoreDataArray::Swap(ScoreDataArray* other) {
+  if (other != this) {
+    score_.Swap(&other->score_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata ScoreDataArray::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = ScoreDataArray_descriptor_;
+  metadata.reflection = ScoreDataArray_reflection_;
   return metadata;
 }
 
@@ -24396,7 +24671,6 @@ const int GetThetaMatrixArgs::MatrixLayout_ARRAYSIZE;
 #ifndef _MSC_VER
 const int GetThetaMatrixArgs::kTopicNameFieldNumber;
 const int GetThetaMatrixArgs::kTopicIndexFieldNumber;
-const int GetThetaMatrixArgs::kCleanCacheFieldNumber;
 const int GetThetaMatrixArgs::kUseSparseFormatFieldNumber;
 const int GetThetaMatrixArgs::kEpsFieldNumber;
 const int GetThetaMatrixArgs::kMatrixLayoutFieldNumber;
@@ -24418,7 +24692,6 @@ GetThetaMatrixArgs::GetThetaMatrixArgs(const GetThetaMatrixArgs& from)
 
 void GetThetaMatrixArgs::SharedCtor() {
   _cached_size_ = 0;
-  clean_cache_ = false;
   use_sparse_format_ = false;
   eps_ = 1e-037f;
   matrix_layout_ = 0;
@@ -24457,7 +24730,6 @@ GetThetaMatrixArgs* GetThetaMatrixArgs::New() const {
 
 void GetThetaMatrixArgs::Clear() {
   if (_has_bits_[2 / 32] & (0xffu << (2 % 32))) {
-    clean_cache_ = false;
     use_sparse_format_ = false;
     eps_ = 1e-037f;
     matrix_layout_ = 0;
@@ -24511,22 +24783,6 @@ bool GetThetaMatrixArgs::MergePartialFromCodedStream(
           goto handle_uninterpreted;
         }
         if (input->ExpectTag(32)) goto parse_topic_index;
-        if (input->ExpectTag(40)) goto parse_clean_cache;
-        break;
-      }
-
-      // optional bool clean_cache = 5 [default = false];
-      case 5: {
-        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
-            ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
-         parse_clean_cache:
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
-                 input, &clean_cache_)));
-          set_has_clean_cache();
-        } else {
-          goto handle_uninterpreted;
-        }
         if (input->ExpectTag(48)) goto parse_use_sparse_format;
         break;
       }
@@ -24617,11 +24873,6 @@ void GetThetaMatrixArgs::SerializeWithCachedSizes(
       4, this->topic_index(i), output);
   }
 
-  // optional bool clean_cache = 5 [default = false];
-  if (has_clean_cache()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBool(5, this->clean_cache(), output);
-  }
-
   // optional bool use_sparse_format = 6;
   if (has_use_sparse_format()) {
     ::google::protobuf::internal::WireFormatLite::WriteBool(6, this->use_sparse_format(), output);
@@ -24661,11 +24912,6 @@ void GetThetaMatrixArgs::SerializeWithCachedSizes(
       WriteInt32ToArray(4, this->topic_index(i), target);
   }
 
-  // optional bool clean_cache = 5 [default = false];
-  if (has_clean_cache()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(5, this->clean_cache(), target);
-  }
-
   // optional bool use_sparse_format = 6;
   if (has_use_sparse_format()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(6, this->use_sparse_format(), target);
@@ -24693,11 +24939,6 @@ int GetThetaMatrixArgs::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[2 / 32] & (0xffu << (2 % 32))) {
-    // optional bool clean_cache = 5 [default = false];
-    if (has_clean_cache()) {
-      total_size += 1 + 1;
-    }
-
     // optional bool use_sparse_format = 6;
     if (has_use_sparse_format()) {
       total_size += 1 + 1;
@@ -24760,9 +25001,6 @@ void GetThetaMatrixArgs::MergeFrom(const GetThetaMatrixArgs& from) {
   topic_name_.MergeFrom(from.topic_name_);
   topic_index_.MergeFrom(from.topic_index_);
   if (from._has_bits_[2 / 32] & (0xffu << (2 % 32))) {
-    if (from.has_clean_cache()) {
-      set_clean_cache(from.clean_cache());
-    }
     if (from.has_use_sparse_format()) {
       set_use_sparse_format(from.use_sparse_format());
     }
@@ -24797,7 +25035,6 @@ void GetThetaMatrixArgs::Swap(GetThetaMatrixArgs* other) {
   if (other != this) {
     topic_name_.Swap(&other->topic_name_);
     topic_index_.Swap(&other->topic_index_);
-    std::swap(clean_cache_, other->clean_cache_);
     std::swap(use_sparse_format_, other->use_sparse_format_);
     std::swap(eps_, other->eps_);
     std::swap(matrix_layout_, other->matrix_layout_);
@@ -25094,6 +25331,231 @@ void GetScoreValueArgs::Swap(GetScoreValueArgs* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = GetScoreValueArgs_descriptor_;
   metadata.reflection = GetScoreValueArgs_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int GetScoreArrayArgs::kScoreNameFieldNumber;
+#endif  // !_MSC_VER
+
+GetScoreArrayArgs::GetScoreArrayArgs()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+}
+
+void GetScoreArrayArgs::InitAsDefaultInstance() {
+}
+
+GetScoreArrayArgs::GetScoreArrayArgs(const GetScoreArrayArgs& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+}
+
+void GetScoreArrayArgs::SharedCtor() {
+  _cached_size_ = 0;
+  score_name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyString());
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+GetScoreArrayArgs::~GetScoreArrayArgs() {
+  SharedDtor();
+}
+
+void GetScoreArrayArgs::SharedDtor() {
+  if (score_name_ != &::google::protobuf::internal::GetEmptyString()) {
+    delete score_name_;
+  }
+  if (this != default_instance_) {
+  }
+}
+
+void GetScoreArrayArgs::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* GetScoreArrayArgs::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return GetScoreArrayArgs_descriptor_;
+}
+
+const GetScoreArrayArgs& GetScoreArrayArgs::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_artm_2fmessages_2eproto();
+  return *default_instance_;
+}
+
+GetScoreArrayArgs* GetScoreArrayArgs::default_instance_ = NULL;
+
+GetScoreArrayArgs* GetScoreArrayArgs::New() const {
+  return new GetScoreArrayArgs;
+}
+
+void GetScoreArrayArgs::Clear() {
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (has_score_name()) {
+      if (score_name_ != &::google::protobuf::internal::GetEmptyString()) {
+        score_name_->clear();
+      }
+    }
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool GetScoreArrayArgs::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) return false
+  ::google::protobuf::uint32 tag;
+  while ((tag = input->ReadTag()) != 0) {
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional string score_name = 2;
+      case 2: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_score_name()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+            this->score_name().data(), this->score_name().length(),
+            ::google::protobuf::internal::WireFormat::PARSE);
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectAtEnd()) return true;
+        break;
+      }
+
+      default: {
+      handle_uninterpreted:
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          return true;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+  return true;
+#undef DO_
+}
+
+void GetScoreArrayArgs::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // optional string score_name = 2;
+  if (has_score_name()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+      this->score_name().data(), this->score_name().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE);
+    ::google::protobuf::internal::WireFormatLite::WriteString(
+      2, this->score_name(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+}
+
+::google::protobuf::uint8* GetScoreArrayArgs::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // optional string score_name = 2;
+  if (has_score_name()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+      this->score_name().data(), this->score_name().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE);
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->score_name(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  return target;
+}
+
+int GetScoreArrayArgs::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional string score_name = 2;
+    if (has_score_name()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::StringSize(
+          this->score_name());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void GetScoreArrayArgs::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const GetScoreArrayArgs* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const GetScoreArrayArgs*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void GetScoreArrayArgs::MergeFrom(const GetScoreArrayArgs& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_score_name()) {
+      set_score_name(from.score_name());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void GetScoreArrayArgs::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GetScoreArrayArgs::CopyFrom(const GetScoreArrayArgs& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GetScoreArrayArgs::IsInitialized() const {
+
+  return true;
+}
+
+void GetScoreArrayArgs::Swap(GetScoreArrayArgs* other) {
+  if (other != this) {
+    std::swap(score_name_, other->score_name_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata GetScoreArrayArgs::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = GetScoreArrayArgs_descriptor_;
+  metadata.reflection = GetScoreArrayArgs_reflection_;
   return metadata;
 }
 
@@ -34920,6 +35382,162 @@ void ClearScoreCacheArgs::Swap(ClearScoreCacheArgs* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = ClearScoreCacheArgs_descriptor_;
   metadata.reflection = ClearScoreCacheArgs_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+#endif  // !_MSC_VER
+
+ClearScoreArrayCacheArgs::ClearScoreArrayCacheArgs()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+}
+
+void ClearScoreArrayCacheArgs::InitAsDefaultInstance() {
+}
+
+ClearScoreArrayCacheArgs::ClearScoreArrayCacheArgs(const ClearScoreArrayCacheArgs& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+}
+
+void ClearScoreArrayCacheArgs::SharedCtor() {
+  _cached_size_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+ClearScoreArrayCacheArgs::~ClearScoreArrayCacheArgs() {
+  SharedDtor();
+}
+
+void ClearScoreArrayCacheArgs::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void ClearScoreArrayCacheArgs::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* ClearScoreArrayCacheArgs::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return ClearScoreArrayCacheArgs_descriptor_;
+}
+
+const ClearScoreArrayCacheArgs& ClearScoreArrayCacheArgs::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_artm_2fmessages_2eproto();
+  return *default_instance_;
+}
+
+ClearScoreArrayCacheArgs* ClearScoreArrayCacheArgs::default_instance_ = NULL;
+
+ClearScoreArrayCacheArgs* ClearScoreArrayCacheArgs::New() const {
+  return new ClearScoreArrayCacheArgs;
+}
+
+void ClearScoreArrayCacheArgs::Clear() {
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool ClearScoreArrayCacheArgs::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) return false
+  ::google::protobuf::uint32 tag;
+  while ((tag = input->ReadTag()) != 0) {
+    if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+        ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+      return true;
+    }
+    DO_(::google::protobuf::internal::WireFormat::SkipField(
+          input, tag, mutable_unknown_fields()));
+  }
+  return true;
+#undef DO_
+}
+
+void ClearScoreArrayCacheArgs::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+}
+
+::google::protobuf::uint8* ClearScoreArrayCacheArgs::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  return target;
+}
+
+int ClearScoreArrayCacheArgs::ByteSize() const {
+  int total_size = 0;
+
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void ClearScoreArrayCacheArgs::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const ClearScoreArrayCacheArgs* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const ClearScoreArrayCacheArgs*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void ClearScoreArrayCacheArgs::MergeFrom(const ClearScoreArrayCacheArgs& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void ClearScoreArrayCacheArgs::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ClearScoreArrayCacheArgs::CopyFrom(const ClearScoreArrayCacheArgs& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ClearScoreArrayCacheArgs::IsInitialized() const {
+
+  return true;
+}
+
+void ClearScoreArrayCacheArgs::Swap(ClearScoreArrayCacheArgs* other) {
+  if (other != this) {
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata ClearScoreArrayCacheArgs::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = ClearScoreArrayCacheArgs_descriptor_;
+  metadata.reflection = ClearScoreArrayCacheArgs_reflection_;
   return metadata;
 }
 

--- a/src/artm/messages.pb.h
+++ b/src/artm/messages.pb.h
@@ -59,6 +59,7 @@ class TopicSelectionThetaConfig;
 class TransformConfig;
 class ScoreConfig;
 class ScoreData;
+class ScoreDataArray;
 class PerplexityScoreConfig;
 class PerplexityScore;
 class SparsityThetaScoreConfig;
@@ -92,6 +93,7 @@ class GetDictionaryArgs;
 class GetTopicModelArgs;
 class GetThetaMatrixArgs;
 class GetScoreValueArgs;
+class GetScoreArrayArgs;
 class ExportModelArgs;
 class ImportModelArgs;
 class AttachModelArgs;
@@ -121,6 +123,7 @@ class TransformMasterModelArgs;
 class ConfigureLoggingArgs;
 class ClearThetaCacheArgs;
 class ClearScoreCacheArgs;
+class ClearScoreArrayCacheArgs;
 
 enum Stream_Type {
   Stream_Type_Global = 0,
@@ -3841,6 +3844,91 @@ class ScoreData : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static ScoreData* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class ScoreDataArray : public ::google::protobuf::Message {
+ public:
+  ScoreDataArray();
+  virtual ~ScoreDataArray();
+
+  ScoreDataArray(const ScoreDataArray& from);
+
+  inline ScoreDataArray& operator=(const ScoreDataArray& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ScoreDataArray& default_instance();
+
+  void Swap(ScoreDataArray* other);
+
+  // implements Message ----------------------------------------------
+
+  ScoreDataArray* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const ScoreDataArray& from);
+  void MergeFrom(const ScoreDataArray& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // repeated .artm.ScoreData score = 1;
+  inline int score_size() const;
+  inline void clear_score();
+  static const int kScoreFieldNumber = 1;
+  inline const ::artm::ScoreData& score(int index) const;
+  inline ::artm::ScoreData* mutable_score(int index);
+  inline ::artm::ScoreData* add_score();
+  inline const ::google::protobuf::RepeatedPtrField< ::artm::ScoreData >&
+      score() const;
+  inline ::google::protobuf::RepeatedPtrField< ::artm::ScoreData >*
+      mutable_score();
+
+  // @@protoc_insertion_point(class_scope:artm.ScoreDataArray)
+ private:
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::google::protobuf::RepeatedPtrField< ::artm::ScoreData > score_;
+
+  mutable int _cached_size_;
+  ::google::protobuf::uint32 _has_bits_[(1 + 31) / 32];
+
+  friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
+  friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
+  friend void protobuf_ShutdownFile_artm_2fmessages_2eproto();
+
+  void InitAsDefaultInstance();
+  static ScoreDataArray* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -8321,13 +8409,6 @@ class GetThetaMatrixArgs : public ::google::protobuf::Message {
   inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
       mutable_topic_index();
 
-  // optional bool clean_cache = 5 [default = false];
-  inline bool has_clean_cache() const;
-  inline void clear_clean_cache();
-  static const int kCleanCacheFieldNumber = 5;
-  inline bool clean_cache() const;
-  inline void set_clean_cache(bool value);
-
   // optional bool use_sparse_format = 6;
   inline bool has_use_sparse_format() const;
   inline void clear_use_sparse_format();
@@ -8351,8 +8432,6 @@ class GetThetaMatrixArgs : public ::google::protobuf::Message {
 
   // @@protoc_insertion_point(class_scope:artm.GetThetaMatrixArgs)
  private:
-  inline void set_has_clean_cache();
-  inline void clear_has_clean_cache();
   inline void set_has_use_sparse_format();
   inline void clear_has_use_sparse_format();
   inline void set_has_eps();
@@ -8364,13 +8443,12 @@ class GetThetaMatrixArgs : public ::google::protobuf::Message {
 
   ::google::protobuf::RepeatedPtrField< ::std::string> topic_name_;
   ::google::protobuf::RepeatedField< ::google::protobuf::int32 > topic_index_;
-  bool clean_cache_;
   bool use_sparse_format_;
   float eps_;
   int matrix_layout_;
 
   mutable int _cached_size_;
-  ::google::protobuf::uint32 _has_bits_[(6 + 31) / 32];
+  ::google::protobuf::uint32 _has_bits_[(5 + 31) / 32];
 
   friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
   friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
@@ -8480,6 +8558,93 @@ class GetScoreValueArgs : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static GetScoreValueArgs* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class GetScoreArrayArgs : public ::google::protobuf::Message {
+ public:
+  GetScoreArrayArgs();
+  virtual ~GetScoreArrayArgs();
+
+  GetScoreArrayArgs(const GetScoreArrayArgs& from);
+
+  inline GetScoreArrayArgs& operator=(const GetScoreArrayArgs& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const GetScoreArrayArgs& default_instance();
+
+  void Swap(GetScoreArrayArgs* other);
+
+  // implements Message ----------------------------------------------
+
+  GetScoreArrayArgs* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const GetScoreArrayArgs& from);
+  void MergeFrom(const GetScoreArrayArgs& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional string score_name = 2;
+  inline bool has_score_name() const;
+  inline void clear_score_name();
+  static const int kScoreNameFieldNumber = 2;
+  inline const ::std::string& score_name() const;
+  inline void set_score_name(const ::std::string& value);
+  inline void set_score_name(const char* value);
+  inline void set_score_name(const char* value, size_t size);
+  inline ::std::string* mutable_score_name();
+  inline ::std::string* release_score_name();
+  inline void set_allocated_score_name(::std::string* score_name);
+
+  // @@protoc_insertion_point(class_scope:artm.GetScoreArrayArgs)
+ private:
+  inline void set_has_score_name();
+  inline void clear_has_score_name();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::std::string* score_name_;
+
+  mutable int _cached_size_;
+  ::google::protobuf::uint32 _has_bits_[(1 + 31) / 32];
+
+  friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
+  friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
+  friend void protobuf_ShutdownFile_artm_2fmessages_2eproto();
+
+  void InitAsDefaultInstance();
+  static GetScoreArrayArgs* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -12024,6 +12189,78 @@ class ClearScoreCacheArgs : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static ClearScoreCacheArgs* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class ClearScoreArrayCacheArgs : public ::google::protobuf::Message {
+ public:
+  ClearScoreArrayCacheArgs();
+  virtual ~ClearScoreArrayCacheArgs();
+
+  ClearScoreArrayCacheArgs(const ClearScoreArrayCacheArgs& from);
+
+  inline ClearScoreArrayCacheArgs& operator=(const ClearScoreArrayCacheArgs& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ClearScoreArrayCacheArgs& default_instance();
+
+  void Swap(ClearScoreArrayCacheArgs* other);
+
+  // implements Message ----------------------------------------------
+
+  ClearScoreArrayCacheArgs* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const ClearScoreArrayCacheArgs& from);
+  void MergeFrom(const ClearScoreArrayCacheArgs& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:artm.ClearScoreArrayCacheArgs)
+ private:
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+
+  mutable int _cached_size_;
+  ::google::protobuf::uint32 _has_bits_[1];
+
+  friend void  protobuf_AddDesc_artm_2fmessages_2eproto();
+  friend void protobuf_AssignDesc_artm_2fmessages_2eproto();
+  friend void protobuf_ShutdownFile_artm_2fmessages_2eproto();
+
+  void InitAsDefaultInstance();
+  static ClearScoreArrayCacheArgs* default_instance_;
 };
 // ===================================================================
 
@@ -16042,6 +16279,35 @@ inline void ScoreData::set_allocated_data(::std::string* data) {
     clear_has_data();
     data_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyString());
   }
+}
+
+// -------------------------------------------------------------------
+
+// ScoreDataArray
+
+// repeated .artm.ScoreData score = 1;
+inline int ScoreDataArray::score_size() const {
+  return score_.size();
+}
+inline void ScoreDataArray::clear_score() {
+  score_.Clear();
+}
+inline const ::artm::ScoreData& ScoreDataArray::score(int index) const {
+  return score_.Get(index);
+}
+inline ::artm::ScoreData* ScoreDataArray::mutable_score(int index) {
+  return score_.Mutable(index);
+}
+inline ::artm::ScoreData* ScoreDataArray::add_score() {
+  return score_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::artm::ScoreData >&
+ScoreDataArray::score() const {
+  return score_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::artm::ScoreData >*
+ScoreDataArray::mutable_score() {
+  return &score_;
 }
 
 // -------------------------------------------------------------------
@@ -21985,37 +22251,15 @@ GetThetaMatrixArgs::mutable_topic_index() {
   return &topic_index_;
 }
 
-// optional bool clean_cache = 5 [default = false];
-inline bool GetThetaMatrixArgs::has_clean_cache() const {
-  return (_has_bits_[0] & 0x00000004u) != 0;
-}
-inline void GetThetaMatrixArgs::set_has_clean_cache() {
-  _has_bits_[0] |= 0x00000004u;
-}
-inline void GetThetaMatrixArgs::clear_has_clean_cache() {
-  _has_bits_[0] &= ~0x00000004u;
-}
-inline void GetThetaMatrixArgs::clear_clean_cache() {
-  clean_cache_ = false;
-  clear_has_clean_cache();
-}
-inline bool GetThetaMatrixArgs::clean_cache() const {
-  return clean_cache_;
-}
-inline void GetThetaMatrixArgs::set_clean_cache(bool value) {
-  set_has_clean_cache();
-  clean_cache_ = value;
-}
-
 // optional bool use_sparse_format = 6;
 inline bool GetThetaMatrixArgs::has_use_sparse_format() const {
-  return (_has_bits_[0] & 0x00000008u) != 0;
+  return (_has_bits_[0] & 0x00000004u) != 0;
 }
 inline void GetThetaMatrixArgs::set_has_use_sparse_format() {
-  _has_bits_[0] |= 0x00000008u;
+  _has_bits_[0] |= 0x00000004u;
 }
 inline void GetThetaMatrixArgs::clear_has_use_sparse_format() {
-  _has_bits_[0] &= ~0x00000008u;
+  _has_bits_[0] &= ~0x00000004u;
 }
 inline void GetThetaMatrixArgs::clear_use_sparse_format() {
   use_sparse_format_ = false;
@@ -22031,13 +22275,13 @@ inline void GetThetaMatrixArgs::set_use_sparse_format(bool value) {
 
 // optional float eps = 7 [default = 1e-037];
 inline bool GetThetaMatrixArgs::has_eps() const {
-  return (_has_bits_[0] & 0x00000010u) != 0;
+  return (_has_bits_[0] & 0x00000008u) != 0;
 }
 inline void GetThetaMatrixArgs::set_has_eps() {
-  _has_bits_[0] |= 0x00000010u;
+  _has_bits_[0] |= 0x00000008u;
 }
 inline void GetThetaMatrixArgs::clear_has_eps() {
-  _has_bits_[0] &= ~0x00000010u;
+  _has_bits_[0] &= ~0x00000008u;
 }
 inline void GetThetaMatrixArgs::clear_eps() {
   eps_ = 1e-037f;
@@ -22053,13 +22297,13 @@ inline void GetThetaMatrixArgs::set_eps(float value) {
 
 // optional .artm.GetThetaMatrixArgs.MatrixLayout matrix_layout = 8 [default = Dense];
 inline bool GetThetaMatrixArgs::has_matrix_layout() const {
-  return (_has_bits_[0] & 0x00000020u) != 0;
+  return (_has_bits_[0] & 0x00000010u) != 0;
 }
 inline void GetThetaMatrixArgs::set_has_matrix_layout() {
-  _has_bits_[0] |= 0x00000020u;
+  _has_bits_[0] |= 0x00000010u;
 }
 inline void GetThetaMatrixArgs::clear_has_matrix_layout() {
-  _has_bits_[0] &= ~0x00000020u;
+  _has_bits_[0] &= ~0x00000010u;
 }
 inline void GetThetaMatrixArgs::clear_matrix_layout() {
   matrix_layout_ = 0;
@@ -22206,6 +22450,80 @@ inline ::std::string* GetScoreValueArgs::release_score_name() {
   }
 }
 inline void GetScoreValueArgs::set_allocated_score_name(::std::string* score_name) {
+  if (score_name_ != &::google::protobuf::internal::GetEmptyString()) {
+    delete score_name_;
+  }
+  if (score_name) {
+    set_has_score_name();
+    score_name_ = score_name;
+  } else {
+    clear_has_score_name();
+    score_name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyString());
+  }
+}
+
+// -------------------------------------------------------------------
+
+// GetScoreArrayArgs
+
+// optional string score_name = 2;
+inline bool GetScoreArrayArgs::has_score_name() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void GetScoreArrayArgs::set_has_score_name() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void GetScoreArrayArgs::clear_has_score_name() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void GetScoreArrayArgs::clear_score_name() {
+  if (score_name_ != &::google::protobuf::internal::GetEmptyString()) {
+    score_name_->clear();
+  }
+  clear_has_score_name();
+}
+inline const ::std::string& GetScoreArrayArgs::score_name() const {
+  return *score_name_;
+}
+inline void GetScoreArrayArgs::set_score_name(const ::std::string& value) {
+  set_has_score_name();
+  if (score_name_ == &::google::protobuf::internal::GetEmptyString()) {
+    score_name_ = new ::std::string;
+  }
+  score_name_->assign(value);
+}
+inline void GetScoreArrayArgs::set_score_name(const char* value) {
+  set_has_score_name();
+  if (score_name_ == &::google::protobuf::internal::GetEmptyString()) {
+    score_name_ = new ::std::string;
+  }
+  score_name_->assign(value);
+}
+inline void GetScoreArrayArgs::set_score_name(const char* value, size_t size) {
+  set_has_score_name();
+  if (score_name_ == &::google::protobuf::internal::GetEmptyString()) {
+    score_name_ = new ::std::string;
+  }
+  score_name_->assign(reinterpret_cast<const char*>(value), size);
+}
+inline ::std::string* GetScoreArrayArgs::mutable_score_name() {
+  set_has_score_name();
+  if (score_name_ == &::google::protobuf::internal::GetEmptyString()) {
+    score_name_ = new ::std::string;
+  }
+  return score_name_;
+}
+inline ::std::string* GetScoreArrayArgs::release_score_name() {
+  clear_has_score_name();
+  if (score_name_ == &::google::protobuf::internal::GetEmptyString()) {
+    return NULL;
+  } else {
+    ::std::string* temp = score_name_;
+    score_name_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyString());
+    return temp;
+  }
+}
+inline void GetScoreArrayArgs::set_allocated_score_name(::std::string* score_name) {
   if (score_name_ != &::google::protobuf::internal::GetEmptyString()) {
     delete score_name_;
   }
@@ -26647,6 +26965,10 @@ inline void ConfigureLoggingArgs::set_stop_logging_if_full_disk(bool value) {
 // -------------------------------------------------------------------
 
 // ClearScoreCacheArgs
+
+// -------------------------------------------------------------------
+
+// ClearScoreArrayCacheArgs
 
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -261,6 +261,10 @@ message ScoreData {
   optional bytes data = 3;
 }
 
+message ScoreDataArray {
+  repeated ScoreData score = 1;
+}
+
 // Represents a configuration of a perplexity score
 message PerplexityScoreConfig {
   enum Type {
@@ -594,6 +598,10 @@ message GetScoreValueArgs {
   optional string score_name = 2;
 }
 
+message GetScoreArrayArgs {
+  optional string score_name = 2;
+}
+
 message ExportModelArgs {
   optional string file_name = 1;
   optional string model_name = 2;
@@ -811,3 +819,4 @@ message ConfigureLoggingArgs {
 
 message ClearThetaCacheArgs {}
 message ClearScoreCacheArgs {}
+message ClearScoreArrayCacheArgs {}


### PR DESCRIPTION
Score tracker API and (buggy) implementation.
This commit introduces a new state in the library, stored in `instance.score_tracker()` variable.
This state is basically a list of scores. It is up to other algorithms, such as `FitOnlineMasterModel`, to decide what to put into it. This state can be requested by `ArtmRequestScoreArrayCache` and cleared by `ArtmClearScoreArrayCache`.

Currently this state will be only populated by `ArtmFitOnlineMasterModel` (not by `ArtmFitOfflineMasterModel`), and only if it got executed without `async` flag. This will be corrected in the future, so that async is also supported, and offline is also supported.

Speaking about ArtmFitOnlineMasterModel with `async==false` --- for non-cummulative scores the values in the ScoreTracker will be correct. For cummulative scores the values will be accumulated since the beginning of the iteration. This is a bug and it will be also corrected as soon as possibel.

The purpose of this commit is to provide basic implementation and API to let @MelLain consume it in Python API.