### PR TITLE
glog and gtest - define snprintf only for VS2013 and earlier

### DIFF
--- a/3rdparty/gflags/src/windows_port.cc
+++ b/3rdparty/gflags/src/windows_port.cc
@@ -59,6 +59,8 @@ int safe_vsnprintf(char *str, size_t size, const char *format, va_list ap) {
 #  pragma warning(pop)
 #endif
 
+#if _MSC_VER < 1900  // msvs 2015 finally includes snprintf
+
 int snprintf(char *str, size_t size, const char *format, ...) {
   int r;
   va_list ap;
@@ -67,5 +69,7 @@ int snprintf(char *str, size_t size, const char *format, ...) {
   va_end(ap);
   return r;
 }
+
+#endif
 
 #endif  /* #if !defined(__MINGW32__) && !defined(__MINGW64__) */

--- a/3rdparty/glog/src/windows/port.cc
+++ b/3rdparty/glog/src/windows/port.cc
@@ -55,6 +55,8 @@ int safe_vsnprintf(char *str, size_t size, const char *format, va_list ap) {
   return _vsnprintf(str, size-1, format, ap);
 }
 
+#if _MSC_VER < 1900  // msvs 2015 finally includes snprintf
+
 int snprintf(char *str, size_t size, const char *format, ...) {
   va_list ap;
   va_start(ap, format);
@@ -62,3 +64,5 @@ int snprintf(char *str, size_t size, const char *format, ...) {
   va_end(ap);
   return r;
 }
+
+#endif


### PR DESCRIPTION
This is taken from https://github.com/gflags/gflags/pull/116/files
Note that this is is not a final solution for gflags and glog project.
They re-organize cmake files to avoid this problem.
We can't take their latest cmake files because they use cmake 3.0,
which is not available on travis-ci yet.