### PR TITLE
TopicSelectionTheta regularizer fixes

### DIFF
--- a/python/artm/artm_model.py
+++ b/python/artm/artm_model.py
@@ -42,7 +42,8 @@ def _topic_selection_regularizer_func(self, regularizers):
         if no_score:
             self._internal_topic_mass_score_name = 'ITMScore_{}'.format(str(uuid.uuid4()))
             self.scores.add(TopicMassPhiScore(name=self._internal_topic_mass_score_name,
-                                              class_id='@default_class'))  # ugly hack!
+                                              class_id='@default_class',
+                                              model_name=self.model_nwt))  # ugly hack!
 
         if not self._synchronizations_processed or no_score:
             phi = self.get_phi(class_ids=['@default_class'])  # ugly hack!

--- a/python/tests/artm/test_regularizer_topic_selection.py
+++ b/python/tests/artm/test_regularizer_topic_selection.py
@@ -8,7 +8,7 @@ import artm
 
 
 def test_func():
-    topic_selection_tau = 1.0
+    topic_selection_tau = 0.5
     num_collection_passes = 3
     num_document_passes = 10
     num_topics = 15
@@ -16,8 +16,8 @@ def test_func():
     data_path = os.environ.get('BIGARTM_UNITTEST_DATA')
     batches_folder = tempfile.mkdtemp()
 
-    perplexity_eps = 2.0
-    perplexity_value = [8963.45939171117, 2550.7275062628664, 2301.3291199618243]
+    perplexity_eps = 0.1
+    perplexity_value = [6676.941798754971, 2534.963709464024, 2463.1544861984794]
 
     try:
         batch_vectorizer = artm.BatchVectorizer(data_path=data_path,
@@ -33,18 +33,13 @@ def test_func():
         model.scores.add(artm.TopicMassPhiScore(name='TopicMass', model_name=model.model_nwt))
         model.fit_offline(batch_vectorizer=batch_vectorizer, num_collection_passes=num_collection_passes)
 
-        # Verify that only 7 topics are non-zero (due to TopicSelection regularizer)
-        # assert 7 == sum(x == 0 for x in model.get_score('TopicMass').topic_mass)
-
-        # According to https://github.com/bigartm/bigartm/issues/580,
-        # we will check only whether the number of non-zero topics changed or not
+        # Verify that only 8 topics are non-zero (due to TopicSelection regularizer)
         topics_left = sum(x == 0 for x in model.get_score('TopicMass').topic_mass)
-        assert topics_left != 0 and topics_left != num_topics
+        assert 8 == topics_left
 
-        # print model.score_tracker['PerplexityScore'].value
         # the following asssertion fails on travis-ci builds, but passes locally
-        # for i in xrange(num_collection_passes):
-        #     assert abs(model.score_tracker['PerplexityScore'].value[i] - perplexity_value[i]) < perplexity_eps
+        for i in xrange(num_collection_passes):
+            assert abs(model.score_tracker['PerplexityScore'].value[i] - perplexity_value[i]) < perplexity_eps
 
         model.fit_online(batch_vectorizer=batch_vectorizer)
     finally:

--- a/src/artm/regularizer/topic_selection_theta.cc
+++ b/src/artm/regularizer/topic_selection_theta.cc
@@ -33,11 +33,10 @@ TopicSelectionTheta::CreateRegularizeThetaAgent(const Batch& batch,
   std::shared_ptr<TopicSelectionThetaAgent> retval(agent);
 
   const int topic_size = args.topic_name_size();
-  const int item_size = batch.item_size();
 
   if (config_.alpha_iter_size()) {
     if (args.num_document_passes() != config_.alpha_iter_size()) {
-      LOG(ERROR) << "ProcessBatchesArgs.num_document_passes() != SmoothSparseThetaConfig.alpha_iter_size()";
+      LOG(ERROR) << "ProcessBatchesArgs.num_document_passes() != TopicSelectionThetaConfig.alpha_iter_size()";
       return nullptr;
     }
 


### PR DESCRIPTION
Fixes #580.
The main change in `python/artm/artm_model.py` file (I believe it was a bug), other changes are "cosmetic" and related to unit testing and typo fixes.