### PR TITLE
Modified Travis CI config file to enable GCC-4.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language:
   - python

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ matrix:
       addons:
         apt:
           sources:
+            - boost-latest
             - ubuntu-toolchain-r-test
           packages:
             - cmake
-            - libboost1.55-all-dev
+            - boost1.55 # from boost-latest
             - python-numpy
             - python-pandas
             - python-virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: false
-dist: trusty
 
 language:
   - python
@@ -16,7 +15,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - cmake
-            - libboost-all-dev
+            - libboost1.55-all-dev
             - python-numpy
             - python-pandas
             - python-virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 install:
   - ./codestyle_checks.sh
   - mkdir build
-  - pushd build && cmake .. && make && file ./src/bigartm/bigartm && popd
+  - pushd build && cmake .. && make CXX=$COMPILER && file ./src/bigartm/bigartm && popd
   - pushd 3rdparty/protobuf/python && python setup.py install && popd
   - pushd python && python setup.py install && popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 install:
   - ./codestyle_checks.sh
   - mkdir build
-  - pushd build && cmake .. && make CXX=$COMPILER && file ./src/bigartm/bigartm && popd
+  - pushd build && export CXX=$COMPILER && cmake .. && make && file ./src/bigartm/bigartm && popd
   - pushd 3rdparty/protobuf/python && python setup.py install && popd
   - pushd python && python setup.py install && popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,29 @@ language:
   - python
   - cpp
 
-compiler:
-  - clang
-  - gcc
 
-python:
-  - "2.7"
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      python:
+        - "2.7"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - cmake
+            - libboost-all-dev
+            - python-numpy
+            - python-pandas
+            - python-virtualenv
+            - g++-4.9
+      env: COMPILER=g++-4.9
+
 
 virtualenv:
   system_site_packages: true
-
-addons:
-  apt:
-    packages:
-      - cmake
-      - libboost-all-dev
-      - python-numpy
-      - python-pandas
-      - python-virtualenv
 
 before_install:
   - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,11 @@ language:
   - python
   - cpp
 
-
 matrix:
   include:
     - os: linux
       compiler: gcc
-      python:
-        - 2.7
+      python: '2.7'
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - os: linux
       compiler: gcc
       python:
-        - "2.7"
+        - 2.7
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - cmake
-            - boost1.55 # from boost-latest
+            - libboost1.55-all-dev # from boost-latest
             - python-numpy
             - python-pandas
             - python-virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 install:
   - ./codestyle_checks.sh
   - mkdir build
-  - pushd build && export CXX=$COMPILER && cmake .. && make && file ./src/bigartm/bigartm && popd
+  - pushd build && export CXX=$COMPILER && cmake .. && make -j2 && file ./src/bigartm/bigartm && popd
   - pushd 3rdparty/protobuf/python && python setup.py install && popd
   - pushd python && python setup.py install && popd
 

--- a/src/bigartm/CMakeLists.txt
+++ b/src/bigartm/CMakeLists.txt
@@ -24,6 +24,7 @@ else (WIN32)
   target_link_libraries(bigartm
       messages_proto
 	  artm-static
+	  rt
 	  ${PROTOBUF_LIBRARIES}
 	  ${GLOG_LIBRARIES}
 	  ${Boost_LIBRARIES})

--- a/src/bigartm/CMakeLists.txt
+++ b/src/bigartm/CMakeLists.txt
@@ -24,10 +24,10 @@ else (WIN32)
   target_link_libraries(bigartm
       messages_proto
 	  artm-static
-	  rt
 	  ${PROTOBUF_LIBRARIES}
 	  ${GLOG_LIBRARIES}
-	  ${Boost_LIBRARIES})
+	  ${Boost_LIBRARIES}
+	  rt)
 endif (WIN32)
 
 install(TARGETS bigartm DESTINATION bin)


### PR DESCRIPTION
This PR relies on following sources:
* [article about c++11 support in Travis CI](http://genbattle.bitbucket.org/blog/2016/01/17/c++-travis-ci/)
* [sample .travis.yml file with build matrix](https://github.com/genbattle/dkm/blob/9c893efb556516f4b121a6201b66e000f838dd59/.travis.yml)