### PR TITLE
Enable ProgressPrinter on Windows

### DIFF
--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -74,7 +74,6 @@ void CollectionParser::ParseDocwordBagOfWordsUci(TokenMap* token_map) {
   std::string str;
   while (true) {
     pos = docword.tellg();
-    progress.Set(pos);
     std::getline(docword, str);
     if (!boost::starts_with(str.c_str(), "%")) {
       // FIXME (JeanPaulShapo) there can be failures when reading from standard input
@@ -134,6 +133,7 @@ void CollectionParser::ParseDocwordBagOfWordsUci(TokenMap* token_map) {
     std::getline(docword, str);
     boost::algorithm::trim(str);
     ++line_no;
+    progress.Set(docword.tellg());
     if (str.empty()) continue;
 
     std::vector<std::string> strs;

--- a/src/artm/utility/progress_printer.cc.in
+++ b/src/artm/utility/progress_printer.cc.in
@@ -17,19 +17,13 @@
 namespace artm {
 namespace utility {
 
-ProgressPrinter::ProgressPrinter(size_t max) noexcept : max_(max), pos_(0) {
+ProgressPrinter::ProgressPrinter(size_t max) : max_(max), pos_(0) {
   if (!isatty(fileno(stderr))) {  // disable in non-interactive mode
     max_ = 0;
   }
-  #ifdef _WIN32
-  // Windows terminal does not support ANSI codes until 10
-  // http://superuser.com/a/1105718
-  // TODO(v.markovtsev): activate ANSI for Windows 10 via SetConsoleMode()
-  max_ = 0;
-  #endif
 }
 
-void ProgressPrinter::Add(int delta) noexcept {
+void ProgressPrinter::Add(int delta) {
   size_t npos = pos_ + delta;
   if (npos < pos_ && delta > 0) {  // max range overflow
     npos = max_;
@@ -39,7 +33,7 @@ void ProgressPrinter::Add(int delta) noexcept {
   Set(npos);
 }
 
-void ProgressPrinter::Set(size_t pos) noexcept {
+void ProgressPrinter::Set(size_t pos) {
   if (max_ == 0) {
     return;  // no-op, progress is disabled
   }
@@ -48,7 +42,7 @@ void ProgressPrinter::Set(size_t pos) noexcept {
   int pct = static_cast<int>((pos_ * 100) / max_);
   if (pct != prevpct) {
     // ANSI code \033[<N>D moves cursor to N positions backwards
-    fprintf(stderr, " %3d%%\033[5D", pct);
+    fprintf(stderr, " %3d%%\b\b\b\b\b", pct);
     fflush(stderr);
   }
 }

--- a/src/artm/utility/progress_printer.cc.in
+++ b/src/artm/utility/progress_printer.cc.in
@@ -42,7 +42,19 @@ void ProgressPrinter::Set(size_t pos) {
   int pct = static_cast<int>((pos_ * 100) / max_);
   if (pct != prevpct) {
     // ANSI code \033[<N>D moves cursor to N positions backwards
-    fprintf(stderr, " %3d%%\b\b\b\b\b", pct);
+    // Windows terminal does not support ANSI codes until 10
+    // http://superuser.com/a/1105718
+    // As a workaround for windows we use \b\b\b\b\b.
+    // This sounds like a bug because \b stands for backspace, e.g. it should remove previous character,
+    // But on Windows terminal it only moves the cursor one position back (no erase).
+
+    fprintf(stderr, " %3d%%"
+#ifdef _WIN32
+                            "\b\b\b\b\b"
+#else
+                            "\033[5D"
+#endif
+                                        , pct);
     fflush(stderr);
   }
 }

--- a/src/artm/utility/progress_printer.h
+++ b/src/artm/utility/progress_printer.h
@@ -10,10 +10,10 @@ namespace utility {
 
 class ProgressPrinter {
  public:
-  explicit ProgressPrinter(size_t max) noexcept;
-  void Add(int delta) noexcept;
-  void Set(size_t pos) noexcept;
-  size_t max() const noexcept { return max_; }
+  explicit ProgressPrinter(size_t max);
+  void Add(int delta);
+  void Set(size_t pos);
+  size_t max() const { return max_; }
 
  private:
   size_t max_;


### PR DESCRIPTION
- remove noexcept for compatibility with Visual Studio 2013
- move cursor back with `\b`