### PR TITLE
Fix problem with newline in vocab files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ src/artm/messages.pb.h
 /python/dist/*
 
 /src/artm/version.h
+
+# configuration file for YouCompleteMe
+.ycm_extra_conf.py

--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -221,7 +221,7 @@ CollectionParser::TokenMap CollectionParser::ParseVocabBagOfWordsUci() {
   int token_id = 0;
   while (!vocab.eof()) {
     std::getline(vocab, str);
-    if (vocab.eof())
+    if (vocab.eof() && str.empty())
       break;
 
     boost::algorithm::trim(str);
@@ -445,3 +445,4 @@ void CollectionParser::Parse() {
 
 }  // namespace core
 }  // namespace artm
+// vim: set ts=2 sw=2:

--- a/src/artm/core/dictionary.cc
+++ b/src/artm/core/dictionary.cc
@@ -256,7 +256,7 @@ Dictionary::Gather(const GatherDictionaryArgs& args,
       int token_id = 0;
       while (!vocab.eof()) {
         std::getline(vocab, str);
-        if (vocab.eof())
+        if (vocab.eof() && str.empty())
           break;
 
         boost::algorithm::trim(str);
@@ -545,3 +545,4 @@ float Dictionary::CountTopicCoherence(const std::vector<core::Token>& tokens_to_
 
 }  // namespace core
 }  // namespace artm
+// vim: set ts=2 sw=2:

--- a/test_data/vocab.parser_test_no_newline.txt
+++ b/test_data/vocab.parser_test_no_newline.txt
@@ -1,0 +1,3 @@
+token1
+token2
+token3


### PR DESCRIPTION
@ofrei
* this PR indents to fix #519;
* new vocab file must be without the last newline;
* is it good idea to have identical code in `src/artm/core/dicitonary.cc` and `src/artm/core/collection_parser.cc`?