### PR TITLE
batch_utils.py must not use os.path.abspath

### DIFF
--- a/python/artm/batches_utils.py
+++ b/python/artm/batches_utils.py
@@ -23,7 +23,7 @@ GLOB_EPS = 1e-37
 
 class Batch(object):
     def __init__(self, filename):
-        self._filename = os.path.abspath(filename)
+        self._filename = filename
 
     def __repr__(self):
         return 'Batch({0})'.format(self._filename)


### PR DESCRIPTION
This is up to user to decide whether to use abspath or not.
One issue is that C++ core of BigARTM only supports ascii-characters in path strings.