### PR TITLE
Ignore some compilation warnings

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 2.8.0)
 
 project(3rdparty)
 
+add_definitions("-w")
+
 if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-all")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(BUILD_STATIC_BIGARTM "Request build of static executable bigartm (for Lin
 
 if (APPLE)
   set (BUILD_STATIC_BIGARTM OFF)
+  set (CMAKE_MACOSX_RPATH 1)
 endif (APPLE)
 
 set(BUILD_STATIC_LIBS ON)


### PR DESCRIPTION
Fix Mac specific build warning (“Policy CMP0042 is not set:
MACOSX_RPATH”).
Ignore warnings from 3rdparty directory.