### PR TITLE
topic segmentation ptdw regularizer added

### DIFF
--- a/python/artm/master_component.py
+++ b/python/artm/master_component.py
@@ -25,6 +25,8 @@ def _regularizer_type(config):
         return constants.RegularizerType_TopicSelectionTheta
     elif isinstance(config, messages.BitermsPhiConfig):
         return constants.RegularizerType_BitermsPhi
+    elif isinstance(config, messages.TopicSegmentationPtdwConfig):
+        return constants.RegularizerType_TopicSegmentationPtdw
 
 
 def _score_type(config):

--- a/python/artm/regularizers.py
+++ b/python/artm/regularizers.py
@@ -17,6 +17,7 @@ __all__ = [
     'SmoothPtdwRegularizer',
     'TopicSelectionThetaRegularizer',
     'BitermsPhiRegularizer',
+    'TopicSegmentationPtdwRegularizer'
 ]
 
 
@@ -623,3 +624,35 @@ class BitermsPhiRegularizer(BaseRegularizerPhi):
                                     topic_names=topic_names,
                                     class_ids=class_ids,
                                     dictionary=dictionary)
+
+class TopicSegmentationPtdwRegularizer(BaseRegularizer):
+    _config_message = messages.TopicSegmentationPtdwConfig
+    _type = const.RegularizerType_TopicSegmentationPtdw
+
+    def __init__(self, name=None, window=None, threshold=None, background_topic_names=None, config=None):
+        """
+        :param str name: the identifier of regularizer, will be auto-generated if not specified
+        :param int window: a number of words to the one side over which smoothing will be performed
+        :param float threshold: probability threshold for a word to be a topic-changing word
+        :param background_topic_names: list of names of topics to be considered background, will not consider background topics if not specified
+        :type background_topic_names: list of str
+        :param config: the low-level config of this regularizer
+        :type config: protobuf object
+        """
+
+        BaseRegularizer.__init__(self,
+                                 name=name,
+                                 tau=0,
+                                 gamma=None,
+                                 config=config)
+        if window is not None:
+            self._config.window = window
+            self._window = window
+
+        if threshold is not None:
+            self._config.threshold = threshold
+            self._threshold = threshold
+
+        if background_topic_names is not None:
+            for topic_name in background_topic_names:
+                self._config.background_topic_names.append(topic_name)

--- a/python/artm/regularizers.py
+++ b/python/artm/regularizers.py
@@ -625,6 +625,7 @@ class BitermsPhiRegularizer(BaseRegularizerPhi):
                                     class_ids=class_ids,
                                     dictionary=dictionary)
 
+
 class TopicSegmentationPtdwRegularizer(BaseRegularizer):
     _config_message = messages.TopicSegmentationPtdwConfig
     _type = const.RegularizerType_TopicSegmentationPtdw
@@ -634,7 +635,8 @@ class TopicSegmentationPtdwRegularizer(BaseRegularizer):
         :param str name: the identifier of regularizer, will be auto-generated if not specified
         :param int window: a number of words to the one side over which smoothing will be performed
         :param float threshold: probability threshold for a word to be a topic-changing word
-        :param background_topic_names: list of names of topics to be considered background, will not consider background topics if not specified
+        :param background_topic_names: list of names of topics to be considered background,\
+                                will not consider background topics if not specified
         :type background_topic_names: list of str
         :param config: the low-level config of this regularizer
         :type config: protobuf object

--- a/python/artm/regularizers.py
+++ b/python/artm/regularizers.py
@@ -17,7 +17,7 @@ __all__ = [
     'SmoothPtdwRegularizer',
     'TopicSelectionThetaRegularizer',
     'BitermsPhiRegularizer',
-    'TopicSegmentationPtdwRegularizer'
+    'TopicSegmentationPtdwRegularizer',
 ]
 
 
@@ -644,7 +644,7 @@ class TopicSegmentationPtdwRegularizer(BaseRegularizer):
 
         BaseRegularizer.__init__(self,
                                  name=name,
-                                 tau=0,
+                                 tau=1.0,
                                  gamma=None,
                                  config=config)
         if window is not None:

--- a/python/artm/wrapper/constants.py
+++ b/python/artm/wrapper/constants.py
@@ -15,6 +15,7 @@ RegularizerType_ImproveCoherencePhi = 6
 RegularizerType_SmoothPtdw = 7
 RegularizerType_TopicSelectionTheta = 8
 RegularizerType_BitermsPhi = 9
+RegularizerType_TopicSegmentationPtdw = 10
 TransformConfig_TransformType_Logarithm = 0
 TransformConfig_TransformType_Polynomial = 1
 TransformConfig_TransformType_Constant = 2

--- a/python/tests/artm/test_topic_seg.py
+++ b/python/tests/artm/test_topic_seg.py
@@ -43,24 +43,25 @@ def test_func():
         
         model_reg.fit_offline(batch_vectorizer=batch_vectorizer, num_collection_passes=num_collection_passes)
         model.fit_offline(batch_vectorizer=batch_vectorizer, num_collection_passes=num_collection_passes)
-        model_reg.regularizers.add(artm.TopicSegmentationPtdwRegularizer(name='TopicSegmentation', window=window,\
-                                                                         threshold=threshold, background_topic_names=background_topics))
-        
+        model_reg.regularizers.add(artm.TopicSegmentationPtdwRegularizer(name='TopicSegmentation', window=window, threshold=threshold, background_topic_names=background_topics))
         ptdw = model.transform(batch_vectorizer=batch_vectorizer, theta_matrix_type='dense_ptdw')
         ptdw_reg = model_reg.transform(batch_vectorizer=batch_vectorizer, theta_matrix_type='dense_ptdw')
         
         doc_ids = np.random.choice(np.arange(3430), size=500)  #choose some documents randomly
         for doc_id in doc_ids:
             doc_df = ptdw[ptdw.columns[doc_id]]
-            token_id = window + np.random.choice(np.arange(doc_df.shape[1] - 2 * window))  #choose the token randomly somewhere from the inner part of the document
+            token_id = window + np.random.choice(np.arange(doc_df.shape[1] - 2 * window))
             
             weights = []
-            def f(x):
-                weights.append(1 - (x[0] + x[1] + x[2]))
-                return x * (1 - (x[0] + x[1] + x[2]))
-            left_dist = doc_df.iloc[:, token_id - window : token_id].apply(f, axis=0).sum(axis=1) / sum(weights)
+            
+            def __f(x):
+                temp = 1 - (x[0] + x[1] + x[2])
+                weights.append(temp)
+                return x * temp
+            
+            left_dist = doc_df.iloc[:, token_id - window : token_id].apply(__f, axis=0).sum(axis=1) / sum(weights)
             weights = []
-            right_dist = doc_df.iloc[:, token_id : token_id + window].apply(f, axis=0).sum(axis=1) / sum(weights)
+            right_dist = doc_df.iloc[:, token_id : token_id + window].apply(__f, axis=0).sum(axis=1) / sum(weights)
             
             l = left_dist.argmax()
             r = right_dist.argmax()

--- a/python/tests/artm/test_topic_seg.py
+++ b/python/tests/artm/test_topic_seg.py
@@ -1,0 +1,75 @@
+#from __future__ import print_function
+import shutil
+import glob
+import tempfile
+import os
+import pytest
+import numpy as np
+
+import artm
+
+def test_func():
+    # constants
+    num_collection_passes = 1
+    num_document_passes = 1
+    num_topics = 10
+    vocab_size = 6906
+    num_docs = 3430
+    num_tokens = 10
+    background_topics = ["topic_0", "topic_1", "topic_2"]
+    window = 3
+    threshold = 0.2
+
+    data_path = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
+    batches_folder = tempfile.mkdtemp()
+
+    try:
+        batch_vectorizer = artm.BatchVectorizer(data_path=data_path,
+                                                data_format='bow_uci',
+                                                collection_name='kos',
+                                                target_folder=batches_folder)
+
+        dictionary = artm.Dictionary()
+        dictionary.gather(data_path=batch_vectorizer.data_path)
+
+        model_reg = artm.ARTM(num_topics=num_topics, dictionary=dictionary, cache_theta=True, reuse_theta=True)
+        model = artm.ARTM(num_topics=num_topics, dictionary=dictionary, cache_theta=True, reuse_theta=True)
+ 
+        model_reg.num_document_passes = num_document_passes
+        model.num_document_passes = num_document_passes
+        
+        model_reg.scores.add(artm.TopTokensScore(name='TopTokensScore', num_tokens=num_tokens))
+        model.scores.add(artm.TopTokensScore(name='TopTokensScore', num_tokens=num_tokens))
+        
+        model_reg.fit_offline(batch_vectorizer=batch_vectorizer, num_collection_passes=num_collection_passes)
+        model.fit_offline(batch_vectorizer=batch_vectorizer, num_collection_passes=num_collection_passes)
+        model_reg.regularizers.add(artm.TopicSegmentationPtdwRegularizer(name='TopicSegmentation', window=window,\
+                                                                         threshold=threshold, background_topic_names=background_topics))
+        
+        ptdw = model.transform(batch_vectorizer=batch_vectorizer, theta_matrix_type='dense_ptdw')
+        ptdw_reg = model_reg.transform(batch_vectorizer=batch_vectorizer, theta_matrix_type='dense_ptdw')
+        
+        doc_ids = np.random.choice(np.arange(3430), size=500)  #choose some documents randomly
+        for doc_id in doc_ids:
+            doc_df = ptdw[ptdw.columns[doc_id]]
+            token_id = window + np.random.choice(np.arange(doc_df.shape[1] - 2 * window))  #choose the token randomly somewhere from the inner part of the document
+            
+            weights = []
+            def f(x):
+                weights.append(1 - (x[0] + x[1] + x[2]))
+                return x * (1 - (x[0] + x[1] + x[2]))
+            left_dist = doc_df.iloc[:, token_id - window : token_id].apply(f, axis=0).sum(axis=1) / sum(weights)
+            weights = []
+            right_dist = doc_df.iloc[:, token_id : token_id + window].apply(f, axis=0).sum(axis=1) / sum(weights)
+            
+            l = left_dist.argmax()
+            r = right_dist.argmax()
+            changes_topic = ((left_dist[l] - left_dist[r]) / 2 + (right_dist[r] - right_dist[l]) / 2 > threshold)
+            
+            if changes_topic:
+                assert r == ptdw_reg[ptdw_reg.columns[doc_id]].iloc[:, token_id].argmax()
+            else:
+                assert ptdw_reg[ptdw_reg.columns[doc_id]].iloc[:, token_id].argmax() == ptdw_reg[ptdw_reg.columns[doc_id]].iloc[:, token_id - 1].argmax()
+
+    finally:
+        shutil.rmtree(batches_folder)

--- a/src/artm/CMakeLists.txt
+++ b/src/artm/CMakeLists.txt
@@ -127,6 +127,8 @@ set(SRC_LIST
 	regularizer/topic_selection_theta.h
 	regularizer/biterms_phi.cc
 	regularizer/biterms_phi.h
+	regularizer/topic_segmentation_ptdw.cc
+	regularizer/topic_segmentation_ptdw.h
 	score/class_precision.cc
 	score/class_precision.h
 	score/items_processed.cc

--- a/src/artm/core/instance.cc
+++ b/src/artm/core/instance.cc
@@ -29,6 +29,7 @@
 #include "artm/regularizer/smooth_ptdw.h"
 #include "artm/regularizer/topic_selection_theta.h"
 #include "artm/regularizer/biterms_phi.h"
+#include "artm/regularizer/topic_segmentation_ptdw.h"
 
 #include "artm/score/items_processed.h"
 #include "artm/score/sparsity_theta.h"
@@ -260,6 +261,12 @@ void Instance::CreateOrReconfigureRegularizer(const RegularizerConfig& config) {
       CREATE_OR_RECONFIGURE_REGULARIZER(::artm::BitermsPhiConfig,
         ::artm::regularizer::BitermsPhi);
       break;
+    }
+
+    case artm::RegularizerType_TopicSegmentationPtdw: {
+        CREATE_OR_RECONFIGURE_REGULARIZER(::artm::TopicSegmentationPtdwConfig,
+                                        ::artm::regularizer::TopicSegmentationPtdw);
+        break;
     }
 
     default:

--- a/src/artm/core/processor.cc
+++ b/src/artm/core/processor.cc
@@ -538,8 +538,8 @@ InferPtdwAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch, 
 
         if (p_dw_val == 0) continue;
         const float Z = 1.0f / p_dw_val;
-        for (int k = 0; k < num_topics; ++k)
-          ptdw_ptr[k] *= Z;
+          for (int k = 0; k < num_topics; ++k)
+              ptdw_ptr[k] *= Z;
       }
 
       ptdw_agents.Apply(d, inner_iter, &local_ptdw);

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -82,6 +82,7 @@ enum RegularizerType {
   RegularizerType_SmoothPtdw = 7;
   RegularizerType_TopicSelectionTheta = 8;
   RegularizerType_BitermsPhi = 9;
+  RegularizerType_TopicSegmentationPtdw = 10;
   RegularizerType_Unknown = 9999;
 }
 
@@ -169,6 +170,13 @@ message BitermsPhiConfig {
   repeated string topic_name = 1;
   repeated string class_id = 2;
   optional string dictionary_name = 3;
+}
+
+// Represents a configuration of a Topic Segmentation regularizer
+message TopicSegmentationPtdwConfig {
+  repeated string background_topic_names = 1;
+  optional int32 window = 3 [default = 10];
+  optional double threshold = 4 [default = 0.5];
 }
 
 // Represents the transform functions

--- a/src/artm/regularizer/topic_segmentation_ptdw.cc
+++ b/src/artm/regularizer/topic_segmentation_ptdw.cc
@@ -1,0 +1,108 @@
+#include <vector>
+#include <algorithm>
+
+#include "glog/logging.h"
+#include "artm/core/protobuf_helpers.h"
+#include "artm/utility/blas.h"
+
+#include "artm/regularizer/topic_segmentation_ptdw.h"
+
+namespace artm {
+namespace regularizer {
+
+void TopicSegmentationPtdwAgent::Apply(int item_index, int inner_iter, ::artm::utility::DenseMatrix<float>* ptdw) const {
+    int local_token_size = ptdw->no_rows();
+    int num_topics = ptdw->no_columns();
+    std::vector<double> background_probability(local_token_size, 0.0);
+    // if background topics are given, count probability for each word to be background
+    if (config_.background_topic_names().size()) {
+        std::vector<bool> is_background_topic = core::is_member(args_.topic_name(), config_.background_topic_names());
+        for (int i = 0; i < local_token_size; ++i) {
+            const float* local_ptdw_ptr = &(*ptdw)(i, 0);  // NOLINT
+            for (int k = 0; k < num_topics; ++k) {
+                if (is_background_topic[k]) {
+                    background_probability[i] += local_ptdw_ptr[k];
+                }
+            }
+        }
+    }
+    
+    int h = config_.window();
+    double threshold_topic_change = config_.threshold();
+    ::artm::utility::DenseMatrix<float> copy_ptdw(*ptdw);
+    std::vector<double> left_distribution(num_topics, 0.0);
+    std::vector<double> right_distribution(num_topics, 0.0);
+    double left_weights = 0.0;
+    double right_weights = 0.0;
+    int l_topic, r_topic;  //topic ids on which maximum of the distribution is reached
+    bool changes_topic = false;
+    int main_topic = std::distance(&(*ptdw)(0, 0), std::max_element(&(*ptdw)(0, 0), &(*ptdw)(0, num_topics)));  //NOLINT
+    for (int k = 0; k < num_topics; ++k) {
+        if (k == main_topic) {
+            (*ptdw)(0, k) = 1;
+        }
+        else {
+            (*ptdw)(0, k) = 0;
+        }
+    }
+    for (int i = 0; i < h && i < local_token_size; ++i) {
+        for (int k = 0; k < num_topics; ++k) {
+            right_distribution[k] += copy_ptdw(i, k) * (1 - background_probability[i]);
+        }
+        right_weights += 1 - background_probability[i];
+    }
+    for (int i = 1; i < local_token_size; ++i) {
+        for (int k = 0; k < num_topics; ++k) {
+            left_distribution[k] += copy_ptdw(i - 1, k) * (1 - background_probability[i - 1]);
+            right_distribution[k] -= copy_ptdw(i - 1, k) * (1 - background_probability[i - 1]);
+        }
+        left_weights += 1 - background_probability[i - 1];
+        right_weights -= 1 - background_probability[i - 1];
+        if (i <= local_token_size - h) {
+            for (int k = 0; k < num_topics; ++k) {
+                right_distribution[k] += copy_ptdw(i + h - 1, k) * (1 - background_probability[i + h - 1]);
+            }
+            right_weights += 1 - background_probability[i + h - 1];
+        }
+        if (i > h) {
+            for (int k = 0; k < num_topics; ++k) {
+                left_distribution[k] -= copy_ptdw(i - h - 1, k) * (1 - background_probability[i - h - 1]);
+            }
+            left_weights -= 1 - background_probability[i - h - 1];
+        }
+        l_topic = std::distance(left_distribution.begin(), std::max_element(left_distribution.begin(), left_distribution.end()));
+        r_topic = std::distance(right_distribution.begin(), std::max_element(right_distribution.begin(), right_distribution.end()));
+        changes_topic = ((left_distribution[l_topic]/left_weights - right_distribution[l_topic]/right_weights) / 2 + (right_distribution[r_topic]/right_weights - left_distribution[r_topic]/left_weights) / 2 > threshold_topic_change);
+        if (changes_topic) {
+            main_topic = r_topic;
+        }
+        for (int k = 0; k < num_topics; ++k) {
+            if (k == main_topic) {
+                (*ptdw)(i, k) = 1;
+            }
+            else {
+                (*ptdw)(i, k) = 0;
+            }
+        }
+    }
+}
+    
+std::shared_ptr<RegularizePtdwAgent>
+TopicSegmentationPtdw::CreateRegularizePtdwAgent(const Batch& batch, const ProcessBatchesArgs& args, double tau) {
+    TopicSegmentationPtdwAgent* agent = new TopicSegmentationPtdwAgent(config_, args, tau);
+    std::shared_ptr<RegularizePtdwAgent> retval(agent);
+    return retval;
+}
+    
+bool TopicSegmentationPtdw::Reconfigure(const RegularizerConfig& config) {
+    std::string config_blob = config.config();
+    TopicSegmentationPtdwConfig regularizer_config;
+    if (!regularizer_config.ParseFromString(config_blob)) {
+        BOOST_THROW_EXCEPTION(::artm::core::CorruptedMessageException("Unable to parse TopicSegmentationPtdwConfig from RegularizerConfig.config"));
+    }
+    config_.CopyFrom(regularizer_config);
+    return true;
+}
+
+} //namespace regularizer
+} //namespace artm

--- a/src/artm/regularizer/topic_segmentation_ptdw.cc
+++ b/src/artm/regularizer/topic_segmentation_ptdw.cc
@@ -40,8 +40,7 @@ void TopicSegmentationPtdwAgent::Apply(int item_index, int inner_iter, ::artm::u
     for (int k = 0; k < num_topics; ++k) {
         if (k == main_topic) {
             (*ptdw)(0, k) = 1;
-        }
-        else {
+        } else {
             (*ptdw)(0, k) = 0;
         }
     }
@@ -70,9 +69,17 @@ void TopicSegmentationPtdwAgent::Apply(int item_index, int inner_iter, ::artm::u
             }
             left_weights -= 1 - background_probability[i - h - 1];
         }
-        l_topic = std::distance(left_distribution.begin(), std::max_element(left_distribution.begin(), left_distribution.end()));
-        r_topic = std::distance(right_distribution.begin(), std::max_element(right_distribution.begin(), right_distribution.end()));
-        changes_topic = ((left_distribution[l_topic]/left_weights - right_distribution[l_topic]/right_weights) / 2 + (right_distribution[r_topic]/right_weights - left_distribution[r_topic]/left_weights) / 2 > threshold_topic_change);
+        std::vector<double>::iterator lb = left_distribution.begin();
+        std::vector<double>::iterator le = left_distribution.end();
+        std::vector<double>::iterator rb = right_distribution.begin();
+        std::vector<double>::iterator re = right_distribution.end();
+        l_topic = std::distance(lb, std::max_element(lb, le));
+        r_topic = std::distance(rb, std::max_element(rb, re));
+        double ll = left_distribution[l_topic];
+        double rl = right_distribution[l_topic];
+        double rr = right_distribution[r_topic];
+        double lr = left_distribution[r_topic];
+        changes_topic = ((ll/left_weights-rl/right_weights)/2+(rr/right_weights-lr/left_weights)/2>threshold_topic_change);
         if (changes_topic) {
             main_topic = r_topic;
         }

--- a/src/artm/regularizer/topic_segmentation_ptdw.h
+++ b/src/artm/regularizer/topic_segmentation_ptdw.h
@@ -1,0 +1,43 @@
+#ifndef SRC_ARTM_REGULARIZER_TOPIC_SEGMENTATION_PTDW_H_
+#define SRC_ARTM_REGULARIZER_TOPIC_SEGMENTATION_PTDW_H_
+
+#include <string>
+#include <vector>
+
+#include "artm/regularizer_interface.h"
+
+namespace artm {
+namespace regularizer {
+
+class TopicSegmentationPtdwAgent : public RegularizePtdwAgent {
+private:
+    friend class TopicSegmentationPtdw;
+    TopicSegmentationPtdwConfig config_;
+    ProcessBatchesArgs args_;
+    double tau_;
+
+public:
+    TopicSegmentationPtdwAgent(const TopicSegmentationPtdwConfig& config, const ProcessBatchesArgs& args, double tau)
+      : config_(config), args_(args), tau_(tau) {}
+
+    virtual void Apply(int item_index, int inner_iter, ::artm::utility::DenseMatrix<float>* ptdw) const;
+};
+
+class TopicSegmentationPtdw : public RegularizerInterface {
+public:
+    explicit TopicSegmentationPtdw(const TopicSegmentationPtdwConfig& config)
+    : config_(config) {}
+
+    virtual std::shared_ptr<RegularizePtdwAgent>
+    CreateRegularizePtdwAgent(const Batch& batch, const ProcessBatchesArgs& args, double tau);
+
+    virtual bool Reconfigure(const RegularizerConfig& config);
+
+private:
+    TopicSegmentationPtdwConfig config_;
+};
+
+}  // namespace regularizer
+}  // namespace artm
+
+#endif  // SRC_ARTM_REGULARIZER_TOPIC_SEGMENTATION_PTDW_H_

--- a/src/artm_tests/CMakeLists.txt
+++ b/src/artm_tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRC_LIST
 	template_manager_test.cc
 	test_mother.cc
 	thread_safe_holder_test.cc
+	topic_seg_test.cc
 	${3RD_PARTY_DIR}/gtest/fused-src/gtest/gtest_main.cc
 	${3RD_PARTY_DIR}/gtest/fused-src/gtest/gtest-all.cc
 	${CMAKE_SOURCE_DIR}/src/artm/cpp_interface.cc

--- a/src/artm_tests/topic_seg_test.cc
+++ b/src/artm_tests/topic_seg_test.cc
@@ -32,25 +32,11 @@ TEST(Regularizer, TopicSegmentationPtdw) {
     artm::Item* item = batch.add_item();
     item->set_id(0);
     item->set_title("doc0");
-    item->add_token_id(0);
-    item->add_token_weight(1.0);
-    item->add_token_id(1);
-    item->add_token_weight(1.0);
-    item->add_token_id(2);
-    item->add_token_weight(1.0);
-    item->add_token_id(0);
-    item->add_token_weight(1.0);
-    item->add_token_id(3);
-    item->add_token_weight(1.0);
-    item->add_token_id(2);
-    item->add_token_weight(1.0);
-    item->add_token_id(1);
-    item->add_token_weight(1.0);
-    item->add_token_id(4);
-    item->add_token_weight(1.0);
-    item->add_token_id(5);
-    item->add_token_weight(1.0);
-    
+    std::vector<int> token_sequence = {0, 1, 2, 0, 3, 2, 1, 4, 5};
+    for (auto e : token_sequence) {
+        item->add_token_id(e);
+        item->add_token_weight(1.0);
+    }
     
     std::vector<std::shared_ptr< ::artm::Batch>> batches;
     batches.push_back(std::make_shared< ::artm::Batch>(batch));

--- a/src/artm_tests/topic_seg_test.cc
+++ b/src/artm_tests/topic_seg_test.cc
@@ -1,0 +1,123 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "artm/cpp_interface.h"
+#include "artm/core/common.h"
+#include "artm/core/instance.h"
+
+#include "artm_tests/test_mother.h"
+#include "artm_tests/api.h"
+
+TEST(Regularizer, TopicSegmentationPtdw) {
+    int n_topics = 5;
+    int n_background_topics = 2;
+    ::artm::MasterModelConfig master_config = ::artm::test::TestMother::GenerateMasterModelConfig(n_topics);
+    master_config.set_cache_theta(true);
+    master_config.set_num_document_passes(0);
+    
+    artm::MasterModel master_model_1(master_config);
+    artm::MasterModel master_model_2(master_config);
+    ::artm::test::Api api_1(master_model_1);
+    ::artm::test::Api api_2(master_model_2);
+    
+    ::artm::Batch batch;
+    batch.set_id(artm::test::Helpers::getUniqueString());
+    batch.add_token("aaaa0");  //0
+    batch.add_token("bbbb1");  //1
+    batch.add_token("cccc2");  //2
+    batch.add_token("dddd3");  //3
+    batch.add_token("eeee4");  //4
+    batch.add_token("ffff5");  //5
+    artm::Item* item = batch.add_item();
+    item->set_id(0);
+    item->set_title("doc0");
+    item->add_token_id(0);
+    item->add_token_weight(1.0);
+    item->add_token_id(1);
+    item->add_token_weight(1.0);
+    item->add_token_id(2);
+    item->add_token_weight(1.0);
+    item->add_token_id(0);
+    item->add_token_weight(1.0);
+    item->add_token_id(3);
+    item->add_token_weight(1.0);
+    item->add_token_id(2);
+    item->add_token_weight(1.0);
+    item->add_token_id(1);
+    item->add_token_weight(1.0);
+    item->add_token_id(4);
+    item->add_token_weight(1.0);
+    item->add_token_id(5);
+    item->add_token_weight(1.0);
+    
+    
+    std::vector<std::shared_ptr< ::artm::Batch>> batches;
+    batches.push_back(std::make_shared< ::artm::Batch>(batch));
+    auto offline_args_1 = api_1.Initialize(batches);
+    auto offline_args_2 = api_2.Initialize(batches);
+    
+    for (int iter = 0; iter < 4; ++iter) {
+        master_model_1.FitOfflineModel(offline_args_1);
+        master_model_2.FitOfflineModel(offline_args_2);
+    }
+    
+    ::artm::RegularizerConfig* regularizer_config = master_config.add_regularizer_config();
+    regularizer_config->set_name("TopicSegmentationPtdwRegularizer");
+    regularizer_config->set_type(::artm::RegularizerType_TopicSegmentationPtdw);
+    regularizer_config->set_tau(0.0);
+    ::artm::TopicSegmentationPtdwConfig internal_config;
+    
+    internal_config.set_window(3);
+    internal_config.set_threshold(0.2);
+    for (int i = 0; i < n_background_topics; ++i) {
+        internal_config.add_background_topic_names("Topic" + boost::lexical_cast<std::string>(i));
+    }
+    regularizer_config->set_config(internal_config.SerializeAsString());
+
+    master_model_1.Reconfigure(master_config);
+    
+    ::artm::TransformMasterModelArgs transform_args;
+    transform_args.set_theta_matrix_type(::artm::ThetaMatrixType_DensePtdw);
+    transform_args.add_batch_filename(batch.id());
+    ::artm::ThetaMatrix ptdw_1 = master_model_1.Transform(transform_args);
+    ::artm::ThetaMatrix ptdw_2 = master_model_2.Transform(transform_args);
+    
+    std::cout << "Ptdw_1 (reg):\n";
+    for (int i = 0; i < ptdw_1.item_weights_size(); ++i) {
+        std::cout << "token" << i << " profile: ";
+        for (int k = 0; k < ptdw_1.item_weights(i).value_size(); ++k) {
+            std::cout << ptdw_1.item_weights(i).value(k) << ", ";
+        }
+        std::cout << "\n";
+    }
+    std::cout << "Ptdw_2 (no reg):\n";
+    for (int i = 0; i < ptdw_2.item_weights_size(); ++i) {
+        std::cout << "token" << i << " profile: ";
+        for (int k = 0; k < ptdw_2.item_weights(i).value_size(); ++k) {
+            std::cout << ptdw_2.item_weights(i).value(k) << ", ";
+        }
+        std::cout << "\n";
+    }
+    
+    for (int i = 0; i < 7; ++i) {
+        for (int k = 0; k < 5; ++k) {
+            if (k == 0) {
+                ASSERT_EQ(ptdw_1.item_weights(i).value(k), 1.0);
+            }
+            else {
+                ASSERT_EQ(ptdw_1.item_weights(i).value(k), 0.0);
+            }
+        }
+    }
+    for (int i = 7; i < 9; ++i) {
+        for (int k = 0; k < 5; ++k) {
+            if (k < 4) {
+                ASSERT_EQ(ptdw_1.item_weights(i).value(k), 0.0);
+            }
+            else {
+                ASSERT_EQ(ptdw_1.item_weights(i).value(k), 1.0);
+            }
+        }
+    }
+}

--- a/utils/cpplint_files.txt
+++ b/utils/cpplint_files.txt
@@ -26,6 +26,7 @@ src/artm/regularizer/improve_coherence_phi.cc
 src/artm/regularizer/smooth_ptdw.cc
 src/artm/regularizer/topic_selection_theta.cc
 src/artm/regularizer/biterms_phi.cc
+src/artm/regularizer/topic_segmentation.cc
 src/artm/score/class_precision.cc
 src/artm/score/peak_memory.cc
 src/artm/score/perplexity.cc
@@ -91,6 +92,7 @@ src/artm/regularizer/improve_coherence_phi.h
 src/artm/regularizer/smooth_ptdw.h
 src/artm/regularizer/topic_selection_theta.h
 src/artm/regularizer/biterms_phi.h
+src/artm/regularizer/topic_segmentation.h
 src/artm/score/class_precision.h
 src/artm/score/peak_memory.h
 src/artm/score/perplexity.h


### PR DESCRIPTION
Topic Segmentation Ptdw regularizer smoothes tokens' topic profiles in a document based on what topic segment they belong to. Topic segments are determined by finding tokens that have a comparatively large probability to change the topic in a document.