### PR TITLE
Update dictionary.cc

### DIFF
--- a/src/artm/core/dictionary.cc
+++ b/src/artm/core/dictionary.cc
@@ -122,7 +122,7 @@ const DictionaryEntry* Dictionary::entry(const Token& token) const {
 }
 
 const DictionaryEntry* Dictionary::entry(int index) const {
-  if (index < 0 || index >= entries_.size()) return nullptr;
+  if (index < 0 || index >= (ssize_t) entries_.size()) return nullptr;
   return &entries_[index];
 }
 


### PR DESCRIPTION
There was one warning because of comarison between signed and unsigned.