### PR TITLE
add simple wrapper for online processing of batches in memory

### DIFF
--- a/python/artm/artm_model.py
+++ b/python/artm/artm_model.py
@@ -484,7 +484,10 @@ class ARTM(object):
         if not self._initialized:
             raise RuntimeError('The model was not initialized. Use initialize() method')
 
-        batches_list = [batch.filename for batch in batch_vectorizer.batches_list]
+        def _func(batch):
+            return batch if batch_vectorizer.process_in_memory else batch.filename
+
+        batches_list = [_func(batch) for batch in batch_vectorizer.batches_list]
         # outer cycle is needed because of TopicSelectionThetaRegularizer
         # and current ScoreTracker implementation
 
@@ -546,7 +549,10 @@ class ARTM(object):
         if not self._initialized:
             raise RuntimeError('The model was not initialized. Use initialize() method')
 
-        batches_list = [batch.filename for batch in batch_vectorizer.batches_list]
+        def _func(batch):
+            return batch if batch_vectorizer.process_in_memory else batch.filename
+
+        batches_list = [_func(batch) for batch in batch_vectorizer.batches_list]
 
         update_after_final, apply_weight_final, decay_weight_final = [], [], []
         if (update_after is None) or (apply_weight is None) or (decay_weight is None):

--- a/python/artm/batches_utils.py
+++ b/python/artm/batches_utils.py
@@ -75,11 +75,14 @@ class BatchVectorizer(object):
         :type class_ids: list of str or str
         :param bool process_in_memory: process batches from disk or from RAM \
                                        (only if data_format == Batches), model parameter is required
-        :param artm.ARTM model: ARTM instance that will use this vectorizer, is need only if\
-                                process_in_memory == True
+        :param artm.ARTM model: ARTM instance that will use this vectorizer, is required when\
+                                process_in_memory == True. Will be ignored in other cases
         """
         self._remove_batches = False
         self._process_in_memory = process_in_memory and data_format == 'batches' and model is not None
+        if self._process_in_memory != process_in_memory:
+            raise IOError("Correct configuration: process_memory == True + data_format == 'batches' + model != None")
+
         self._model = model
         if data_format == 'bow_n_wd' or data_format == 'vowpal_wabbit' or data_format == 'bow_uci':
             self._remove_batches = target_folder is None
@@ -123,7 +126,7 @@ class BatchVectorizer(object):
 
         if self._process_in_memory:
             for batch in self._batches_list:
-                model.master.remove_batch(batch)
+                self._model.master.remove_batch(batch)
         self._process_in_memory = False
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/python/artm/batches_utils.py
+++ b/python/artm/batches_utils.py
@@ -38,7 +38,8 @@ class Batch(object):
 class BatchVectorizer(object):
     def __init__(self, batches=None, collection_name=None, data_path='', data_format='batches',
                  target_folder=None, batch_size=1000, batch_name_type='code', data_weight=1.0,
-                 n_wd=None, vocabulary=None, gather_dictionary=True, class_ids=None):
+                 n_wd=None, vocabulary=None, gather_dictionary=True, class_ids=None,
+                 process_in_memory=False, model=None):
         """
         :param str collection_name: the name of text collection (required if data_format == 'bow_uci')
         :param str data_path: 1) if data_format == 'bow_uci' => folder containing\
@@ -54,8 +55,10 @@ class BatchVectorizer(object):
         :param int batch_size: number of documents to be stored in each batch
         :param str target_folder: full path to folder for future batches storing;\
                                   if not set, no batches will be produced for further work
-        :param batches: list with non-full file names of batches (necessary parameters are\
-                              batches + data_path + data_fromat=='batches' in this case)
+        :param batches: if process_in_memory == False -> list with non-full file names of\
+                              batches (necessary parameters are batches + data_path +\
+                              data_fromat=='batches' in this case)\
+                        else -> list of batches (messages.Batch objects), loaded in memory
         :type batches: list of str
         :param str batch_name_type: name batches in natural order ('code') or using random guids (guid)
         :param float data_weight: weight for a group of batches from data_path;\
@@ -70,8 +73,14 @@ class BatchVectorizer(object):
                                        and if data_weight is list - automatically set to False
         :param class_ids: list of class_ids or single class_id to parse and include in batches
         :type class_ids: list of str or str
+        :param bool process_in_memory: process batches from disk or from RAM \
+                                       (only if data_format == Batches), model parameter is required
+        :param artm.ARTM model: ARTM instance that will use this vectorizer, is need only if\
+                                process_in_memory == True
         """
         self._remove_batches = False
+        self._process_in_memory = process_in_memory and data_format == 'batches' and model is not None
+        self._model = model
         if data_format == 'bow_n_wd' or data_format == 'vowpal_wabbit' or data_format == 'bow_uci':
             self._remove_batches = target_folder is None
         elif data_format == 'batches':
@@ -111,6 +120,11 @@ class BatchVectorizer(object):
         if self._remove_batches:
             shutil.rmtree(self._target_folder)
         self._remove_batches = False
+
+        if self._process_in_memory:
+            for batch in self._batches_list:
+                model.master.remove_batch(batch)
+        self._process_in_memory = False
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.__dispose()
@@ -180,6 +194,11 @@ class BatchVectorizer(object):
                 self._dictionary.gather(data_path=target_f)
 
     def _parse_batches(self, data_weight=None, batches=None):
+        if self._process_in_memory:
+            self._model.master.import_batches(batches)
+            self._batches_list = [batch.id for batch in batches]
+            return
+
         data_paths, data_weights, target_folders = self._populate_data(data_weight, True)
         for (data_p, data_w, target_f) in zip(data_paths, data_weights, target_folders):
             if batches is None:
@@ -292,6 +311,13 @@ class BatchVectorizer(object):
         :return: Dictionary object, if parameter gather_dictionary was True, else None
         """
         return self._dictionary
+
+    @property
+    def process_in_memory(self):
+        """
+        :return: if Vectorizer uses processing of batches in core memory
+        """
+        return self._process_in_memory
 
     def __repr__(self):
         return 'artm.BatchVectorizer(data_path="{0}", num_batches={1})'.format(

--- a/python/artm/master_component.py
+++ b/python/artm/master_component.py
@@ -873,3 +873,22 @@ class MasterComponent(object):
         else:
             self._lib.ArtmRequestTransformMasterModel(self.master_id, args)
             return None, None
+
+    def import_batches(self, batches=None):
+        """
+        :param list batches: list of BigARTM batches loaded into RAM
+        """
+        args = messages.ImportBatchesArgs()
+        if batches is not None:
+            args.ClearField('batch')
+            for batch in batches:
+                batch_ref = args.batch.add()
+                batch_ref.CopyFrom(batch)
+        self._lib.ArtmImportBatches(self.master_id, args)
+
+    def remove_batch(self, batch_id=None):
+        """
+        :param str batches: id of batch, loaded in RAM
+        """
+        if batch_id is not None:
+            self._lib.ArtmDisposeBatch(self.master_id, batch_id)

--- a/python/tests/artm/test_batches_utils.py
+++ b/python/tests/artm/test_batches_utils.py
@@ -105,6 +105,8 @@ def test_func():
                     
             assert counter == n_wd_num_tokens + 2
 
+            # ToDo: we're not able to compare lists directly in Python 3 because of
+            #       unknown reasons. This should be fixed
             assert set(tokens) == set(n_wd_tokens_list)
             assert set(token_tf) == set(n_wd_token_tf_list)
             assert set(token_df) == set(n_wd_token_df_list)

--- a/python/tests/artm/test_batches_utils.py
+++ b/python/tests/artm/test_batches_utils.py
@@ -34,8 +34,31 @@ def test_func():
         assert len(glob.glob(os.path.join(batches_folder, '*.batch'))) == num_uci_batches
         assert len(uci_batch_vectorizer.batches_list) == num_uci_batches
 
+
+        dictionary = uci_batch_vectorizer.dictionary
+        model = artm.ARTM(num_topics=10, dictionary=dictionary)
+        model.scores.add(artm.PerplexityScore(name='perplexity', dictionary=dictionary))
+
+        batches = []
+        for b in uci_batch_vectorizer.batches_list:
+            batch = artm.messages.Batch()
+            with open(b.filename, 'rb') as fin:
+                batch.ParseFromString(fin.read())
+                batches.append(batch)
+
+        in_memory_batch_vectorizer = artm.BatchVectorizer(data_format='batches',
+                                                          process_in_memory=True,
+                                                          model=model,
+                                                          batches=batches)
+
+        model.fit_offline(num_collection_passes=10, batch_vectorizer=in_memory_batch_vectorizer)
+        model.fit_online(update_every=1, batch_vectorizer=in_memory_batch_vectorizer)
+        assert len(model.score_tracker['perplexity'].value) == 14
+
+
         batch_batch_vectorizer = artm.BatchVectorizer(data_path=batches_folder, data_format='batches')
         assert len(batch_batch_vectorizer.batches_list) == num_uci_batches
+
 
         uci_batch_vectorizer = artm.BatchVectorizer(data_path=data_path,
                                                     data_format='bow_uci',
@@ -47,6 +70,7 @@ def test_func():
 
         uci_batch_vectorizer.__del__()
         assert not os.path.isdir(temp_target_folder)
+
 
         n_wd_batch_vectorizer = artm.BatchVectorizer(data_path=data_path,
                                                      data_format='bow_n_wd',
@@ -81,11 +105,9 @@ def test_func():
                     
             assert counter == n_wd_num_tokens + 2
 
-            # The following tests are commented out because they don't pass with Python 3
-            # Please, investigate.
-            # assert tokens == n_wd_tokens_list
-            # assert token_tf == n_wd_token_tf_list
-            # assert token_df == n_wd_token_df_list
+            assert set(tokens) == set(n_wd_tokens_list)
+            assert set(token_tf) == set(n_wd_token_tf_list)
+            assert set(token_df) == set(n_wd_token_df_list)
 
         n_wd_batch_vectorizer.__del__()
         assert not os.path.isdir(temp_target_folder)


### PR DESCRIPTION
I don't see any reasonable way of using this oppurtunity besides multiply iteration over given set of batches. So I don't think it's a good way to parse vw file into the Python memory and than pass batches to C++. The good case (as I think) is the following:
1) create batches as usual
2) pass them into the C++ memory using BV
3) iterate over them
4) remove them by deleting BV

It is a discussable thing.