### PR TITLE
Try out boost::serialize for serialization in BigARTM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if (NOT Boost_FOUND)
   message(SEND_ERROR "Failed to find boost libraries.")
 endif (NOT Boost_FOUND)
 
-set(BIGARTM_BOOST_COMPONENTS thread program_options date_time filesystem iostreams system)
+set(BIGARTM_BOOST_COMPONENTS thread program_options date_time filesystem iostreams serialization system)
 if (Boost_VERSION GREATER 104700)
   set(BIGARTM_BOOST_COMPONENTS ${BIGARTM_BOOST_COMPONENTS} chrono timer)
 endif (Boost_VERSION GREATER 104700)

--- a/src/artm_tests/CMakeLists.txt
+++ b/src/artm_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SRC_LIST
 	multiple_classes_test.cc
 	regularizers_test.cc
 	repeatable_result_test.cc
+	serialize_test.cc
 	supcry_test.cc
 	template_manager_test.cc
 	test_mother.cc

--- a/src/artm_tests/serialize_test.cc
+++ b/src/artm_tests/serialize_test.cc
@@ -1,0 +1,30 @@
+// Copyright 2015, Additive Regularization of Topic Models.
+#include <fstream>
+
+#include "boost/archive/text_oarchive.hpp"
+#include "boost/archive/text_iarchive.hpp"
+
+#include "gtest/gtest.h"
+
+#include "artm/core/token.h"
+
+// artm_tests.exe --gtest_filter=Serializer.Token
+TEST(Serializer, Token) {
+  // http://stackoverflow.com/questions/3015582/direct-boost-serialization-to-char-array
+  std::ofstream ofs("filename");
+  ::artm::core::Token token("my class", "my keyword");
+
+  {
+    boost::archive::text_oarchive oa(ofs);
+    oa << token;
+  }
+
+  ::artm::core::Token token2;
+  {
+    std::ifstream ifs("filename");
+    boost::archive::text_iarchive ia(ifs);
+    ia >> token2;
+  }
+
+  ASSERT_EQ(token, token2);
+}

--- a/utils/cpplint_files.txt
+++ b/utils/cpplint_files.txt
@@ -49,6 +49,7 @@ src/artm_tests/regularizers_test.cc
 src/artm_tests/repeatable_result_test.cc
 src/artm_tests/master_model_test.cc
 src/artm_tests/multiple_classes_test.cc
+src/artm_tests/serialize_test.cc
 src/artm_tests/supcry_test.cc
 src/artm_tests/test_mother.cc
 src/artm_tests/thread_safe_holder_test.cc


### PR DESCRIPTION
The plan is to use boost::serialize for dictionaries and models. Serialization of batches may still use google protobuf format.
See https://github.com/bigartm/bigartm/issues/403 for details.