### PR TITLE
Fix #634 bigartm CLI fails without --threads param

### DIFF
--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -1259,7 +1259,7 @@ int main(int argc, char * argv[]) {
       ("kappa", po::value(&options.kappa)->default_value(0.7f), "[online algorithm] exponent option from online update formula")
       ("reuse-theta", po::bool_switch(&options.b_reuse_theta)->default_value(false), "reuse theta between iterations")
       ("regularizer", po::value< std::vector<std::string> >(&options.regularizer)->multitoken(), "regularizers (SmoothPhi,SparsePhi,SmoothTheta,SparseTheta,Decorrelation)")
-      ("threads", po::value(&options.threads)->default_value(0), "number of concurrent processors (default: auto-detect)")
+      ("threads", po::value(&options.threads)->default_value(-1), "number of concurrent processors (default: auto-detect)")
       ("async", po::bool_switch(&options.async)->default_value(false), "invoke asynchronous version of the online algorithm")
     ;
 


### PR DESCRIPTION
Auto-detection only happens if num_processors is set to a negative number, as implemented here:
https://github.com/bigartm/bigartm/blob/master/src/artm/core/instance.cc#L359
```
 if (!master_config.has_num_processors() || master_config.num_processors() < 0) {
```
This is because it is valid to create a master component without processor threads.
The fix is to set use ``-1`` as a default value for ``threads`` parameter in bigartm CLI.