### PR TITLE
Remove sudo from mac os installation instructions

### DIFF
--- a/docs/installation/linux.txt
+++ b/docs/installation/linux.txt
@@ -28,7 +28,7 @@ To simplify things, you may type:
   (for Fedora 22 or higher use ``dnf`` instead of ``yum``) 
 
 * **On Mac OS distributions**:
-  ``sudo brew install git cmake boost``
+  ``brew install git cmake boost``
 
 
 Download sources and build


### PR DESCRIPTION
Fixed #662