### PR TITLE
Fix Appveyor problems with slashes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ before_build:
   - cmd: cd build
   - cmd: if "%platform%"=="Win32" set CMAKE_GENERATOR_NAME=Visual Studio 14 2015
   - cmd: if "%platform%"=="x64"   set CMAKE_GENERATOR_NAME=Visual Studio 14 2015 Win64
-  - cmd: cmake -DPYTHON=python -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%configuration% -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" ..
+  - cmd: cmake -DPYTHON=python -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%configuration% -DBOOST_ROOT:PATH="%BOOST_ROOT%" -DBOOST_LIBRARYDIR:PATH="%BOOST_LIBRARYDIR%" ..
   - cmd: cd %BIGARTM_UNITTEST_DATA%
   - ps: Start-FileDownload 'https://s3-eu-west-1.amazonaws.com/artm/docword.kos.txt'
   - ps: Start-FileDownload 'https://s3-eu-west-1.amazonaws.com/artm/vocab.kos.txt'


### PR DESCRIPTION
We had Appveyor build problems at least for week.
In particular, there were errors connected with improper slashes
in path naming while finding Boost library (Boost expects Unix-way /,
found Windows-specific \).
The solution has found in interesting discussion on CMake issue-tracker
(https://gitlab.kitware.com/cmake/cmake/issues/16670):
specify type of Boost variable provided when invoking `cmake` command.