### PR TITLE
Do not generate empty class_id when parsing Vowpal wabbit format (v2)

### DIFF
--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -372,10 +372,12 @@ void CollectionParser::ParseVowpalWabbit() {
     ClassId class_id = DefaultClass;
     for (unsigned elem_index = 1; elem_index < strs.size(); ++elem_index) {
       std::string elem = strs[elem_index];
-      if (elem.size() <= 1)
+      if (elem.size() == 0)
         continue;
       if (elem[0] == '|') {
         class_id = elem.substr(1);
+        if (class_id.empty())
+          class_id = DefaultClass;
         continue;
       }
 


### PR DESCRIPTION
This fixes #533 . Previous fix (https://github.com/bigartm/bigartm/commit/5b43abbe5beb3f3989b21892af7edef98a045235) was wrong as it ignored tokens with length `1`. 