### PR TITLE
Multiple weighted data paths in batch_vectorizer

### DIFF
--- a/python/artm/batches_utils.py
+++ b/python/artm/batches_utils.py
@@ -32,7 +32,7 @@ class BatchVectorizer(object):
       3) if data_format == 'plain_text' => file with text;
       4) if data_format == 'batches' => folder containing batches
       default=''
-      data_format (str:) the type of input data;
+      data_format (str): the type of input data;
       1) 'bow_uci' --- Bag-Of-Words in UCI format;
       2) 'vowpal_wabbit' --- Vowpal Wabbit format;
       3) 'plain_text' --- source text;
@@ -45,54 +45,87 @@ class BatchVectorizer(object):
       batches + data_path + data_fromat=='batches' in this case)
       batch_name_type(str): name batches in natural order ('code') or using random guids (guid),
       default='code'
+      data_weight (float): weight for a group of batches from data_path;
+      it can be a list of floats, then data_path (and target_folder if not data_format == 'batches')
+      should also be lists; one weight corresponds to one path from the data_path list;
+      default=1.0
     """
     def __init__(self, batches=None, collection_name=None, data_path='', data_format='batches',
-                 target_folder='', batch_size=1000, batch_name_type='code'):
+                 target_folder='', batch_size=1000, batch_name_type='code', data_weight=1.0):
         self._batches_list = []
-        if data_format == 'batches':
-            if batches is None:
-                batch_filenames = glob.glob(os.path.join(data_path, '*.batch'))
-                self._batches_list = [Batch(filename) for filename in batch_filenames]
-                if len(self._batches_list) < 1:
-                    raise RuntimeError('No batches were found')
-            else:
-                self._batches_list = [Batch(os.path.join(data_path, batch)) for batch in batches]
-
-        elif data_format == 'bow_uci' or data_format == 'vowpal_wabbit':
-            parser_config = messages.CollectionParserConfig()
-            parser_config.num_items_per_batch = batch_size
-
-            parser_config.name_type = const.CollectionParserConfig_NameType_Code
-            if batch_name_type == 'guid':
-                parser_config.name_type = const.CollectionParserConfig_NameType_Guid
-
-            if data_format == 'bow_uci':
-                parser_config.docword_file_path = os.path.join(
-                    data_path, 'docword.{0}.txt'.format(collection_name))
-                parser_config.vocab_file_path = os.path.join(
-                    data_path, 'vocab.{0}.txt'.format(collection_name))
-                parser_config.format = const.CollectionParserConfig_Format_BagOfWordsUci
-            elif data_format == 'vowpal_wabbit':
-                parser_config.docword_file_path = data_path
-                parser_config.format = const.CollectionParserConfig_Format_VowpalWabbit
-            parser_config.target_folder = target_folder
-
-            lib = wrapper.LibArtm()
-            lib.ArtmParseCollection(parser_config)
-            batch_filenames = glob.glob(os.path.join(target_folder, '*.batch'))
-            self._batches_list = [Batch(filename) for filename in batch_filenames]
-
-        elif data_format == 'plain_text':
-            raise NotImplementedError()
-        else:
-            raise IOError('Unknown data format')
-
+        self._weights = []
         self._data_path = data_path if data_format == 'batches' else target_folder
         self._batch_size = batch_size
+
+        if isinstance(data_path, list):
+            data_paths = data_path
+            if len(data_path) != len(data_weight):
+                raise IOError('Lists for data_path and data_weight should have the same length')
+            data_weights = data_weight
+            if data_format == 'batches':
+                target_folders = ['' for p in data_paths]
+            else:
+                if len(data_path) != len(target_folder):
+                    raise IOError('Lists for data_path and target_folder should have same length')
+                target_folders = target_folder
+        else:
+            if isinstance(data_weight, list) or isinstance(target_folder, list):
+                raise IOError('data_path should be also a list for multiple weights or folders')
+            data_paths = [data_path]
+            data_weights = [data_weight]
+            target_folders = [target_folder]
+
+        for (data_path, data_weight, target_folder) in zip(data_paths, data_weights,
+                                                           target_folders):
+            if data_format == 'batches':
+                if batches is None:
+                    batch_filenames = glob.glob(os.path.join(data_path, '*.batch'))
+                    self._batches_list += [Batch(filename) for filename in batch_filenames]
+                    if len(self._batches_list) < 1:
+                        raise RuntimeError('No batches were found')
+                    self._weights += [data_weight for i in xrange(len(batch_filenames))]
+                else:
+                    self._batches_list += [Batch(os.path.join(data_path, batch))
+                                           for batch in batches]
+                    self._weights += [data_weight for i in xrange(len(batches))]
+
+            elif data_format == 'bow_uci' or data_format == 'vowpal_wabbit':
+                parser_config = messages.CollectionParserConfig()
+                parser_config.num_items_per_batch = batch_size
+
+                parser_config.name_type = const.CollectionParserConfig_NameType_Code
+                if batch_name_type == 'guid':
+                    parser_config.name_type = const.CollectionParserConfig_NameType_Guid
+
+                if data_format == 'bow_uci':
+                    parser_config.docword_file_path = os.path.join(
+                        data_path, 'docword.{0}.txt'.format(collection_name))
+                    parser_config.vocab_file_path = os.path.join(
+                        data_path, 'vocab.{0}.txt'.format(collection_name))
+                    parser_config.format = const.CollectionParserConfig_Format_BagOfWordsUci
+                elif data_format == 'vowpal_wabbit':
+                    parser_config.docword_file_path = data_path
+                    parser_config.format = const.CollectionParserConfig_Format_VowpalWabbit
+                parser_config.target_folder = target_folder
+
+                lib = wrapper.LibArtm()
+                lib.ArtmParseCollection(parser_config)
+                batch_filenames = glob.glob(os.path.join(target_folder, '*.batch'))
+                self._batches_list += [Batch(filename) for filename in batch_filenames]
+                self._weights += [data_weight for i in xrange(len(batch_filenames))]
+
+            elif data_format == 'plain_text':
+                raise NotImplementedError()
+            else:
+                raise IOError('Unknown data format')
 
     @property
     def batches_list(self):
         return self._batches_list
+
+    @property
+    def weights(self):
+        return self._weights
 
     @property
     def num_batches(self):

--- a/python/artm/model.py
+++ b/python/artm/model.py
@@ -533,6 +533,7 @@ class ARTM(object):
             self._synchronizations_processed += 1
             self.master.clear_score_array_cache()
             self.master.fit_offline(batch_filenames=batches_list,
+                                    batch_weights=batch_vectorizer.weights,
                                     num_collection_passes=1)
 
             for name in self.scores.data.keys():
@@ -620,6 +621,7 @@ class ARTM(object):
 
         self.master.clear_score_array_cache()
         self.master.fit_online(batch_filenames=batches_list,
+                               batch_weights=batch_vectorizer.weights,
                                update_after=update_after_final,
                                apply_weight=apply_weight_final,
                                decay_weight=decay_weight_final,


### PR DESCRIPTION
Batch_vectorizer now can get lists for data_path and target_folder and weight each group of batches with a weight given by data_weight list. Then these weights go to master.fit_offline and master.fit_online as batch_weights. As a result, a user can easily weight two VW-files or two batch-folders and fit a model on this weighted data.