### PR TITLE
Misc improvements in BigARTM CLI

### DIFF
--- a/docs/download.txt
+++ b/docs/download.txt
@@ -20,37 +20,32 @@ Downloads
 
   Download one of the following datasets to start experimenting with BigARTM.
   See :doc:`formats` page for the description of input data formats.
+  Note that ``docword.*`` and ``vocab.*`` files indicate ``UCI BOW`` format,
+  while ``vw.*`` file indicate ``Vowpal Wabbit`` format.
   
-
     ========= ========= ======= ======= ==================================================================================================================
     Task      Source    #Words  #Items  Files
     ========= ========= ======= ======= ==================================================================================================================
     kos       `UCI`_    6906    3430    * `docword.kos.txt.gz (1 MB) <https://s3-eu-west-1.amazonaws.com/artm/docword.kos.txt.gz>`_
                                         * `vocab.kos.txt (54 KB) <https://s3-eu-west-1.amazonaws.com/artm/vocab.kos.txt>`_      
-                                        * `kos_1k (700 KB)     <https://s3-eu-west-1.amazonaws.com/artm/kos_1k.7z>`_           
     nips      `UCI`_    12419   1500    * `docword.nips.txt.gz (2.1 MB) <https://s3-eu-west-1.amazonaws.com/artm/docword.nips.txt.gz>`_
                                         * `vocab.nips.txt (98 KB) <https://s3-eu-west-1.amazonaws.com/artm/vocab.nips.txt>`_
-                                        * `nips_200 (1.5 MB)   <https://s3-eu-west-1.amazonaws.com/artm/nips_200.7z>`_         
     enron     `UCI`_    28102   39861   * `docword.enron.txt.gz (11.7 MB) <https://s3-eu-west-1.amazonaws.com/artm/docword.enron.txt.gz>`_
                                         * `vocab.enron.txt (230 KB) <https://s3-eu-west-1.amazonaws.com/artm/vocab.enron.txt>`_
-                                        * `enron_1k (7.1 MB)   <https://s3-eu-west-1.amazonaws.com/artm/enron_1k.7z>`_         
     nytimes   `UCI`_    102660  300000  * `docword.nytimes.txt.gz (223 MB) <https://s3-eu-west-1.amazonaws.com/artm/docword.nytimes.txt.gz>`_
                                         * `vocab.nytimes.txt (1.2 MB) <https://s3-eu-west-1.amazonaws.com/artm/vocab.nytimes.txt>`_
-                                        * `nytimes_1k (131 MB) <https://s3-eu-west-1.amazonaws.com/artm/nytimes_1k.7z>`_
     pubmed    `UCI`_    141043  8200000 * `docword.pubmed.txt.gz (1.7 GB) <https://s3-eu-west-1.amazonaws.com/artm/docword.pubmed.txt.gz>`_
                                         * `vocab.pubmed.txt (1.3 MB) <https://s3-eu-west-1.amazonaws.com/artm/vocab.pubmed.txt>`_
-                                        * `pubmed_10k (1 GB)   <https://s3-eu-west-1.amazonaws.com/artm/pubmed_10k.7z>`_
-    wiki      `Gensim`_ 100000  3665223 * `enwiki-20141208_10k (1.2 GB)   <https://s3-eu-west-1.amazonaws.com/artm/enwiki-20141208_10k.7z>`_
-                                        * `enwiki-20141208_1k (1.4 GB)    <https://s3-eu-west-1.amazonaws.com/artm/enwiki-20141208_1k.7z>`_
-    wiki_enru `Wiki`_   196749  216175  * `wiki_enru (282 MB)  <https://s3-eu-west-1.amazonaws.com/artm/wiki_enru.7z>`_
-                                        * namespaces: ``@english``, ``@russian``
-    lastfm    `lastfm`_         1k,     * `lastfm_1k ( MB)  <https://s3-eu-west-1.amazonaws.com/artm/lastfm_1k.7z>`_ (VW format)
-                                360k    * `lastfm_360k ( MB)  <https://s3-eu-west-1.amazonaws.com/artm/lastfm_360k.7z>`_ (VW format)
+    wiki      `Gensim`_ 100000  3665223 * `vw.wiki-en.txt.zip (1.8 GB) <https://s3-eu-west-1.amazonaws.com/artm/vw.wiki-en.txt.zip>`_
+    wiki_enru `Wiki`_   196749  216175  * `vw.wiki_enru.txt.zip (285 MB)  <https://s3-eu-west-1.amazonaws.com/artm/vw.wiki-enru.txt.zip>`_
+    eurlex    `eurlex`_ 19800   21000   * `vw.eurlex.txt.zip (13 MB) <https://s3-eu-west-1.amazonaws.com/artm/vw.eurlex.txt.zip>`_
+                                        * `vw.eurlex-test.txt.zip (13 MB) <https://s3-eu-west-1.amazonaws.com/artm/vw.eurlex-test.txt.zip>`_
+    lastfm    `lastfm`_         1k,     * `vw.lastfm_1k.txt.zip (100 MB)  <https://s3-eu-west-1.amazonaws.com/artm/vw.lastfm_1k.txt.zip>`_
+                                360k    * `vw.lastfm_360k.txt.zip (330 MB)  <https://s3-eu-west-1.amazonaws.com/artm/vw.lastfm_360k.txt.zip>`_
     mmro      `mmro`_   7805    1061    * `docword.mmro.txt.gz (500 KB) <https://s3-eu-west-1.amazonaws.com/artm/docword.mmro.txt.7z>`_
                                         * `vocab.mmro.txt (150 KB) <https://s3-eu-west-1.amazonaws.com/artm/vocab.mmro.txt>`_
                                         * `pPMI_w100.mmro.txt.7z (23 MB) <https://s3-eu-west-1.amazonaws.com/artm/pPMI_w100.mmro.txt.7z>`_
                                         * `vw.mmro.txt.7z (1.4 MB) <https://s3-eu-west-1.amazonaws.com/artm/vw.mmro.txt.7z>`_
-    eurlex    `eurlex`_ 19800   21000   * `eurlex_1k (13 MB) <https://s3-eu-west-1.amazonaws.com/artm/eurlex_1k.zip>`_
     ========= ========= ======= ======= ==================================================================================================================
 
 .. _UCI: https://archive.ics.uci.edu/ml/datasets/Bag+of+Words

--- a/docs/release_notes/bigartm_cli.txt
+++ b/docs/release_notes/bigartm_cli.txt
@@ -12,6 +12,8 @@ v0.8.2
 * added switch ``--guid-batch-name`` to enable old naming scheme of batches (guid-based names).
   This option is useful if you launch multiple instances of BigARTM CLI to concurrently generate batches.
 * speedup parsing large files in VowpalWabbit format
+* when ``--use-modality`` is specified, the batches saved with ``--save-batches`` will only include tokens from these modalities.
+  Other tokens will be ignored during parsing. This option is implemented for both VW and UCI BOW formats.
 
 v0.8.0
 ------

--- a/docs/release_notes/bigartm_cli.txt
+++ b/docs/release_notes/bigartm_cli.txt
@@ -14,6 +14,7 @@ v0.8.2
 * speedup parsing large files in VowpalWabbit format
 * when ``--use-modality`` is specified, the batches saved with ``--save-batches`` will only include tokens from these modalities.
   Other tokens will be ignored during parsing. This option is implemented for both VW and UCI BOW formats.
+* implement ``TopicSelection`` regularizer in BigARTM CLI
 
 v0.8.0
 ------

--- a/docs/release_notes/bigartm_cli.txt
+++ b/docs/release_notes/bigartm_cli.txt
@@ -14,7 +14,7 @@ v0.8.2
 * speedup parsing large files in VowpalWabbit format
 * when ``--use-modality`` is specified, the batches saved with ``--save-batches`` will only include tokens from these modalities.
   Other tokens will be ignored during parsing. This option is implemented for both VW and UCI BOW formats.
-* implement ``TopicSelection`` regularizer in BigARTM CLI
+* implement ``TopicSelection``, ``LabelRegularization``, ``ImproveCoherence``, ``Biterms`` regularizer in BigARTM CLI
 
 v0.8.0
 ------

--- a/docs/release_notes/bigartm_cli.txt
+++ b/docs/release_notes/bigartm_cli.txt
@@ -5,6 +5,12 @@ v0.8.2
 ------
 
 * added option ``--rand-seed`` to initialize random number generator; without this options, RNG will be set using system time
+* added option ``--write-vw-corpus`` to convert batches into plain text file in Vowpal Wabbit format
+* change the naming scheme of the batches, saved with ``--save-batches`` option.
+  Previously file names were guid-based, while new format will look like this: ``aabcde.batch``.
+  New format ensures the ordering of the documents in the collection is be preserved, given that user scans batches alphabetically.
+* added switch ``--guid-batch-name`` to enable old naming scheme of batches (guid-based names).
+  This option is useful if you launch multiple instances of BigARTM CLI to concurrently generate batches.
 * speedup parsing large files in VowpalWabbit format
 
 v0.8.0

--- a/docs/release_notes/messages.txt
+++ b/docs/release_notes/messages.txt
@@ -6,6 +6,9 @@ v0.8.2
 
 * added ``CollectionParserConfig.num_threads`` to control the number of threads that perform parsing.
   At the moment the feature is only implemented for VW-format.
+* added ``CollectionParserConfig.class_id`` (repeated string) to control which modalities should be parsed.
+  If token's class_id is not from this list, it will be excluded from the resulting batches.
+  When the list is empty, all modalities are included (this is the default behavior, as before).
 
 v0.8.0
 ------

--- a/src/artm/cpp_interface.h
+++ b/src/artm/cpp_interface.h
@@ -61,6 +61,7 @@ int HandleErrorCode(int artm_error_code);
 
 void ParseCollection(const CollectionParserConfig& config);
 void ConfigureLogging(const ConfigureLoggingArgs& args);
+Batch LoadBatch(std::string filename);
 
 class Matrix {
  public:

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -428,6 +428,7 @@ message CollectionParserConfig {
   optional bool use_unity_based_indices = 6 [default = true];
   optional BatchNameType name_type = 7 [default = Guid];
   optional int32 num_threads = 8;
+  repeated string class_id = 9;
 }
 
 // Represents an argument of 'initialize model' operation

--- a/src/artm/regularizer/topic_selection_theta.cc
+++ b/src/artm/regularizer/topic_selection_theta.cc
@@ -14,6 +14,12 @@ namespace regularizer {
 
 void TopicSelectionThetaAgent::Apply(int item_index, int inner_iter, int topics_size,
                                      const float* n_td, float* r_td) const {
+  if (topic_value.empty()) {
+    LOG_FIRST_N(ERROR, 1) << "TopicSelectionThetaAgent regularizer can not be applied with opt_for_avx=False. "
+                          << "Regularization will be skipped.";
+    return;
+  }
+
   assert(topics_size == topic_weight.size());
   assert(inner_iter < alpha_weight.size());
   if (topics_size != topic_weight.size()) return;
@@ -23,6 +29,45 @@ void TopicSelectionThetaAgent::Apply(int item_index, int inner_iter, int topics_
     if (n_td[topic_id] > 0.0f)
       r_td[topic_id] += alpha_weight[inner_iter] * topic_weight[topic_id] * topic_value[topic_id] * n_td[topic_id];
   }
+}
+
+void TopicSelectionThetaAgent::Apply(int inner_iter,
+                                     const ::artm::utility::LocalThetaMatrix<float>& n_td,
+                                     ::artm::utility::LocalThetaMatrix<float>* r_td) const {
+  int topics_num = n_td.num_topics(), items_num = n_td.num_items();
+
+  assert(topics_num == topic_weight.size());
+  assert(inner_iter < alpha_weight.size());
+  if (topics_num != topic_weight.size()) return;
+  if (inner_iter >= alpha_weight.size()) return;
+
+  auto local_topic_value = topic_value;
+  if (local_topic_value.empty()) {
+    std::vector<double> n_t(topics_num, 0.0);
+    double n = 0.0;
+
+    // count n_t
+    for (int item_id = 0; item_id < items_num; ++item_id)
+      for (int topic_id = 0; topic_id < topics_num; ++topic_id)
+        n_t[topic_id] += n_td(topic_id, item_id);
+
+    // count n = sum(n_t)
+    for (int topic_id = 0; topic_id < topics_num; ++topic_id)
+      n += n_t[topic_id];
+
+    for (int topic_id = 0; topic_id < topics_num; ++topic_id) {
+      double val = n_t[topic_id] * topics_num;
+      local_topic_value.push_back((val > 0) ? static_cast<float>(n / val) : 0.0f);
+    }
+  }
+
+  for (int item_id = 0; item_id < items_num; ++item_id)
+    for (int topic_id = 0; topic_id < topics_num; ++topic_id)
+      if (n_td(topic_id, item_id) > 0.0f)
+        (*r_td)(topic_id, item_id) += alpha_weight[inner_iter] *
+                                      topic_weight[topic_id] *
+                                      local_topic_value[topic_id] *
+                                      n_td(topic_id, item_id);
 }
 
 TopicSelectionTheta::TopicSelectionTheta(const TopicSelectionThetaConfig& config) : config_(config) { }
@@ -57,8 +102,8 @@ TopicSelectionTheta::CreateRegularizeThetaAgent(const Batch& batch,
     for (int i = 0; i < topic_size; ++i)
       agent->topic_value.push_back(config_.topic_value(i));
   } else {
-    for (int i = 0; i < topic_size; ++i)
-      agent->topic_value.push_back(1.0f);
+    // Keep topic_value empty, and assume we are running in opt_for_avx mode.
+    // Then topic_value will be calculated from local theta matrix (per batch).
   }
 
   agent->topic_weight.resize(topic_size, 0.0f);

--- a/src/artm/regularizer/topic_selection_theta.h
+++ b/src/artm/regularizer/topic_selection_theta.h
@@ -35,6 +35,8 @@ namespace regularizer {
 class TopicSelectionThetaAgent : public RegularizeThetaAgent {
  public:
   virtual void Apply(int item_index, int inner_iter, int topics_size, const float* n_td, float* r_td) const;
+  virtual void Apply(int inner_iter, const ::artm::utility::LocalThetaMatrix<float>& n_td,
+                     ::artm::utility::LocalThetaMatrix<float>* r_td) const;
 
  private:
   friend class TopicSelectionTheta;

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -481,7 +481,7 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
 
   RegularizerConfig* config = master_config->add_regularizer_config();
 
-  // SmoothPhi, SparsePhi, SmoothTheta, SparseTheta, Decorrelation, TopicSelection
+  // SmoothPhi, SparsePhi, SmoothTheta, SparseTheta, Decorrelation, TopicSelection, LabelRegularization, ImproveCoherence, Biterms
   std::string regularizer_type = boost::to_lower_copy(strs[1]);
   if (regularizer_type == "smooththeta" || regularizer_type == "sparsetheta") {
     ::artm::SmoothSparseThetaConfig specific_config;
@@ -535,6 +535,48 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
 
     // Force disable opt_for_avx because it is incompatible with TopicSelection regularizer
     master_config->set_opt_for_avx(false);
+  }
+  else if (regularizer_type == "labelregularization") {
+    ::artm::LabelRegularizationPhiConfig specific_config;
+    for (auto& topic_name : topic_names)
+      specific_config.add_topic_name(topic_name);
+    for (auto& class_id : class_ids)
+      specific_config.add_class_id(class_id.first);
+    if (!dictionary_name.empty())
+      specific_config.set_dictionary_name(dictionary_name);
+
+    config->set_name(regularizer);
+    config->set_type(::artm::RegularizerType_LabelRegularizationPhi);
+    config->set_config(specific_config.SerializeAsString());
+    config->set_tau(tau);
+  }
+  else if (regularizer_type == "improvecoherence") {
+    ::artm::ImproveCoherencePhiConfig specific_config;
+    for (auto& topic_name : topic_names)
+      specific_config.add_topic_name(topic_name);
+    for (auto& class_id : class_ids)
+      specific_config.add_class_id(class_id.first);
+    if (!dictionary_name.empty())
+      specific_config.set_dictionary_name(dictionary_name);
+
+    config->set_name(regularizer);
+    config->set_type(::artm::RegularizerType_ImproveCoherencePhi);
+    config->set_config(specific_config.SerializeAsString());
+    config->set_tau(tau);
+  }
+  else if (regularizer_type == "biterms") {
+    ::artm::BitermsPhiConfig specific_config;
+    for (auto& topic_name : topic_names)
+      specific_config.add_topic_name(topic_name);
+    for (auto& class_id : class_ids)
+      specific_config.add_class_id(class_id.first);
+    if (!dictionary_name.empty())
+      specific_config.set_dictionary_name(dictionary_name);
+
+    config->set_name(regularizer);
+    config->set_type(::artm::RegularizerType_BitermsPhi);
+    config->set_config(specific_config.SerializeAsString());
+    config->set_tau(tau);
   } else {
     throw std::invalid_argument(std::string("Unknown regularizer type: " + strs[1]));
   }
@@ -1431,11 +1473,11 @@ int main(int argc, char * argv[]) {
       std::cerr << "\t--regularizer \"tau SparsePhi #topics @class_ids !dictionary\"\n";
       std::cerr << "\t--regularizer \"tau Decorrelation #topics @class_ids\"\n";
       std::cerr << "\t--regularizer \"tau TopicSelection #topics\"\n";
+      std::cerr << "\t--regularizer \"tau LabelRegularization #topics @class_ids !dictionary\"\n";
+      std::cerr << "\t--regularizer \"tau ImproveCoherence #topics @class_ids !dictionary\"\n";
+      std::cerr << "\t--regularizer \"tau Biterms #topics @class_ids !dictionary\"\n";
       std::cerr << "\nList of regularizers available in BigARTM, but not exposed in CLI:\n\n";
       std::cerr << "\t--regularizer \"tau SpecifiedSparsePhi\"\n";
-      std::cerr << "\t--regularizer \"tau LabelRegularizationPhi\"\n";
-      std::cerr << "\t--regularizer \"tau ImproveCoherencePhi\"\n";
-      std::cerr << "\t--regularizer \"tau BitermsPhi\"\n";
       std::cerr << "\t--regularizer \"tau SmoothPtdw\"\n";
       std::cerr << "\t--regularizer \"tau HierarchySparsingTheta\"\n\n";
       std::cerr << "If you are interested to see any of these regularizers in BigARTM CLI please send a message to\n";

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -481,7 +481,7 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
 
   RegularizerConfig* config = master_config->add_regularizer_config();
 
-  // SmoothPhi, SparsePhi, SmoothTheta, SparseTheta, Decorrelation
+  // SmoothPhi, SparsePhi, SmoothTheta, SparseTheta, Decorrelation, TopicSelection
   std::string regularizer_type = boost::to_lower_copy(strs[1]);
   if (regularizer_type == "smooththeta" || regularizer_type == "sparsetheta") {
     ::artm::SmoothSparseThetaConfig specific_config;
@@ -522,6 +522,19 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
     config->set_type(::artm::RegularizerType_DecorrelatorPhi);
     config->set_config(specific_config.SerializeAsString());
     config->set_tau(tau);
+  }
+  else if (regularizer_type == "topicselection") {
+    ::artm::TopicSelectionThetaConfig specific_config;
+    for (auto& topic_name : topic_names)
+      specific_config.add_topic_name(topic_name);
+
+    config->set_name(regularizer);
+    config->set_type(::artm::RegularizerType_TopicSelectionTheta);
+    config->set_config(specific_config.SerializeAsString());
+    config->set_tau(tau);
+
+    // Force disable opt_for_avx because it is incompatible with TopicSelection regularizer
+    master_config->set_opt_for_avx(false);
   } else {
     throw std::invalid_argument(std::string("Unknown regularizer type: " + strs[1]));
   }
@@ -1417,8 +1430,8 @@ int main(int argc, char * argv[]) {
       std::cerr << "\t--regularizer \"tau SmoothPhi #topics @class_ids !dictionary\"\n";
       std::cerr << "\t--regularizer \"tau SparsePhi #topics @class_ids !dictionary\"\n";
       std::cerr << "\t--regularizer \"tau Decorrelation #topics @class_ids\"\n";
+      std::cerr << "\t--regularizer \"tau TopicSelection #topics\"\n";
       std::cerr << "\nList of regularizers available in BigARTM, but not exposed in CLI:\n\n";
-      std::cerr << "\t--regularizer \"tau TopicSelectionTheta\"\n";
       std::cerr << "\t--regularizer \"tau SpecifiedSparsePhi\"\n";
       std::cerr << "\t--regularizer \"tau LabelRegularizationPhi\"\n";
       std::cerr << "\t--regularizer \"tau ImproveCoherencePhi\"\n";

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -845,6 +845,13 @@ class BatchVectorizer {
       collection_parser_config.set_target_folder(batch_folder_);
       collection_parser_config.set_num_items_per_batch(options_.batch_size);
       collection_parser_config.set_name_type(options_.b_guid_batch_name ? CollectionParserConfig_BatchNameType_Guid : CollectionParserConfig_BatchNameType_Code);
+
+      // If user specifies specific modalities "use_modality", pass it to collection parser to limit set of modalities available in batches
+      std::vector<std::pair<std::string, float>> class_ids = parseKeyValuePairs<float>(options_.use_modality);
+      for (auto& class_id : class_ids)
+        if (!class_id.first.empty())
+          collection_parser_config.add_class_id(class_id.first);
+
       ::artm::ParseCollection(collection_parser_config);
     }
     else if (!options_.use_batches.empty()) {
@@ -1445,6 +1452,7 @@ int main(int argc, char * argv[]) {
       std::cerr << "  wget https://s3-eu-west-1.amazonaws.com/artm/docword.kos.txt \n";
       std::cerr << "  wget https://s3-eu-west-1.amazonaws.com/artm/vocab.kos.txt \n";
       std::cerr << "  wget https://s3-eu-west-1.amazonaws.com/artm/vw.mmro.txt \n";
+      std::cerr << "  wget https://s3-eu-west-1.amazonaws.com/artm/vw.wiki-enru.txt.zip \n";
       std::cerr << std::endl;
       std::cerr << "* Parse docword and vocab files from UCI bag-of-word format; then fit topic model with 20 topics:\n";
       std::cerr << "  bigartm -d docword.kos.txt -v vocab.kos.txt -t 20 --num_collection_passes 10\n";
@@ -1457,6 +1465,9 @@ int main(int argc, char * argv[]) {
       std::cerr << std::endl;
       std::cerr << "* Re-save batches back into VW format:\n";
       std::cerr << "  bigartm --use-batches mmro_batches --write-vw-corpus vw.mmro.txt\n";
+      std::cerr << std::endl;
+      std::cerr << "* Parse only specific modalities from VW file, and save them as a new VW file:\n";
+      std::cerr << "  bigartm --read-vw-corpus vw.wiki-enru.txt --use-modality @russian --write-vw-corpus vw.wiki-ru.txt\n";
       std::cerr << std::endl;
       std::cerr << "* Load and filter the dictionary on document frequency; save the result into a new file:\n";
       std::cerr << "  bigartm --use-dictionary mmro.dict --dictionary-min-df 5 dictionary-max-df 40% --save-dictionary mmro-filter.dict\n";


### PR DESCRIPTION
- Add options ``--write-vw-corpus``, ``--guid-batch-name``.
- Only parse certain modalities when user specifies ``--use-modality``
- Enable TopicSelectionTheta regularizer
- Enable other regularizers (LabelRegularization, ImproveCoherence, Biterms); this is not tested.