### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ src/Win32/*
 *.log.ERROR.*
 *.batch
 
+*\#*\#*
+
 # Binaries
 /src/artm/unittests/
 /src/cpp_client/cpp_client

--- a/python/artm/master_component.py
+++ b/python/artm/master_component.py
@@ -513,8 +513,8 @@ class MasterComponent(object):
         :param regularizer_name: list of names of Phi regularizers to use
         :type regularizer_name: list of str
         :param regularizer_tau: list of tau coefficients for Phi regularizers
-        :type regularizer_tau: list of double
-        :type regularizer_tau: list of double
+        :type regularizer_tau: list of floats
+        :type regularizer_tau: list of floats
         """
         args = messages.RegularizeModelArgs(pwt_source_name=pwt,
                                             nwt_source_name=nwt,

--- a/python/artm/regularizers.py
+++ b/python/artm/regularizers.py
@@ -45,7 +45,7 @@ class KlFunctionInfo(object):
     def __init__(self, function_type='log', power_value=2.0):
         """
         :param str function_type: the type of function, 'log' (logarithm) or 'pol' (polynomial)
-        :param float power_value: the double power of polynomial, ignored if type = 'log'
+        :param float power_value: the float power of polynomial, ignored if type = 'log'
         """
         if function_type not in ['log', 'pol']:
             raise ValueError('Function type can be only "log" or "pol"')
@@ -390,16 +390,16 @@ class SmoothSparseThetaRegularizer(BaseRegularizerTheta):
                            User should guarantee the existence and correctness of\
                            document titles in batches (e.g. in src files with data, like WV).
         :type doc_titles: list of strings
-        :param doc_topic_coef: Two cases: 1) list of doubles with length equal to num of topics.\
+        :param doc_topic_coef: Two cases: 1) list of floats with length equal to num of topics.\
                                Means additional multiplier in M-step formula besides alpha and\
                                tau, unique for each topic, but general for all processing documents.\
-                               2) list of lists of doubles with outer list length equal to length\
+                               2) list of lists of floats with outer list length equal to length\
                                of doc_titles, and each inner list length equal to num of topics.\
                                Means case 1 with unique list of additional multipliers for each\
                                document from doc_titles. Other documents will not be regularized\
                                according to description of doc_titles parameter.\
                                Note, that doc_topic_coef and topic_names are both using.
-        :type doc_topic_coef: list of doubles or list of lists of doubles
+        :type doc_topic_coef: list of floats or list of lists of floats
         :param config: the low-level config of this regularizer
         :type config: protobuf object
         """

--- a/src/artm/c_interface.cc
+++ b/src/artm/c_interface.cc
@@ -63,28 +63,53 @@ static void set_last_error(const std::string& error) {
 static void EnableLogging(artm::ConfigureLoggingArgs* args) {
   static bool logging_enabled = false;
 
-  if (logging_enabled && args != nullptr && args->has_log_dir() && (FLAGS_log_dir != args->log_dir()))
+  if (logging_enabled && args != nullptr && args->has_log_dir() && (FLAGS_log_dir != args->log_dir())) {
     BOOST_THROW_EXCEPTION(::artm::core::InvalidOperation(
       "Logging directory can't be change after the logging started."));
-  if (!logging_enabled && args != nullptr && args->has_log_dir())
-    if (!boost::filesystem::exists(args->log_dir()) || !boost::filesystem::is_directory(args->log_dir()))
+  }
+  if (!logging_enabled && args != nullptr && args->has_log_dir()) {
+    if (!boost::filesystem::exists(args->log_dir()) || !boost::filesystem::is_directory(args->log_dir())) {
       BOOST_THROW_EXCEPTION(::artm::core::InvalidOperation(
         "Can not enable logging to " + args->log_dir() + ", check that the folder exist"));
+    }
+  }
 
   // Setting all other flags except log_dir
   if (args != nullptr) {
-    if (args->has_minloglevel()) FLAGS_minloglevel = args->minloglevel();
-    if (args->has_stderrthreshold()) FLAGS_stderrthreshold = args->stderrthreshold();
-    if (args->has_logtostderr()) FLAGS_logtostderr = args->logtostderr();
+    if (args->has_minloglevel()) {
+      FLAGS_minloglevel = args->minloglevel();
+    }
 
-    if (args->has_colorlogtostderr()) FLAGS_colorlogtostderr = args->colorlogtostderr();
-    if (args->has_alsologtostderr()) FLAGS_alsologtostderr = args->alsologtostderr();
+    if (args->has_stderrthreshold()) {
+      FLAGS_stderrthreshold = args->stderrthreshold();
+    }
 
-    if (args->has_logbufsecs()) FLAGS_logbufsecs = args->logbufsecs();
-    if (args->has_logbuflevel()) FLAGS_logbuflevel = args->logbuflevel();
+    if (args->has_logtostderr()) {
+      FLAGS_logtostderr = args->logtostderr();
+    }
 
-    if (args->has_max_log_size()) FLAGS_max_log_size = args->max_log_size();
-    if (args->has_stop_logging_if_full_disk()) FLAGS_stop_logging_if_full_disk = args->stop_logging_if_full_disk();
+    if (args->has_colorlogtostderr()) {
+      FLAGS_colorlogtostderr = args->colorlogtostderr();
+    }
+
+    if (args->has_alsologtostderr()) {
+      FLAGS_alsologtostderr = args->alsologtostderr();
+    }
+
+    if (args->has_logbufsecs()) {
+      FLAGS_logbufsecs = args->logbufsecs();
+    }
+
+    if (args->has_logbuflevel()) {
+      FLAGS_logbuflevel = args->logbuflevel();
+    }
+
+    if (args->has_max_log_size()) {
+      FLAGS_max_log_size = args->max_log_size();
+    }
+    if (args->has_stop_logging_if_full_disk()) {
+      FLAGS_stop_logging_if_full_disk = args->stop_logging_if_full_disk();
+    }
 
     // ::google::SetVLOGLevel() is not supported in non-gcc compilers
     // https://groups.google.com/forum/#!topic/google-glog/f8D7qpXLWXw
@@ -277,14 +302,16 @@ int64_t ArtmAwaitOperation(int operation_id, int64_t length, const char* await_o
     const int timeout = args.timeout_milliseconds();
     auto time_start = boost::posix_time::microsec_clock::local_time();
     for (;;) {
-      if (batch_manager->IsEverythingProcessed())
+      if (batch_manager->IsEverythingProcessed()) {
         return ARTM_SUCCESS;
+      }
 
       boost::this_thread::sleep(boost::posix_time::milliseconds(::artm::core::kIdleLoopFrequency));
       auto time_end = boost::posix_time::microsec_clock::local_time();
       if (timeout >= 0) {
-        if ((time_end - time_start).total_milliseconds() >= timeout)
+        if ((time_end - time_start).total_milliseconds() >= timeout) {
           break;
+        }
       }
     }
 
@@ -369,10 +396,11 @@ int64_t ArtmExecute(int master_id, int64_t length, const char* args_blob, const 
     ArgsT args;
     ParseFromArray(args_blob, length, &args);
 
-    if (name != nullptr)
+    if (name != nullptr) {
       args.set_name(name);
-    else
+    } else {
       args.clear_name();
+    }
 
     ::artm::core::FixAndValidateMessage(&args, /* throw_error =*/ true);
     std::string description = ::artm::core::DescribeMessage(args);

--- a/src/artm/c_interface.h
+++ b/src/artm/c_interface.h
@@ -4,8 +4,7 @@
 // All methods must be inside "extern "C"" scope. All complex data structures should be passed in
 // as Google Protobuf Messages, defined in messages.proto.
 
-#ifndef SRC_ARTM_C_INTERFACE_H_
-#define SRC_ARTM_C_INTERFACE_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -104,5 +103,3 @@ extern "C" {
   DLL_PUBLIC int64_t ArtmSetProtobufMessageFormatToBinary();
   DLL_PUBLIC int64_t ArtmProtobufMessageFormatIsJson();
 }
-
-#endif  // SRC_ARTM_C_INTERFACE_H_

--- a/src/artm/core/batch_manager.cc
+++ b/src/artm/core/batch_manager.cc
@@ -7,7 +7,7 @@
 namespace artm {
 namespace core {
 
-BatchManager::BatchManager() : lock_(), in_progress_() {}
+BatchManager::BatchManager() : lock_(), in_progress_() { }
 
 void BatchManager::Add(const boost::uuids::uuid& task_id) {
   boost::lock_guard<boost::mutex> guard(lock_);

--- a/src/artm/core/batch_manager.h
+++ b/src/artm/core/batch_manager.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_BATCH_MANAGER_H_
-#define SRC_ARTM_CORE_BATCH_MANAGER_H_
+#pragma once
 
 #include <set>
 #include <string>
@@ -40,5 +39,3 @@ class BatchManager : boost::noncopyable {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_BATCH_MANAGER_H_

--- a/src/artm/core/cache_manager.cc
+++ b/src/artm/core/cache_manager.cc
@@ -140,7 +140,7 @@ static bool PopulateThetaMatrixFromCacheEntry(const ThetaMatrix& cache,
         // dense output -- dense cache
         for (int topic_index : topics_to_use) {
           theta_vec->add_value(item_theta.value(topic_index));
-	}
+        }
       }
     } else {
       ::artm::IntArray* sparse_topic_indices = theta_matrix->add_topic_indices();

--- a/src/artm/core/cache_manager.cc
+++ b/src/artm/core/cache_manager.cc
@@ -18,17 +18,21 @@ namespace artm {
 namespace core {
 
 ThetaCacheEntry::ThetaCacheEntry()
-    : theta_matrix_(std::make_shared<ThetaMatrix>()), filename_() {}
+    : theta_matrix_(std::make_shared<ThetaMatrix>())
+    , filename_() { }
 
 ThetaCacheEntry::~ThetaCacheEntry() {
   if (!filename_.empty()) {
     try { fs::remove(fs::path(filename_)); }
-    catch (...) {}
+    catch (...) { }
   }
 }
 
 CacheManager::CacheManager(const std::string& disk_path, Instance* instance)
-    : lock_(), disk_path_(disk_path), instance_(instance), cache_() {
+    : lock_()
+    , disk_path_(disk_path)
+    , instance_(instance)
+    , cache_() {
   Clear();
 }
 
@@ -46,10 +50,11 @@ void CacheManager::Clear() {
 }
 
 void CacheManager::RequestMasterComponentInfo(MasterComponentInfo* master_info) const {
-  for (auto& key : cache_.keys()) {
+  for (const auto& key : cache_.keys()) {
     std::shared_ptr<ThetaCacheEntry> entry = cache_.get(key);
-    if (entry == nullptr)
+    if (entry == nullptr) {
       continue;
+    }
 
     MasterComponentInfo::CacheEntryInfo* info = master_info->add_cache_entry();
     info->set_key(boost::lexical_cast<std::string>(key));
@@ -83,36 +88,44 @@ static bool PopulateThetaMatrixFromCacheEntry(const ThetaMatrix& cache,
     }
   } else {  // use all topics
     assert(cache.topic_name_size() > 0);
-    for (int i = 0; i < cache.topic_name_size(); ++i)
+    for (int i = 0; i < cache.topic_name_size(); ++i) {
       topics_to_use.push_back(i);
+    }
     use_all_topics = true;
   }
 
   // Populate num_topics and topic_name fields in the resulting message
   ::google::protobuf::RepeatedPtrField< ::std::string> result_topic_name;
-  for (int topic_index : topics_to_use)
+  for (int topic_index : topics_to_use) {
     result_topic_name.Add()->assign(cache.topic_name(topic_index));
+  }
 
   if (theta_matrix->topic_name_size() == 0) {
     // Assign
     theta_matrix->set_num_topics(result_topic_name.size());
     assert(theta_matrix->topic_name_size() == 0);
-    for (const TopicName& topic_name : result_topic_name)
+    for (const TopicName& topic_name : result_topic_name) {
       theta_matrix->add_topic_name(topic_name);
+    }
   } else {
     // Verify
-    if (theta_matrix->num_topics() != result_topic_name.size())
+    if (theta_matrix->num_topics() != result_topic_name.size()) {
       BOOST_THROW_EXCEPTION(artm::core::InternalError("theta_matrix->num_topics() != result_topic_name.size()"));
+    }
+
     for (int i = 0; i < theta_matrix->topic_name_size(); ++i) {
-      if (theta_matrix->topic_name(i) != result_topic_name.Get(i))
+      if (theta_matrix->topic_name(i) != result_topic_name.Get(i)) {
         BOOST_THROW_EXCEPTION(artm::core::InternalError("theta_matrix->topic_name(i) != result_topic_name.Get(i)"));
+      }
     }
   }
 
   bool has_title = (cache.item_title_size() == cache.item_id_size());
   for (int item_index = 0; item_index < cache.item_id_size(); ++item_index) {
     theta_matrix->add_item_id(cache.item_id(item_index));
-    if (has_title) theta_matrix->add_item_title(cache.item_title(item_index));
+    if (has_title) {
+      theta_matrix->add_item_title(cache.item_title(item_index));
+    }
     ::artm::FloatArray* theta_vec = theta_matrix->add_item_weights();
 
     const artm::FloatArray& item_theta = cache.item_weights(item_index);
@@ -125,8 +138,9 @@ static bool PopulateThetaMatrixFromCacheEntry(const ThetaMatrix& cache,
         }
       } else {
         // dense output -- dense cache
-        for (int topic_index : topics_to_use)
+        for (int topic_index : topics_to_use) {
           theta_vec->add_value(item_theta.value(topic_index));
+	}
       }
     } else {
       ::artm::IntArray* sparse_topic_indices = theta_matrix->add_topic_indices();
@@ -179,8 +193,9 @@ void CacheManager::RequestThetaMatrix(const GetThetaMatrixArgs& get_theta_args,
       cached_theta.add_item_id(-1);  // not available
       ::artm::FloatArray* item_weights = cached_theta.add_item_weights();
       phi_matrix->get(token_id, &values);
-      for (int topic_index = 0; topic_index < phi_matrix->topic_size(); topic_index++)
+      for (int topic_index = 0; topic_index < phi_matrix->topic_size(); topic_index++) {
         item_weights->add_value(values[topic_index]);
+      }
     }
 
     PopulateThetaMatrixFromCacheEntry(cached_theta, get_theta_args, theta_matrix);
@@ -188,10 +203,11 @@ void CacheManager::RequestThetaMatrix(const GetThetaMatrixArgs& get_theta_args,
   }
 
   auto keys = cache_.keys();
-  for (auto &key : keys) {
+  for (const auto &key : keys) {
     std::shared_ptr<ThetaMatrix> cached_theta = FindCacheEntry(key);
-    if (cached_theta != nullptr)
+    if (cached_theta != nullptr) {
       PopulateThetaMatrixFromCacheEntry(*cached_theta, get_theta_args, theta_matrix);
+    }
   }
 }
 
@@ -205,15 +221,23 @@ std::shared_ptr<ThetaMatrix> CacheManager::FindCacheEntry(const Batch& batch) co
     std::vector<float> values; values.resize(phi_matrix->topic_size());
     for (int item_id = 0; item_id < batch.item_size(); item_id++) {
       Token token(DocumentsClass, batch.item(item_id).title());
-      if (token.keyword.empty()) continue;
+
+      if (token.keyword.empty()) {
+        continue;
+      }
+
       int token_index = phi_matrix->token_index(token);
-      if (token_index < 0) continue;
+      if (token_index < 0) {
+        continue;
+      }
+
       cached_theta->add_item_title(batch.item(item_id).title());
       cached_theta->add_item_id(batch.item(item_id).id());
       ::artm::FloatArray* item_weights = cached_theta->add_item_weights();
       phi_matrix->get(token_index, &values);
-      for (int topic_index = 0; topic_index < phi_matrix->topic_size(); topic_index++)
+      for (int topic_index = 0; topic_index < phi_matrix->topic_size(); topic_index++) {
         item_weights->add_value(values[topic_index]);
+      }
     }
 
     return cached_theta;
@@ -224,16 +248,18 @@ std::shared_ptr<ThetaMatrix> CacheManager::FindCacheEntry(const Batch& batch) co
 
 std::shared_ptr<ThetaMatrix> CacheManager::FindCacheEntry(const std::string& batch_id) const {
   std::shared_ptr<ThetaCacheEntry> retval = cache_.get(batch_id);
-  if (retval == nullptr)
+  if (retval == nullptr) {
     return nullptr;
-  if (retval->filename().empty())
+  }
+  if (retval->filename().empty()) {
     return retval->theta_matrix();
+  }
 
   try {
     std::shared_ptr<ThetaMatrix> copy(std::make_shared<ThetaMatrix>());
     Helpers::LoadMessage(retval->filename(), copy.get());
     return copy;
-  } catch(...) {
+  } catch (...) {
     LOG(ERROR) << "Unable to reload cache for " << retval->filename();
   }
 
@@ -249,9 +275,12 @@ void CacheManager::UpdateCacheEntry(const std::string& batch_id, const ThetaMatr
     for (int i = 0; i < theta_matrix.item_title_size(); i++) {
       Token token(DocumentsClass, theta_matrix.item_title(i));
       int token_id = phi_matrix->token_index(token);
-      if (token_id < 0) token_id = mutable_phi_matrix->AddToken(token);
-      for (int topic_index = 0; topic_index < theta_matrix.topic_name_size(); topic_index++)
+      if (token_id < 0) {
+        token_id = mutable_phi_matrix->AddToken(token);
+      }
+      for (int topic_index = 0; topic_index < theta_matrix.topic_name_size(); topic_index++) {
         mutable_phi_matrix->set(token_id, topic_index, theta_matrix.item_weights(i).value(topic_index));
+      }
     }
     return;
   }
@@ -278,8 +307,9 @@ void CacheManager::UpdateCacheEntry(const std::string& batch_id, const ThetaMatr
 void CacheManager::CopyFrom(const CacheManager& cache_manager) {
   disk_path_ = cache_manager.disk_path_;
   auto keys = cache_manager.cache_.keys();
-  for (auto key : keys)
+  for (const auto& key : keys) {
     cache_.set(key, cache_manager.cache_.get(key));
+  }
 }
 
 }  // namespace core

--- a/src/artm/core/cache_manager.h
+++ b/src/artm/core/cache_manager.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_CACHE_MANAGER_H_
-#define SRC_ARTM_CORE_CACHE_MANAGER_H_
+#pragma once
 
 #include <algorithm>
 #include <string>
@@ -76,5 +75,3 @@ class CacheManager : boost::noncopyable {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_CACHE_MANAGER_H_

--- a/src/artm/core/call_on_destruction.h
+++ b/src/artm/core/call_on_destruction.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_CALL_ON_DESTRUCTION_H_
-#define SRC_ARTM_CORE_CALL_ON_DESTRUCTION_H_
+#pragma once
 
 #include <functional>
 
@@ -28,5 +27,3 @@ class call_on_destruction {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_CALL_ON_DESTRUCTION_H_

--- a/src/artm/core/call_on_destruction.h
+++ b/src/artm/core/call_on_destruction.h
@@ -17,7 +17,7 @@ namespace core {
 // An object that accepts a lambda expression end executes it in destructor
 class call_on_destruction {
  public:
-  explicit call_on_destruction(std::function<void()> f) : f_(f) {}
+  explicit call_on_destruction(std::function<void()> f) : f_(f) { }
   ~call_on_destruction() { f_(); }
 
  private:

--- a/src/artm/core/check_messages.h
+++ b/src/artm/core/check_messages.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_CHECK_MESSAGES_H_
-#define SRC_ARTM_CORE_CHECK_MESSAGES_H_
+#pragma once
 
 #include <string>
 
@@ -998,6 +997,3 @@ inline void FixPackedMessage(std::string* message) {
 
 }  // namespace core
 }  // namespace artm
-
-
-#endif  // SRC_ARTM_CORE_CHECK_MESSAGES_H_

--- a/src/artm/core/check_messages.h
+++ b/src/artm/core/check_messages.h
@@ -40,20 +40,24 @@ inline std::string DescribeErrors(const ::artm::TopicModel& message) {
   const bool has_sparse_format = has_bulk_data && (message.topic_indices_size() != 0);
 
   if (has_topic_data) {
-    if (message.num_topics() != message.topic_name_size())
+    if (message.num_topics() != message.topic_name_size()) {
       ss << "Length mismatch in fields TopicModel.num_topics and TopicModel.topic_name";
+    }
   }
 
   if (has_token_data) {
-    if (message.class_id_size() != message.token_size())
+    if (message.class_id_size() != message.token_size()) {
       ss << "Inconsistent fields size in TopicModel.token and TopicModel.class_id: "
          << message.token_size() << " vs " << message.class_id_size();
+    }
   }
 
-  if (has_bulk_data && !has_topic_data)
+  if (has_bulk_data && !has_topic_data) {
     ss << "TopicModel.topic_name_size is empty";
-  if (has_bulk_data && !has_token_data)
+  }
+  if (has_bulk_data && !has_token_data) {
     ss << "TopicModel.token_size is empty";
+  }
 
   if (has_bulk_data) {
     if ((message.token_weights_size() != message.token_size()) ||
@@ -82,8 +86,9 @@ inline std::string DescribeErrors(const ::artm::TopicModel& message) {
           }
         }
 
-        if (!ok)
+        if (!ok) {
           break;
+        }
       }
 
       if (!has_sparse_format) {
@@ -111,10 +116,12 @@ inline std::string DescribeErrors(const ::artm::ThetaMatrix& message) {
        << " vs " << message.item_title_size() << " vs " << message.topic_indices_size() << ";";
   }
 
-  if (message.num_topics() == 0 || message.topic_name_size() == 0)
+  if (message.num_topics() == 0 || message.topic_name_size() == 0) {
     ss << "ThetaMatrix.topic_name_size is empty";
-  if (message.num_topics() != message.topic_name_size())
+  }
+  if (message.num_topics() != message.topic_name_size()) {
     ss << "Length mismatch in fields ThetaMatrix.num_topics and ThetaMatrix.topic_name";
+  }
 
   for (int i = 0; i < message.item_id_size(); ++i) {
     if (has_sparse_format) {
@@ -134,8 +141,9 @@ inline std::string DescribeErrors(const ::artm::ThetaMatrix& message) {
         }
       }
 
-      if (!ok)
+      if (!ok) {
         break;
+      }
     }
   }
 
@@ -197,26 +205,29 @@ inline std::string DescribeErrors(const ::artm::Batch& message) {
 inline std::string DescribeErrors(const ::artm::GetScoreValueArgs& message) {
   std::stringstream ss;
 
-  if (!message.has_score_name() || message.score_name().empty())
+  if (!message.has_score_name() || message.score_name().empty()) {
     ss << "GetScoreValueArgs.score_name is missing; ";
-
+  }
   return ss.str();
 }
 
 inline std::string DescribeErrors(const ::artm::MasterModelConfig& message) {
   std::stringstream ss;
 
-  if (message.class_weight_size() != message.class_id_size())
+  if (message.class_weight_size() != message.class_id_size()) {
     ss << "Length mismatch in fields MasterModelConfig.class_id and MasterModelConfig.class_weight; ";
+  }
 
-  if (message.num_document_passes() < 0)
+  if (message.num_document_passes() < 0) {
     ss << "Field MasterModelConfig.num_document_passes must be non-negative; ";
+  }
 
   for (int i = 0; i < message.regularizer_config_size(); ++i) {
     const RegularizerConfig& config = message.regularizer_config(i);
-    if (!config.has_tau())
+    if (!config.has_tau()) {
       ss << "Field MasterModelConfig.RegularizerConfig.tau must not be empty "
          << "(regularizer name: " << config.name() << "); ";
+    }
   }
 
   return ss.str();
@@ -225,16 +236,19 @@ inline std::string DescribeErrors(const ::artm::MasterModelConfig& message) {
 inline std::string DescribeErrors(const ::artm::FitOfflineMasterModelArgs& message) {
   std::stringstream ss;
 
-  if (message.batch_filename_size() != message.batch_weight_size())
+  if (message.batch_filename_size() != message.batch_weight_size()) {
     ss << "Length mismatch in fields FitOfflineMasterModelArgs.batch_filename "
        << "and FitOfflineMasterModelArgs.batch_weight; ";
+  }
 
-  if (message.num_collection_passes() <= 0)
+  if (message.num_collection_passes() <= 0) {
     ss << "FitOfflineMasterModelArgs.passes() must be a positive number";
+  }
 
-  if (message.has_batch_folder() && (message.batch_filename_size() != 0))
+  if (message.has_batch_folder() && (message.batch_filename_size() != 0)) {
     ss << "Only one of FitOfflineMasterModelArgs.batch_folder, "
        << "FitOfflineMasterModelArgs.batch_filename must be specified; ";
+  }
 
   return ss.str();
 }
@@ -242,15 +256,18 @@ inline std::string DescribeErrors(const ::artm::FitOfflineMasterModelArgs& messa
 inline std::string DescribeErrors(const ::artm::FitOnlineMasterModelArgs& message) {
   std::stringstream ss;
 
-  if (message.batch_filename_size() == 0)
+  if (message.batch_filename_size() == 0) {
     ss << "Fields FitOnlineMasterModelArgs.batch_filename must not be empty; ";
+  }
 
-  if (message.batch_filename_size() != message.batch_weight_size())
+  if (message.batch_filename_size() != message.batch_weight_size()) {
     ss << "Length mismatch in fields FitOnlineMasterModelArgs.batch_filename "
     << "and FitOnlineMasterModelArgs.batch_weight; ";
+  }
 
-  if (message.update_after_size() == 0)
+  if (message.update_after_size() == 0) {
     ss << "Field FitOnlineMasterModelArgs.update_after must not be empty; ";
+  }
 
   if (message.update_after_size() != message.apply_weight_size() ||
       message.update_after_size() != message.decay_weight_size()) {
@@ -291,11 +308,13 @@ inline std::string DescribeErrors(const ::artm::FitOnlineMasterModelArgs& messag
 inline std::string DescribeErrors(const ::artm::TransformMasterModelArgs& message) {
   std::stringstream ss;
 
-  if (message.batch_filename_size() == 0 && message.batch_size() == 0)
+  if (message.batch_filename_size() == 0 && message.batch_size() == 0) {
     ss << "Either TransformMasterModelArgs.batch_filename or TransformMasterModelArgs.batch must be specified; ";
-  if (message.batch_filename_size() != 0 && message.batch_size() != 0)
+  }
+  if (message.batch_filename_size() != 0 && message.batch_size() != 0) {
     ss << "Only one of TransformMasterModelArgs.batch_filename, "
        << "TransformMasterModelArgs.batch must be specified; ";
+  }
 
   return ss.str();
 }
@@ -318,14 +337,17 @@ inline std::string DescribeErrors(const ::artm::InitializeModelArgs& message) {
 inline std::string DescribeErrors(const ::artm::FilterDictionaryArgs& message) {
   std::stringstream ss;
 
-  if (!message.has_dictionary_name())
+  if (!message.has_dictionary_name()) {
     ss << "FilterDictionaryArgs has no dictionary name; ";
+  }
 
-  if (!message.has_dictionary_target_name())
+  if (!message.has_dictionary_target_name()) {
      ss << "FilterDictionaryArgs has no target dictionary name; ";
+  }
 
-  if (message.has_max_dictionary_size() && (message.max_dictionary_size() <= 0))
+  if (message.has_max_dictionary_size() && (message.max_dictionary_size() <= 0)) {
     ss << "FilterDictionaryArgs.max_dictionary_size must be positive integer; ";
+  }
 
   return ss.str();
 }
@@ -333,11 +355,13 @@ inline std::string DescribeErrors(const ::artm::FilterDictionaryArgs& message) {
 inline std::string DescribeErrors(const ::artm::GatherDictionaryArgs& message) {
   std::stringstream ss;
 
-  if (!message.has_dictionary_target_name())
+  if (!message.has_dictionary_target_name()) {
     ss << "GatherDictionaryArgs has no target dictionary name; ";
+  }
 
-  if (!message.has_data_path() && (message.batch_path_size() == 0))
+  if (!message.has_data_path() && (message.batch_path_size() == 0)) {
     ss << "GatherDictionaryArgs has neither batch_path nor data_path set; ";
+  }
 
   return ss.str();
 }
@@ -345,8 +369,9 @@ inline std::string DescribeErrors(const ::artm::GatherDictionaryArgs& message) {
 inline std::string DescribeErrors(const ::artm::DictionaryData& message) {
   std::stringstream ss;
 
-  if (!message.has_name())
+  if (!message.has_name()) {
     ss << "DictionaryData has no dictionary name; ";
+  }
 
   bool is_token_df_ok = message.token_df_size() == 0 || message.token_df_size() == message.token_size();
   bool is_token_tf_ok = message.token_tf_size() == 0 || message.token_tf_size() == message.token_size();
@@ -377,7 +402,9 @@ inline std::string DescribeErrors(const ::artm::DictionaryData& message) {
 
 inline std::string DescribeErrors(const ::artm::ExportModelArgs& message) {
   std::stringstream ss;
-  if (!message.has_file_name()) ss << "ExportModelArgs.file_name is not defined; ";
+  if (!message.has_file_name()) {
+    ss << "ExportModelArgs.file_name is not defined; ";
+  }
 
   // Allow this to default to MasterModelConfig.pwt_name
   // if (!message.has_model_name()) ss << "ExportModelArgs.model_name is not defined; ";
@@ -387,7 +414,9 @@ inline std::string DescribeErrors(const ::artm::ExportModelArgs& message) {
 
 inline std::string DescribeErrors(const ::artm::ImportModelArgs& message) {
   std::stringstream ss;
-  if (!message.has_file_name()) ss << "ImportModelArgs.file_name is not defined; ";
+  if (!message.has_file_name()) {
+    ss << "ImportModelArgs.file_name is not defined; ";
+  }
 
   // Allow this to default to MasterModelConfig.pwt_name
   // if (!message.has_model_name()) ss << "ImportModelArgs.model_name is not defined; ";
@@ -397,23 +426,31 @@ inline std::string DescribeErrors(const ::artm::ImportModelArgs& message) {
 
 inline std::string DescribeErrors(const ::artm::ExportScoreTrackerArgs& message) {
   std::stringstream ss;
-  if (!message.has_file_name()) ss << "ExportScoreTrackerArgs.file_name is not defined; ";
+  if (!message.has_file_name()) {
+    ss << "ExportScoreTrackerArgs.file_name is not defined; ";
+  }
 
   return ss.str();
 }
 
 inline std::string DescribeErrors(const ::artm::ImportScoreTrackerArgs& message) {
   std::stringstream ss;
-  if (!message.has_file_name()) ss << "ImportScoreTrackerArgs.file_name is not defined; ";
+  if (!message.has_file_name()) {
+    ss << "ImportScoreTrackerArgs.file_name is not defined; ";
+  }
 
   return ss.str();
 }
 
 inline std::string DescribeErrors(const ::artm::ImportDictionaryArgs& message) {
   std::stringstream ss;
-  if (!message.has_file_name()) ss << "ImportDictionaryArgs.file_name is not defined; ";
-  if (!message.has_dictionary_name())
+  if (!message.has_file_name()) {
+    ss << "ImportDictionaryArgs.file_name is not defined; ";
+  }
+
+  if (!message.has_dictionary_name()) {
     ss << "ImportDictionaryArgs.dictionary_name is not defined; ";
+  }
 
   return ss.str();
 }
@@ -421,17 +458,21 @@ inline std::string DescribeErrors(const ::artm::ImportDictionaryArgs& message) {
 inline std::string DescribeErrors(const ::artm::ProcessBatchesArgs& message) {
   std::stringstream ss;
 
-  if (message.batch_filename_size() == 0 && message.batch_size() == 0)
+  if (message.batch_filename_size() == 0 && message.batch_size() == 0) {
     ss << "Either ProcessBatchesArgs.batch_filename or ProcessBatchesArgs.batch must be specified; ";
-  if (message.batch_filename_size() != 0 && message.batch_size() != 0)
+  }
+  if (message.batch_filename_size() != 0 && message.batch_size() != 0) {
     ss << "Only one of ProcessBatchesArgs.batch_filename, "
        << "ProcessBatchesArgs.batch must be specified; ";
+  }
 
-  if (message.batch_filename_size() != 0 && message.batch_filename_size() != message.batch_weight_size())
+  if (message.batch_filename_size() != 0 && message.batch_filename_size() != message.batch_weight_size()) {
     ss << "Length mismatch in fields ProcessBatchesArgs.batch_filename and ProcessBatchesArgs.batch_weight";
+  }
 
-  if (message.batch_size() != 0 && message.batch_size() != message.batch_weight_size())
+  if (message.batch_size() != 0 && message.batch_size() != message.batch_weight_size()) {
     ss << "Length mismatch in fields ProcessBatchesArgs.batch_filename and ProcessBatchesArgs.batch_weight";
+  }
 
   return ss.str();
 }
@@ -439,8 +480,9 @@ inline std::string DescribeErrors(const ::artm::ProcessBatchesArgs& message) {
 inline std::string DescribeErrors(const ::artm::ImportBatchesArgs& message) {
   std::stringstream ss;
 
-  if (message.batch_size() == 0)
+  if (message.batch_size() == 0) {
     ss << "Empty ImportBatchesArgs.batch field";
+  }
 
   return ss.str();
 }
@@ -448,8 +490,9 @@ inline std::string DescribeErrors(const ::artm::ImportBatchesArgs& message) {
 inline std::string DescribeErrors(const ::artm::MergeModelArgs& message) {
   std::stringstream ss;
 
-  if (message.source_weight_size() != 0 && message.source_weight_size() != message.nwt_source_name_size())
+  if (message.source_weight_size() != 0 && message.source_weight_size() != message.nwt_source_name_size()) {
     ss << "Length mismatch in fields MergeModelArgs.source_weight and MergeModelArgs.nwt_source_name";
+  }
 
   return ss.str();
 }
@@ -478,7 +521,7 @@ inline std::string DescribeErrors(const ::artm::CollectionParserConfig& message)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename T>
-inline void FixMessage(T* message) {}
+inline void FixMessage(T* message) { }
 
 #define FIX_REGULARIZER_CONFIG(T, U) if (message->type() == T) { message->set_config(ProtobufSerialization::ConvertJsonToBinary< U>(message->config_json())); fixed = true; }  // NOLINT
 #define FIX_SCORE_CONFIG(T, U) if (message->type() == T) { message->set_config(ProtobufSerialization::ConvertJsonToBinary< U>(message->config_json())); fixed = true; }  // NOLINT
@@ -499,7 +542,9 @@ inline void FixMessage(::artm::RegularizerConfig* message) {
     FIX_REGULARIZER_CONFIG(RegularizerType_TopicSelectionTheta, ::artm::TopicSelectionThetaConfig);
     FIX_REGULARIZER_CONFIG(RegularizerType_BitermsPhi, ::artm::BitermsPhiConfig);
     FIX_REGULARIZER_CONFIG(RegularizerType_HierarchySparsingTheta, ::artm::HierarchySparsingThetaConfig);
-    if (!fixed) BOOST_THROW_EXCEPTION(InternalError("Given RegularizerType is not supported for json serialization"));
+    if (!fixed) {
+      BOOST_THROW_EXCEPTION(InternalError("Given RegularizerType is not supported for json serialization"));
+    }
   }
 }
 
@@ -518,11 +563,14 @@ inline void FixMessage(::artm::ScoreConfig* message) {
     FIX_SCORE_CONFIG(ScoreType_ClassPrecision, ::artm::ClassPrecisionScoreConfig);
     FIX_SCORE_CONFIG(ScoreType_PeakMemory, ::artm::PeakMemoryScoreConfig);
     FIX_SCORE_CONFIG(ScoreType_BackgroundTokensRatio, ::artm::BackgroundTokensRatioScoreConfig);
-    if (!fixed) BOOST_THROW_EXCEPTION(InternalError("Given ScoreType is not supported for json serialization"));
+    if (!fixed) {
+      BOOST_THROW_EXCEPTION(InternalError("Given ScoreType is not supported for json serialization"));
+    }
   }
 
-  if (message->type() == ScoreType_TopTokens)
+  if (message->type() == ScoreType_TopTokens) {
     FixPackedMessage<TopTokensScoreConfig>(message->mutable_config());
+  }
 }
 
 template<>
@@ -540,7 +588,9 @@ inline void FixMessage(::artm::ScoreData* message) {
     FIX_SCORE_DATA(ScoreType_ClassPrecision, ::artm::ClassPrecisionScore);
     FIX_SCORE_DATA(ScoreType_PeakMemory, ::artm::PeakMemoryScore);
     FIX_SCORE_DATA(ScoreType_BackgroundTokensRatio, ::artm::BackgroundTokensRatioScore);
-    if (!fixed) BOOST_THROW_EXCEPTION(InternalError("Given ScoreType is not supported for json de-serialization"));
+    if (!fixed) {
+      BOOST_THROW_EXCEPTION(InternalError("Given ScoreType is not supported for json de-serialization"));
+    }
   }
 }
 
@@ -553,12 +603,14 @@ inline void FixMessage(::artm::TopicModel* message) {
   const int token_size = message->token_size();
   if ((message->class_id_size() == 0) && (token_size > 0)) {
     message->mutable_class_id()->Reserve(token_size);
-    for (int i = 0; i < token_size; ++i)
+    for (int i = 0; i < token_size; ++i) {
       message->add_class_id(::artm::core::DefaultClass);
+    }
   }
 
-  if (message->topic_name_size() > 0)
+  if (message->topic_name_size() > 0) {
     message->set_num_topics(message->topic_name_size());
+  }
 }
 
 template<>
@@ -574,8 +626,9 @@ inline void FixMessage(::artm::Batch* message) {
     for (auto& field : *item.mutable_field()) {
       if (field.token_count_size() != 0 && field.token_weight_size() == 0) {
         field.mutable_token_weight()->Reserve(field.token_count_size());
-        for (int i = 0; i < field.token_count_size(); ++i)
+        for (int i = 0; i < field.token_count_size(); ++i) {
           field.add_token_weight(static_cast<float>(field.token_count(i)));
+	}
         field.clear_token_count();
       }
     }
@@ -592,21 +645,25 @@ inline void FixMessage(::artm::Batch* message) {
   }
 
   // For items without title set title to item id
-  for (auto& item : *message->mutable_item())
-    if (!item.has_title() && item.has_id())
+  for (auto& item : *message->mutable_item()) {
+    if (!item.has_title() && item.has_id()) {
       item.set_title(boost::lexical_cast<std::string>(item.id()));
+    }
+  }
 }
 
 template<>
 inline void FixMessage(::artm::GetThetaMatrixArgs* message) {
-  if (message->has_use_sparse_format())
+  if (message->has_use_sparse_format()) {
     message->set_matrix_layout(MatrixLayout_Sparse);
+  }
 }
 
 template<>
 inline void FixMessage(::artm::GetTopicModelArgs* message) {
-  if (message->has_use_sparse_format())
+  if (message->has_use_sparse_format()) {
     message->set_matrix_layout(MatrixLayout_Sparse);
+  }
 }
 
 template<>
@@ -622,16 +679,19 @@ template<>
 inline void FixMessage(::artm::ProcessBatchesArgs* message) {
   if (message->batch_weight_size() == 0) {
     int size = message->batch_filename_size() > 0 ? message->batch_filename_size() : message->batch_size();
-    for (int i = 0; i < size; ++i)
+    for (int i = 0; i < size; ++i) {
       message->add_batch_weight(1.0f);
+    }
   }
 
-  for (int i = 0; i < message->batch_size(); ++i)
+  for (int i = 0; i < message->batch_size(); ++i) {
     FixMessage(message->mutable_batch(i));
+  }
 
   if (message->class_weight_size() == 0) {
-    for (int i = 0; i < message->class_id_size(); ++i)
+    for (int i = 0; i < message->class_id_size(); ++i) {
       message->add_class_weight(1.0f);
+    }
   }
 }
 
@@ -645,12 +705,14 @@ inline void FixMessage(::artm::TopTokensScoreConfig* message) {
 template<>
 inline void FixMessage(::artm::MasterModelConfig* message) {
   if (message->class_weight_size() == 0) {
-    for (int i = 0; i < message->class_id_size(); ++i)
+    for (int i = 0; i < message->class_id_size(); ++i) {
       message->add_class_weight(1.0f);
+    }
   }
 
-  if (message->reuse_theta())
+  if (message->reuse_theta()) {
     message->set_cache_theta(true);
+  }
 
   for (int i = 0; i < message->regularizer_config_size(); ++i) {
     FixMessage(message->mutable_regularizer_config(i));
@@ -660,8 +722,9 @@ inline void FixMessage(::artm::MasterModelConfig* message) {
     ScoreConfig* score_config = message->mutable_score_config(i);
     FixMessage(score_config);
 
-    if (!score_config->has_model_name())
+    if (!score_config->has_model_name()) {
       score_config->set_model_name(message->pwt_name());
+    }
   }
 
   ScoreConfig* items_processed_score = message->add_score_config();
@@ -669,27 +732,32 @@ inline void FixMessage(::artm::MasterModelConfig* message) {
   items_processed_score->set_type(ScoreType_ItemsProcessed);
   items_processed_score->set_config(::artm::ItemsProcessedScore().SerializeAsString());
 
-  if (message->topic_name_size() == 0) message->set_ptd_name(std::string());
+  if (message->topic_name_size() == 0) {
+    message->set_ptd_name(std::string());
+  }
 }
 
 template<>
 inline void FixMessage(::artm::FitOfflineMasterModelArgs* message) {
   if (message->batch_weight_size() == 0) {
-    for (int i = 0; i < message->batch_filename_size(); ++i)
+    for (int i = 0; i < message->batch_filename_size(); ++i) {
       message->add_batch_weight(1.0f);
+    }
   }
 }
 
 template<>
 inline void FixMessage(::artm::FitOnlineMasterModelArgs* message) {
   if (message->batch_weight_size() == 0) {
-    for (int i = 0; i < message->batch_filename_size(); ++i)
+    for (int i = 0; i < message->batch_filename_size(); ++i) {
       message->add_batch_weight(1.0f);
+    }
   }
 
   if (message->apply_weight_size() == 0) {
-    for (int i = 0; i < message->decay_weight_size(); ++i)
+    for (int i = 0; i < message->decay_weight_size(); ++i) {
       message->add_apply_weight(1.0f - message->decay_weight(i));
+    }
   }
 
   if (message->decay_weight_size() == 0) {
@@ -701,33 +769,38 @@ inline void FixMessage(::artm::FitOnlineMasterModelArgs* message) {
 
 template<>
 inline void FixMessage(::artm::TransformMasterModelArgs* message) {
-  for (int i = 0; i < message->batch_size(); ++i)
+  for (int i = 0; i < message->batch_size(); ++i) {
     FixMessage(message->mutable_batch(i));
+  }
 }
 
 template<>
 inline void FixMessage(::artm::ImportBatchesArgs* message) {
-  for (int i = 0; i < message->batch_size(); ++i)
+  for (int i = 0; i < message->batch_size(); ++i) {
     FixMessage(message->mutable_batch(i));
+  }
 }
 
 template<>
 inline void FixMessage(::artm::ProcessBatchesResult* message) {
-  for (int i = 0; i < message->score_data_size(); ++i)
+  for (int i = 0; i < message->score_data_size(); ++i) {
     FixMessage(message->mutable_score_data(i));
+  }
 }
 
 template<>
 inline void FixMessage(::artm::ScoreArray* message) {
-  for (int i = 0; i < message->score_size(); ++i)
+  for (int i = 0; i < message->score_size(); ++i) {
     FixMessage(message->mutable_score(i));
+  }
 }
 
 template<>
 inline void FixMessage(::artm::MergeModelArgs* message) {
   if (message->source_weight().empty()) {
-    for (int i = 0; i < message->nwt_source_name_size(); ++i)
+    for (int i = 0; i < message->nwt_source_name_size(); ++i) {
       message->add_source_weight(1.0f);
+    }
   }
 }
 
@@ -743,10 +816,11 @@ inline std::string DescribeMessage(const ::artm::RegularizerSettings& message) {
   std::stringstream ss;
   ss << ", regularizer=(name:" << message.name() <<
         ", tau:" << message.tau();
-  if (message.has_gamma())
+  if (message.has_gamma()) {
     ss << "gamma:" << message.gamma() << ")";
-  else
+  } else {
     ss << "gamma:None" << ")";
+  }
   return ss.str();
 }
 
@@ -756,8 +830,9 @@ inline std::string DescribeMessage(const ::artm::InitializeModelArgs& message) {
   ss << "InitializeModelArgs";
   ss << ": model_name=" << message.model_name();
 
-  if (message.has_dictionary_name())
+  if (message.has_dictionary_name()) {
     ss << ", dictionary_name=" << message.dictionary_name();
+  }
   ss << ", topic_name_size=" << message.topic_name_size();
   return ss.str();
 }
@@ -768,21 +843,28 @@ inline std::string DescribeMessage(const ::artm::FilterDictionaryArgs& message) 
   ss << "FilterDictionaryArgs";
   ss << ": dictionary_name=" << message.dictionary_name();
 
-  if (message.has_class_id())
+  if (message.has_class_id()) {
     ss << ", class_id=" << message.class_id();
-  if (message.has_min_df())
+  }
+  if (message.has_min_df()) {
     ss << ", min_df=" << message.min_df();
-  if (message.has_max_df())
+  }
+  if (message.has_max_df()) {
     ss << ", max_df=" << message.max_df();
-  if (message.has_min_tf())
+  }
+  if (message.has_min_tf()) {
     ss << ", min_tf=" << message.min_tf();
-  if (message.has_max_tf())
+  }
+  if (message.has_max_tf()) {
     ss << ", max_tf=" << message.max_tf();
+  }
 
-  if (message.has_min_df_rate())
+  if (message.has_min_df_rate()) {
     ss << ", min_df_rate=" << message.min_df_rate();
-  if (message.has_max_df_rate())
+  }
+  if (message.has_max_df_rate()) {
     ss << ", max_df_rate=" << message.max_df_rate();
+  }
 
   return ss.str();
 }
@@ -793,12 +875,15 @@ inline std::string DescribeMessage(const ::artm::GatherDictionaryArgs& message) 
   ss << "GatherDictionaryArgs";
   ss << ": dictionary_target_name=" << message.dictionary_target_name();
 
-  if (message.has_data_path())
+  if (message.has_data_path()) {
     ss << ", data_path=" << message.data_path();
-  if (message.has_cooc_file_path())
+  }
+  if (message.has_cooc_file_path()) {
     ss << ", cooc_file_path=" << message.cooc_file_path();
-  if (message.has_vocab_file_path())
+  }
+  if (message.has_vocab_file_path()) {
     ss << ", vocab_file_path=" << message.vocab_file_path();
+  }
   ss << ", symmetric_cooc_values=" << message.symmetric_cooc_values();
 
   return ss.str();
@@ -814,10 +899,12 @@ inline std::string DescribeMessage(const ::artm::ProcessBatchesArgs& message) {
   ss << ", batch_weight_size=" << message.batch_weight_size();
   ss << ", pwt_source_name=" << message.pwt_source_name();
   ss << ", num_document_passes=" << message.num_document_passes();
-  for (int i = 0; i < message.regularizer_name_size(); ++i)
+  for (int i = 0; i < message.regularizer_name_size(); ++i) {
     ss << ", regularizer=(name:" << message.regularizer_name(i) << ", tau:" << message.regularizer_tau(i) << ")";
-  for (int i = 0; i < message.class_id_size(); ++i)
+  }
+  for (int i = 0; i < message.class_id_size(); ++i) {
     ss << ", class=(" << message.class_id(i) << ":" << message.class_weight(i) << ")";
+  }
   ss << ", reuse_theta=" << (message.reuse_theta() ? "yes" : "no");
   ss << ", opt_for_avx=" << (message.opt_for_avx() ? "yes" : "no");
   ss << ", predict_class_id=" << (message.predict_class_id());
@@ -839,8 +926,9 @@ inline std::string DescribeMessage(const ::artm::MergeModelArgs& message) {
   std::stringstream ss;
   ss << "MergeModelArgs";
   ss << ": nwt_target_name=" << message.nwt_target_name();
-  for (int i = 0; i < message.nwt_source_name_size(); ++i)
+  for (int i = 0; i < message.nwt_source_name_size(); ++i) {
     ss << ", class=(" << message.nwt_source_name(i) << ":" << message.source_weight(i) << ")";
+  }
   ss << ", topic_name_size=" << message.topic_name_size();
   return ss.str();
 }
@@ -852,8 +940,9 @@ inline std::string DescribeMessage(const ::artm::RegularizeModelArgs& message) {
   ss << ": rwt_target_name=" << message.rwt_target_name();
   ss << ", pwt_source_name=" << message.pwt_source_name();
   ss << ", nwt_source_name=" << message.nwt_source_name();
-  for (int i = 0; i < message.regularizer_settings_size(); ++i)
+  for (int i = 0; i < message.regularizer_settings_size(); ++i) {
     DescribeMessage(message.regularizer_settings(i));
+  }
   return ss.str();
 }
 
@@ -862,17 +951,19 @@ inline std::string DescribeMessage(const ::artm::MasterModelConfig& message) {
   std::stringstream ss;
   ss << "MasterModelConfig";
   ss << ": topic_name_size=" << message.topic_name_size();
-  for (int i = 0; i < message.class_id_size(); ++i)
+  for (int i = 0; i < message.class_id_size(); ++i) {
     ss << ", class=(" << message.class_id(i) << ":" << message.class_weight(i) << ")";
+  }
   ss << ", score_config_size=" << message.score_config_size();
   ss << ", num_processors=" << message.num_processors();
   ss << ", pwt_name=" << message.pwt_name();
   ss << ", nwt_name=" << message.nwt_name();
   ss << ", num_document_passes=" << message.num_document_passes();
-  for (int i = 0; i < message.regularizer_config_size(); ++i)
+  for (int i = 0; i < message.regularizer_config_size(); ++i) {
     ss << ", regularizer=("
        << message.regularizer_config(i).name() << ":"
        << message.regularizer_config(i).tau() << ")";
+  }
   ss << ", reuse_theta=" << (message.reuse_theta() ? "yes" : "no");
   ss << ", cache_theta=" << (message.cache_theta() ? "yes" : "no");
   ss << ", opt_for_avx=" << (message.opt_for_avx() ? "yes" : "no");
@@ -899,7 +990,9 @@ inline std::string DescribeMessage(const ::artm::FitOnlineMasterModelArgs& messa
   ss << ", batch_weight_size=" << message.batch_weight_size();
   ss << ", update_after:apply_weight:decay_weight=(";
   for (int i = 0; i < message.update_after_size(); ++i) {
-    if (i != 0) ss << ", ";
+    if (i != 0) {
+      ss << ", ";
+    }
     ss << message.update_after(i) << ":";
     ss << message.apply_weight(i) << ":";
     ss << message.decay_weight(i);
@@ -971,11 +1064,14 @@ template <typename T>
 inline bool ValidateMessage(const T& message, bool throw_error) {
   std::string ss = DescribeErrors(message);
 
-  if (ss.empty())
+  if (ss.empty()) {
     return true;
+  }
 
-  if (throw_error)
+  if (throw_error) {
     BOOST_THROW_EXCEPTION(InvalidOperation(ss));
+  }
+
   LOG(WARNING) << ss;
   return false;
 }

--- a/src/artm/core/check_messages.h
+++ b/src/artm/core/check_messages.h
@@ -628,7 +628,7 @@ inline void FixMessage(::artm::Batch* message) {
         field.mutable_token_weight()->Reserve(field.token_count_size());
         for (int i = 0; i < field.token_count_size(); ++i) {
           field.add_token_weight(static_cast<float>(field.token_count(i)));
-	}
+        }
         field.clear_token_count();
       }
     }

--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -35,9 +35,9 @@ namespace artm {
 namespace core {
 
 BatchNameGenerator::BatchNameGenerator(int length, bool use_guid_name)
-  : length_(length)
-  , next_name_(std::string())
-  , use_guid_name_(use_guid_name) {
+    : length_(length)
+    , next_name_(std::string())
+    , use_guid_name_(use_guid_name) {
   next_name_ = std::string(length, 'a');
 }
 
@@ -449,7 +449,7 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
         first_line_no_for_batch = global_line_no;
         if (docword.eof()) {
           return;
-	}
+        }
 
         while ((int64_t) all_strs_for_batch.size() < config.num_items_per_batch()) {
           std::string str;
@@ -458,14 +458,14 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
           progress.Set(docword.tellg());
           if (docword.eof()) {
             break;
-	  }
+          }
 
           all_strs_for_batch.push_back(str);
         }
 
         if (all_strs_for_batch.size() > 0) {
           batch_name = batch_name_generator.next_name(batch_collector.batch());
-	}
+        }
       }
 
       for (int str_index = 0; str_index < (int64_t) all_strs_for_batch.size(); ++str_index) {
@@ -502,7 +502,7 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
           // Skip token when it is not among modalities that user has requested to parse
           if (!useClassId(class_id, config)) {
             continue;
-	  }
+          }
 
           float token_weight = 1.0f;
           std::string token = elem;
@@ -540,7 +540,7 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
           batch = batch_collector.FinishBatch(&parser_info);
           for (int token_id = 0; token_id < batch.token_size(); ++token_id) {
             token_map[artm::core::Token(batch.class_id(token_id), batch.token(token_id))] = true;
-	  }
+          }
         }
         ::artm::core::Helpers::SaveBatch(batch, config.target_folder(), batch_name);
       }

--- a/src/artm/core/collection_parser.h
+++ b/src/artm/core/collection_parser.h
@@ -42,9 +42,9 @@ class CollectionParser : boost::noncopyable {
  private:
   struct CollectionParserTokenInfo {
     CollectionParserTokenInfo()
-      : keyword(), class_id(DefaultClass), token_weight(), items_count() {}
+      : keyword(), class_id(DefaultClass), token_weight(), items_count() { }
     explicit CollectionParserTokenInfo(std::string keyword_, ClassId class_id_)
-      : keyword(keyword_), class_id(class_id_), token_weight(0.0f), items_count(0) {}
+      : keyword(keyword_), class_id(class_id_), token_weight(0.0f), items_count(0) { }
     std::string keyword;
     ClassId class_id;
     float token_weight;

--- a/src/artm/core/collection_parser.h
+++ b/src/artm/core/collection_parser.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_COLLECTION_PARSER_H_
-#define SRC_ARTM_CORE_COLLECTION_PARSER_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -69,5 +68,3 @@ class CollectionParser : boost::noncopyable {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_COLLECTION_PARSER_H_

--- a/src/artm/core/common.h
+++ b/src/artm/core/common.h
@@ -3,8 +3,7 @@
 // File 'common.h' contains constants, helpers and typedefs used across the entire library.
 // The goal is to keep this file as short as possible.
 
-#ifndef SRC_ARTM_CORE_COMMON_H_
-#define SRC_ARTM_CORE_COMMON_H_
+#pragma once
 
 #include <string>
 
@@ -47,5 +46,3 @@ std::string to_string(T value) {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_COMMON_H_

--- a/src/artm/core/cuckoo_watch.h
+++ b/src/artm/core/cuckoo_watch.h
@@ -18,28 +18,30 @@ class CuckooWatch {
  public:
   explicit CuckooWatch(std::string message)
       : message_(message), submessage_(), start_(std::chrono::system_clock::now()), parent_(nullptr),
-        threshold_ms_(0) {}
+        threshold_ms_(0) { }
   explicit CuckooWatch(std::string message, int threshold_ms)
       : message_(message), submessage_(), start_(std::chrono::system_clock::now()), parent_(nullptr),
-        threshold_ms_(threshold_ms) {}
+        threshold_ms_(threshold_ms) { }
   CuckooWatch(std::string message, CuckooWatch* parent)
       : message_(message), submessage_(), start_(std::chrono::system_clock::now()), parent_(parent),
-        threshold_ms_(1) {}
+        threshold_ms_(1) { }
   CuckooWatch(std::string message, CuckooWatch* parent, int threshold_ms)
       : message_(message), submessage_(), start_(std::chrono::system_clock::now()), parent_(parent),
-        threshold_ms_(threshold_ms) {}
+        threshold_ms_(threshold_ms) { }
 
   ~CuckooWatch() {
     auto delta = (std::chrono::system_clock::now() - start_);
     auto delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(delta);
-    if (delta_ms.count() < threshold_ms_)
+    if (delta_ms.count() < threshold_ms_) {
       return;
+    }
 
     if (parent_ == nullptr) {
       std::stringstream ss;
       ss << delta_ms.count() << "ms in " << message_;
-      if (!submessage_.empty())
+      if (!submessage_.empty()) {
         ss << " [including " << submessage_ << "]";
+      }
       LOG(INFO) << ss.str();
     } else {
       std::stringstream ss;

--- a/src/artm/core/cuckoo_watch.h
+++ b/src/artm/core/cuckoo_watch.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_CUCKOO_WATCH_H_
-#define SRC_ARTM_CORE_CUCKOO_WATCH_H_
+#pragma once
 
 #include <chrono>  // NOLINT
 #include <string>
@@ -59,5 +58,3 @@ class CuckooWatch {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_CUCKOO_WATCH_H_

--- a/src/artm/core/dense_phi_matrix.cc
+++ b/src/artm/core/dense_phi_matrix.cc
@@ -362,9 +362,10 @@ void DensePhiMatrix::Clear() {
 
 int64_t DensePhiMatrix::ByteSize() const {
   int64_t retval = PhiMatrixFrame::ByteSize();
-  for (auto& value : values_) retval += value.ByteSize(); {
-    return retval;
+  for (const auto& value : values_) {
+    retval += value.ByteSize();
   }
+  return retval;
 }
 
 int DensePhiMatrix::AddToken(const Token& token) {

--- a/src/artm/core/dense_phi_matrix.cc
+++ b/src/artm/core/dense_phi_matrix.cc
@@ -16,8 +16,9 @@ namespace core {
 
 int TokenCollection::AddToken(const Token& token) {
   int token_id = this->token_id(token);
-  if (token_id != -1)
+  if (token_id != -1) {
     return token_id;
+  }
 
   token_id = token_size();
   token_to_token_id_.insert(
@@ -57,7 +58,9 @@ int64_t TokenCollection::ByteSize() const {
   int64_t retval = 0;
   retval += artm::utility::getMemoryUsage(token_id_to_token_);
   retval += artm::utility::getMemoryUsage(token_to_token_id_);
-  for (auto& token : token_id_to_token_) retval += 2 * (token.keyword.size() + token.class_id.size());
+  for (const auto& token : token_id_to_token_) {
+    retval += 2 * (token.keyword.size() + token.class_id.size());
+  }
   return retval;
 }
 
@@ -81,9 +84,14 @@ void SpinLock::Unlock() {
 
 PhiMatrixFrame::PhiMatrixFrame(const ModelName& model_name,
                                const google::protobuf::RepeatedPtrField<std::string>& topic_name)
-    : model_name_(model_name), topic_name_(), token_collection_(), spin_locks_() {
-  if (topic_name.size() == 0)
+    : model_name_(model_name)
+    , topic_name_()
+    , token_collection_()
+    , spin_locks_() {
+  if (topic_name.size() == 0) {
     BOOST_THROW_EXCEPTION(artm::core::InvalidOperation("Can not create model " + model_name + " with 0 topics"));
+  }
+
   for (auto iter = topic_name.begin(); iter != topic_name.end(); ++iter) {
     topic_name_.push_back(*iter);
   }
@@ -95,8 +103,9 @@ PhiMatrixFrame::PhiMatrixFrame(const PhiMatrixFrame& rhs)
       token_collection_(rhs.token_collection_),
       spin_locks_() {
   spin_locks_.reserve(rhs.spin_locks_.size());
-  for (unsigned i = 0; i < rhs.spin_locks_.size(); ++i)
+  for (unsigned i = 0; i < rhs.spin_locks_.size(); ++i) {
     spin_locks_.push_back(std::make_shared<SpinLock>());
+  }
 }
 
 const Token& PhiMatrixFrame::token(int index) const {
@@ -139,8 +148,9 @@ void PhiMatrixFrame::Clear() {
 
 int PhiMatrixFrame::AddToken(const Token& token) {
   int token_id = token_collection_.token_id(token);
-  if (token_id != -1)
+  if (token_id != -1) {
     return token_id;
+  }
 
   spin_locks_.push_back(std::make_shared<SpinLock>());
   return token_collection_.AddToken(token);
@@ -161,16 +171,27 @@ int64_t PhiMatrixFrame::ByteSize() const {
 // PackedValues methods
 // =======================================================
 
-PackedValues::PackedValues() : values_(), bitmask_(), ptr_() {}
+PackedValues::PackedValues()
+    : values_()
+    , bitmask_()
+    , ptr_() { }
 
-PackedValues::PackedValues(int size) : values_(), bitmask_(), ptr_() {
+PackedValues::PackedValues(int size)
+    : values_()
+    , bitmask_()
+    , ptr_() {
   bitmask_.resize(size, false);
 }
 
 PackedValues::PackedValues(const PackedValues& rhs)
-    : values_(rhs.values_), bitmask_(rhs.bitmask_), ptr_(rhs.ptr_) {}
+    : values_(rhs.values_)
+    , bitmask_(rhs.bitmask_)
+    , ptr_(rhs.ptr_) { }
 
-PackedValues::PackedValues(const float* values, int size) : values_(), bitmask_(), ptr_() {
+PackedValues::PackedValues(const float* values, int size)
+    : values_()
+    , bitmask_()
+    , ptr_() {
   values_.resize(size); memcpy(&values_[0], values, sizeof(float) * size);
   pack();
 }
@@ -181,8 +202,9 @@ bool PackedValues::is_packed() const {
 
 float PackedValues::get(int index) const {
   if (is_packed()) {
-    if (!bitmask_[index])
+    if (!bitmask_[index]) {
       return 0.0f;
+    }
     const auto sparse_ptr = std::lower_bound(ptr_.begin(), ptr_.end(), index);
     const int sparse_index = sparse_ptr - ptr_.begin();
     return values_[sparse_index];
@@ -194,8 +216,9 @@ float PackedValues::get(int index) const {
 void PackedValues::get(std::vector<float>* buffer) const {
   if (is_packed()) {
     buffer->assign(buffer->size(), 0.0f);
-    for (int i = 0; i < (int64_t) ptr_.size(); i++)
+    for (int i = 0; i < (int64_t) ptr_.size(); i++) {
       buffer->at(ptr_[i]) = values_[i];
+    }
   } else {
     buffer->assign(values_.begin(), values_.end());
   }
@@ -205,12 +228,14 @@ float* PackedValues::unpack() {
   if (is_packed()) {
     const int full_size = bitmask_.size();
     const int sparse_size = values_.size();
-    if (values_.size() != ptr_.size())
+    if (values_.size() != ptr_.size()) {
       assert(values_.size() == ptr_.size());
+    }
 
     std::vector<float> values(full_size, 0.0f);
-    for (int i = 0; i < sparse_size; ++i)
+    for (int i = 0; i < sparse_size; ++i) {
       values[ptr_[i]] = values_[i];
+    }
 
     values_.swap(values);
 
@@ -222,17 +247,21 @@ float* PackedValues::unpack() {
 }
 
 void PackedValues::pack() {
-  if (is_packed())
+  if (is_packed()) {
     return;
+  }
 
   int num_zeros = 0;
-  for (auto value : values_)
-    if (value == 0)
+  for (auto value : values_) {
+    if (value == 0) {
       num_zeros++;
+    }
+  }
 
   // pack iff at 60% of elements (or more) are zeros
-  if (num_zeros < (int64_t) (3 * values_.size() / 5))
+  if (num_zeros < (int64_t) (3 * values_.size() / 5)) {
     return;
+  }
 
   bitmask_.resize(values_.size(), false);
   ptr_.resize(values_.size() - num_zeros);
@@ -240,8 +269,9 @@ void PackedValues::pack() {
 
   int sparse_index = 0;
   for (int i = 0; i < (int64_t) values_.size(); ++i) {
-    if (values_[i] == 0)
+    if (values_[i] == 0) {
       continue;
+    }
 
     ptr_[sparse_index] = i;
     values[sparse_index] = values_[i];
@@ -270,7 +300,7 @@ int64_t PackedValues::ByteSize() const {
 
 DensePhiMatrix::DensePhiMatrix(const ModelName& model_name,
                                const google::protobuf::RepeatedPtrField<std::string>& topic_name)
-    : PhiMatrixFrame(model_name, topic_name), values_() {}
+    : PhiMatrixFrame(model_name, topic_name), values_() { }
 
 DensePhiMatrix::DensePhiMatrix(const DensePhiMatrix& rhs) : PhiMatrixFrame(rhs), values_() {
   for (int token_index = 0; token_index < rhs.token_size(); ++token_index) {
@@ -300,14 +330,16 @@ void DensePhiMatrix::get(int token_id, std::vector<float>* buffer) const {
 
 void DensePhiMatrix::set(int token_id, int topic_id, float value) {
   values_[token_id].unpack()[topic_id] = value;
-  if ((topic_id + 1) == topic_size())
+  if ((topic_id + 1) == topic_size()) {
     values_[token_id].pack();
+  }
 }
 
 void DensePhiMatrix::increase(int token_id, int topic_id, float increment) {
   values_[token_id].unpack()[topic_id] += increment;
-  if ((topic_id + 1) == topic_size())
+  if ((topic_id + 1) == topic_size()) {
     values_[token_id].pack();
+  }
 }
 
 void DensePhiMatrix::increase(int token_id, const std::vector<float>& increment) {
@@ -316,8 +348,9 @@ void DensePhiMatrix::increase(int token_id, const std::vector<float>& increment)
 
   this->Lock(token_id);
   float* values = values_[token_id].unpack();
-  for (int topic_index = 0; topic_index < topic_size; ++topic_index)
+  for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
     values[topic_index] += increment[topic_index];
+  }
   values_[token_id].pack();
   this->Unlock(token_id);
 }
@@ -329,14 +362,16 @@ void DensePhiMatrix::Clear() {
 
 int64_t DensePhiMatrix::ByteSize() const {
   int64_t retval = PhiMatrixFrame::ByteSize();
-  for (auto& value : values_) retval += value.ByteSize();
-  return retval;
+  for (auto& value : values_) retval += value.ByteSize(); {
+    return retval;
+  }
 }
 
 int DensePhiMatrix::AddToken(const Token& token) {
   int token_id = token_index(token);
-  if (token_id != -1)
+  if (token_id != -1) {
     return token_id;
+  }
 
   values_.push_back(PackedValues(topic_size()));
   int retval = PhiMatrixFrame::AddToken(token);
@@ -345,8 +380,9 @@ int DensePhiMatrix::AddToken(const Token& token) {
 }
 
 void DensePhiMatrix::Reset() {
-  for (PackedValues& value : values_)
+  for (PackedValues& value : values_) {
     value.reset(topic_size());
+  }
 }
 
 void DensePhiMatrix::Reshape(const PhiMatrix& phi_matrix) {
@@ -400,8 +436,9 @@ void AttachedPhiMatrix::increase(int token_id, const std::vector<float>& increme
   float* values = values_[token_id];
 
   this->Lock(token_id);
-  for (int topic_index = 0; topic_index < topic_size; ++topic_index)
+  for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
     values[topic_index] += increment[topic_index];
+  }
   this->Unlock(token_id);
 }
 

--- a/src/artm/core/dense_phi_matrix.h
+++ b/src/artm/core/dense_phi_matrix.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_DENSE_PHI_MATRIX_H_
-#define SRC_ARTM_CORE_DENSE_PHI_MATRIX_H_
+#pragma once
 
 #include <atomic>
 #include <map>
@@ -180,5 +179,3 @@ class AttachedPhiMatrix : boost::noncopyable, public PhiMatrixFrame {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_DENSE_PHI_MATRIX_H_

--- a/src/artm/core/dictionary.cc
+++ b/src/artm/core/dictionary.cc
@@ -70,8 +70,9 @@ void Dictionary::AddCoocDf(int index_1, int index_2, float value) {
 }
 
 bool Dictionary::has_valid_cooc_state() const {
-  if (cooc_tfs_.size() == 0 && cooc_dfs_.size() == 0)
+  if (cooc_tfs_.size() == 0 && cooc_dfs_.size() == 0) {
     return true;
+  }
 
   return (cooc_dfs_.size() == cooc_tfs_.size()) && (cooc_dfs_.size() == cooc_values_.size());
 }
@@ -83,20 +84,34 @@ int64_t Dictionary::ByteSize() const {
   retval += ::artm::utility::getMemoryUsage(cooc_values_);
   retval += ::artm::utility::getMemoryUsage(cooc_tfs_);
   retval += ::artm::utility::getMemoryUsage(cooc_dfs_);
-  for (auto& entry : cooc_values_) retval += ::artm::utility::getMemoryUsage(entry.second);
-  for (auto& entry : cooc_tfs_) retval += ::artm::utility::getMemoryUsage(entry.second);
-  for (auto& entry : cooc_dfs_) retval += ::artm::utility::getMemoryUsage(entry.second);
-  for (auto& entry : entries_)
+  for (const auto& entry : cooc_values_) {
+    retval += ::artm::utility::getMemoryUsage(entry.second);
+  }
+
+  for (const auto& entry : cooc_tfs_) {
+    retval += ::artm::utility::getMemoryUsage(entry.second);
+  }
+
+  for (const auto& entry : cooc_dfs_) {
+    retval += ::artm::utility::getMemoryUsage(entry.second);
+  }
+
+  for (const auto& entry : entries_) {
     retval += 2 * (entry.token().keyword.size() + entry.token().class_id.size());
+  }
   return retval;
 }
 
 const std::unordered_map<int, float>* Dictionary::cooc_info_impl(const Token& token, const CoocMap& cooc_map) const {
   auto index_iter = token_index_.find(token);
-  if (index_iter == token_index_.end()) return nullptr;
+  if (index_iter == token_index_.end()) {
+    return nullptr;
+  }
 
   auto cooc_map_iter = cooc_map.find(index_iter->second);
-  if (cooc_map_iter == cooc_map.end()) return nullptr;
+  if (cooc_map_iter == cooc_map.end()) {
+    return nullptr;
+  }
 
   return &(cooc_map_iter->second);
 }
@@ -115,41 +130,60 @@ const std::unordered_map<int, float>*  Dictionary::token_cooc_dfs(const Token& t
 
 const DictionaryEntry* Dictionary::entry(const Token& token) const {
   auto find_iter = token_index_.find(token);
-  if (find_iter != token_index_.end())
+  if (find_iter != token_index_.end()) {
     return &entries_[find_iter->second];
-  else
+  } else {
     return nullptr;
+  }
 }
 
 const DictionaryEntry* Dictionary::entry(int index) const {
-  if (index < 0 || index >= (int64_t) entries_.size()) return nullptr;
+  if (index < 0 || index >= (int64_t) entries_.size()) {
+    return nullptr;
+  }
   return &entries_[index];
 }
 
 float Dictionary::CountTopicCoherence(const std::vector<core::Token>& tokens_to_score) {
   float coherence_value = 0.0;
   int k = static_cast<int>(tokens_to_score.size());
-  if (k == 0 || k == 1) return 0.0f;
+  if (k == 0 || k == 1) {
+    return 0.0f;
+  }
 
   // -1 means that find() result == end()
   auto indices = std::vector<int>(k, -1);
   for (int i = 0; i < k; ++i) {
     auto token_index_iter = token_index_.find(tokens_to_score[i]);
-    if (token_index_iter == token_index_.end()) continue;
+    if (token_index_iter == token_index_.end()) {
+      continue;
+    }
     indices[i] = token_index_iter->second;
   }
 
   for (int i = 0; i < k - 1; ++i) {
-    if (indices[i] == -1) continue;
+    if (indices[i] == -1) {
+      continue;
+    }
+
     auto cooc_map_iter = cooc_values_.find(indices[i]);
-    if (cooc_map_iter == cooc_values_.end()) continue;
+    if (cooc_map_iter == cooc_values_.end()) {
+      continue;
+    }
 
     for (int j = i; j < k; ++j) {
-      if (indices[j] == -1) continue;
-      if (tokens_to_score[j].class_id != tokens_to_score[i].class_id) continue;
+      if (indices[j] == -1) {
+        continue;
+      }
+
+      if (tokens_to_score[j].class_id != tokens_to_score[i].class_id) {
+        continue;
+      }
 
       auto value_iter = cooc_map_iter->second.find(indices[j]);
-      if (value_iter == cooc_map_iter->second.end()) continue;
+      if (value_iter == cooc_map_iter->second.end()) {
+        continue;
+      }
       coherence_value += static_cast<float>(value_iter->second);
     }
   }

--- a/src/artm/core/dictionary.h
+++ b/src/artm/core/dictionary.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_DICTIONARY_H_
-#define SRC_ARTM_CORE_DICTIONARY_H_
+#pragma once
 
 #include <map>
 #include <string>
@@ -115,5 +114,3 @@ class Dictionary {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_DICTIONARY_H_

--- a/src/artm/core/dictionary_operations.cc
+++ b/src/artm/core/dictionary_operations.cc
@@ -120,7 +120,7 @@ void DictionaryOperations::Export(const ExportDictionaryArgs& args, const Dictio
             if (tf_iter == cooc_tfs_info->end() || df_iter == cooc_dfs_info->end()) {
               BOOST_THROW_EXCEPTION(InvalidOperation("Dictionary " +
                   args.dictionary_name() + " has internal cooc tf/df inconsistence"));
-	    }
+            }
 
             cooc_dict_data.add_cooc_tf(tf_iter->second);
             cooc_dict_data.add_cooc_df(df_iter->second);
@@ -225,9 +225,9 @@ std::shared_ptr<Dictionary> DictionaryOperations::Import(const ImportDictionaryA
 class TokenValues {
  public:
   TokenValues()
-    : token_value(0.0f)
-    , token_tf(0.0f)
-    , token_df(0.0f) { }
+      : token_value(0.0f)
+      , token_tf(0.0f)
+      , token_df(0.0f) { }
 
   float token_value;
   float token_tf;

--- a/src/artm/core/dictionary_operations.cc
+++ b/src/artm/core/dictionary_operations.cc
@@ -239,7 +239,7 @@ std::shared_ptr<Dictionary> DictionaryOperations::Gather(const GatherDictionaryA
   }
 
   int total_items_count = 0;
-  std::unordered_map<ClassId, double> sum_w_tf;
+  std::unordered_map<ClassId, float> sum_w_tf;
   for (const std::string& batch_file : batches) {
     std::shared_ptr<Batch> batch_ptr = mem_batches.get(batch_file);
     try {

--- a/src/artm/core/dictionary_operations.h
+++ b/src/artm/core/dictionary_operations.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_DICTIONARY_OPERATIONS_H_
-#define SRC_ARTM_CORE_DICTIONARY_OPERATIONS_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -30,5 +29,3 @@ class DictionaryOperations {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_DICTIONARY_OPERATIONS_H_

--- a/src/artm/core/exceptions.h
+++ b/src/artm/core/exceptions.h
@@ -44,8 +44,8 @@ namespace core {
 
 #define DEFINE_EXCEPTION_TYPE(Type, BaseType)          \
 class Type : public BaseType { public:  /*NOLINT*/     \
-  explicit Type(std::string what) : BaseType(what) {}  \
-  explicit Type(const char* what) : BaseType(what) {}  \
+  explicit Type(std::string what) : BaseType(what) { }  \
+  explicit Type(const char* what) : BaseType(what) { }  \
 };
 
 DEFINE_EXCEPTION_TYPE(InternalError, std::runtime_error);
@@ -54,11 +54,11 @@ class ArgumentOutOfRangeException : public std::runtime_error {
   template<class T>
   explicit ArgumentOutOfRangeException(std::string argument, T actual)
       : std::runtime_error(argument + " == " +
-        boost::lexical_cast<std::string>(actual) + ", out of range.") {}
+        boost::lexical_cast<std::string>(actual) + ", out of range.") { }
   template<class T>
   explicit ArgumentOutOfRangeException(std::string argument, T actual, std::string message)
       : std::runtime_error(argument + " == " +
-        boost::lexical_cast<std::string>(actual) + ", out of range. " + message) {}
+        boost::lexical_cast<std::string>(actual) + ", out of range. " + message) { }
 };
 DEFINE_EXCEPTION_TYPE(InvalidMasterIdException, std::runtime_error);
 DEFINE_EXCEPTION_TYPE(CorruptedMessageException, std::runtime_error);

--- a/src/artm/core/helpers.cc
+++ b/src/artm/core/helpers.cc
@@ -89,7 +89,9 @@ std::vector<float> Helpers::GenerateRandomVector(int size, size_t seed) {
   }
 
   float sum = 0.0f;
-  for (int i = 0; i < size; ++i) sum += retval[i];
+  for (int i = 0; i < size; ++i) {
+    sum += retval[i];
+  }
   if (sum > 0) {
     for (int i = 0; i < size; ++i) retval[i] /= sum;
   }
@@ -101,16 +103,20 @@ std::vector<float> Helpers::GenerateRandomVector(int size, const Token& token, i
   size_t h = 1125899906842597L;  // prime
 
   if (token.class_id != DefaultClass) {
-    for (unsigned i = 0; i < token.class_id.size(); i++)
+    for (unsigned i = 0; i < token.class_id.size(); i++) {
       h = 31 * h + token.class_id[i];
+    }
   }
 
   h = 31 * h + 255;  // separate class_id and token
 
-  for (unsigned i = 0; i < token.keyword.size(); i++)
+  for (unsigned i = 0; i < token.keyword.size(); i++) {
     h = 31 * h + token.keyword[i];
+  }
 
-  if (seed > 0) h = 31 * h + seed;
+  if (seed > 0) {
+    h = 31 * h + seed;
+  }
 
   return GenerateRandomVector(size, h);
 }
@@ -135,8 +141,9 @@ std::vector<boost::filesystem::path> Helpers::ListAllBatches(const boost::filesy
 
 boost::uuids::uuid Helpers::SaveBatch(const Batch& batch,
                                       const std::string& disk_path, const std::string& name) {
-  if (!batch.has_id())
+  if (!batch.has_id()) {
     BOOST_THROW_EXCEPTION(InvalidOperation("Helpers::SaveBatch: batch expecting id"));
+  }
 
   boost::uuids::uuid uuid;
   try {
@@ -161,8 +168,9 @@ void Helpers::LoadMessage(const std::string& filename, const std::string& disk_p
 void Helpers::LoadMessage(const std::string& full_filename,
                           ::google::protobuf::Message* message) {
   std::ifstream fin(full_filename.c_str(), std::ifstream::binary);
-  if (!fin.is_open())
+  if (!fin.is_open()) {
     BOOST_THROW_EXCEPTION(DiskReadException("Unable to open file " + full_filename));
+  }
 
   message->Clear();
   if (!message->ParseFromIstream(&fin)) {
@@ -180,7 +188,7 @@ void Helpers::LoadMessage(const std::string& full_filename,
       // Attempt to detect UUID based on batche's filename
       std::string filename_only = boost::filesystem::path(full_filename).stem().string();
       uuid = boost::lexical_cast<boost::uuids::uuid>(filename_only);
-    } catch (...) {}
+    } catch (...) { }
 
     if (uuid.is_nil()) {
       // Otherwise throw the exception
@@ -191,15 +199,17 @@ void Helpers::LoadMessage(const std::string& full_filename,
     batch->set_id(boost::lexical_cast<std::string>(uuid));
   }
 
-  if (batch != nullptr)
+  if (batch != nullptr) {
     FixAndValidateMessage(batch);
+  }
 }
 
 void Helpers::CreateFolderIfNotExists(const std::string& disk_path) {
   boost::filesystem::path dir(disk_path);
   if (!boost::filesystem::is_directory(dir)) {
-    if (!boost::filesystem::create_directory(dir))
+    if (!boost::filesystem::create_directory(dir)) {
       BOOST_THROW_EXCEPTION(DiskWriteException("Unable to create folder '" + disk_path + "'"));
+    }
   }
 }
 
@@ -207,8 +217,9 @@ void Helpers::SaveMessage(const std::string& filename, const std::string& disk_p
                           const ::google::protobuf::Message& message) {
   CreateFolderIfNotExists(disk_path);
   boost::filesystem::path full_filename = boost::filesystem::path(disk_path) / boost::filesystem::path(filename);
-  if (boost::filesystem::exists(full_filename))
+  if (boost::filesystem::exists(full_filename)) {
     LOG(WARNING) << "File already exists: " << full_filename.string();
+  }
 
   SaveMessage(full_filename.string(), message);
 }
@@ -216,8 +227,9 @@ void Helpers::SaveMessage(const std::string& filename, const std::string& disk_p
 void Helpers::SaveMessage(const std::string& full_filename,
                           const ::google::protobuf::Message& message) {
   std::ofstream fout(full_filename.c_str(), std::ofstream::binary);
-  if (!fout.is_open())
+  if (!fout.is_open()) {
     BOOST_THROW_EXCEPTION(DiskReadException("Unable to create file " + full_filename));
+  }
 
   if (!message.SerializeToOstream(&fout)) {
     BOOST_THROW_EXCEPTION(DiskWriteException("Batch has not been serialized to disk."));

--- a/src/artm/core/helpers.h
+++ b/src/artm/core/helpers.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_HELPERS_H_
-#define SRC_ARTM_CORE_HELPERS_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -61,5 +60,3 @@ class Helpers {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_HELPERS_H_

--- a/src/artm/core/instance.cc
+++ b/src/artm/core/instance.cc
@@ -94,17 +94,19 @@ Instance::Instance(const Instance& rhs)
   Reconfigure(*rhs.config());
 
   std::vector<std::string> batch_name = rhs.batches_.keys();
-  for (auto& key : batch_name) {
+  for (const auto& key : batch_name) {
     std::shared_ptr<Batch> value = rhs.batches_.get(key);
-    if (value != nullptr)
+    if (value != nullptr) {
       batches_.set(key, value);  // store same batch as rhs (OK as batches here are read-only)
+    }
   }
 
   std::vector<ModelName> model_name = rhs.models_.keys();
-  for (auto& key : model_name) {
+  for (const auto& key : model_name) {
     std::shared_ptr<const PhiMatrix> value = rhs.GetPhiMatrix(key);
-    if (value != nullptr)
+    if (value != nullptr) {
       this->SetPhiMatrix(key, value->Duplicate());
+    }
   }
 
   cache_manager_->CopyFrom(*rhs.cache_manager_);
@@ -120,23 +122,26 @@ std::shared_ptr<Instance> Instance::Duplicate() const {
 
 void Instance::RequestMasterComponentInfo(MasterComponentInfo* master_info) const {
   auto config = master_model_config_.get();
-  if (config != nullptr)
+  if (config != nullptr) {
     master_info->mutable_config()->CopyFrom(*config);
+  }
 
-  for (auto key : regularizers_.keys()) {
+  for (const auto& key : regularizers_.keys()) {
     auto regularizer = regularizers_.get(key);
-    if (regularizer == nullptr)
+    if (regularizer == nullptr) {
       continue;
+    }
 
     MasterComponentInfo::RegularizerInfo* info = master_info->add_regularizer();
     info->set_name(key);
     info->set_type(typeid(*regularizer).name());
   }
 
-  for (auto key : score_calculators_.keys()) {
+  for (const auto& key : score_calculators_.keys()) {
     auto score_calculator = score_calculators_.get(key);
-    if (score_calculator == nullptr)
+    if (score_calculator == nullptr) {
       continue;
+    }
 
     MasterComponentInfo::ScoreInfo* info = master_info->add_score();
     info->set_name(key);
@@ -145,10 +150,11 @@ void Instance::RequestMasterComponentInfo(MasterComponentInfo* master_info) cons
 
   cache_manager_->RequestMasterComponentInfo(master_info);
 
-  for (auto& name : dictionaries()->keys()) {
+  for (const auto& name : dictionaries()->keys()) {
     std::shared_ptr<Dictionary> dict = dictionaries()->get(name);
-    if (dict == nullptr)
+    if (dict == nullptr) {
       continue;
+    }
 
     MasterComponentInfo::DictionaryInfo* info = master_info->add_dictionary();
     info->set_name(name);
@@ -156,10 +162,11 @@ void Instance::RequestMasterComponentInfo(MasterComponentInfo* master_info) cons
     info->set_byte_size(dict->ByteSize());
   }
 
-  for (auto& name : batches_.keys()) {
+  for (const auto& name : batches_.keys()) {
     std::shared_ptr<Batch> batch = batches_.get(name);
-    if (batch == nullptr)
+    if (batch == nullptr) {
       continue;
+    }
 
     MasterComponentInfo::BatchInfo* info = master_info->add_batch();
     info->set_name(name);
@@ -167,7 +174,7 @@ void Instance::RequestMasterComponentInfo(MasterComponentInfo* master_info) cons
     info->set_num_items(batch->item_size());
   }
 
-  for (auto& name : models_.keys()) {
+  for (const auto& name : models_.keys()) {
     std::shared_ptr<const PhiMatrix> p_wt = this->GetPhiMatrix(name);
     if (p_wt != nullptr) {
       MasterComponentInfo::ModelInfo* info = master_info->add_model();
@@ -421,8 +428,9 @@ void Instance::Reconfigure(const MasterModelConfig& master_config) {
   if (master_config.has_disk_cache_path()) {
     boost::filesystem::path dir(master_config.disk_cache_path());
     if (!boost::filesystem::is_directory(dir)) {
-      if (!boost::filesystem::create_directory(dir))
+      if (!boost::filesystem::create_directory(dir)) {
         BOOST_THROW_EXCEPTION(DiskWriteException("Unable to create folder '" + master_config.disk_cache_path() + "'"));
+      }
     }
   }
 }
@@ -435,15 +443,17 @@ Instance::GetPhiMatrix(ModelName model_name) const {
 std::shared_ptr<const ::artm::core::PhiMatrix>
 Instance::GetPhiMatrixSafe(ModelName model_name) const {
   std::shared_ptr<const PhiMatrix> retval = models_.get(model_name);
-  if (retval == nullptr)
+  if (retval == nullptr) {
     BOOST_THROW_EXCEPTION(InvalidOperation("Model " + model_name + " does not exist"));
+  }
   return retval;
 }
 
 void Instance::SetPhiMatrix(ModelName model_name, std::shared_ptr< ::artm::core::PhiMatrix> phi_matrix) {
   models_.erase(model_name);
-  if (phi_matrix != nullptr)
+  if (phi_matrix != nullptr) {
     models_.set(model_name, phi_matrix);
+  }
 }
 
 }  // namespace core

--- a/src/artm/core/instance.h
+++ b/src/artm/core/instance.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_INSTANCE_H_
-#define SRC_ARTM_CORE_INSTANCE_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -105,5 +104,3 @@ class Instance {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_INSTANCE_H_

--- a/src/artm/core/master_component.cc
+++ b/src/artm/core/master_component.cc
@@ -66,8 +66,9 @@ static void HandleExternalThetaMatrixRequest(::artm::ThetaMatrix* theta_matrix, 
 }
 
 static void HandleSparseTopicModelRequest(::artm::TopicModel* topic_model, std::string* lm) {
-  if (topic_model->topic_indices_size() == 0)
+  if (topic_model->topic_indices_size() == 0) {
     BOOST_THROW_EXCEPTION(InternalError("topic_model->topic_indices_size() == 0"));
+  }
 
   int32_t coo_token = 0;
   std::vector<int32_t> coo_token_index;
@@ -79,8 +80,9 @@ static void HandleSparseTopicModelRequest(::artm::TopicModel* topic_model, std::
   for (int token_index = 0; token_index < topic_model->token_weights_size(); ++token_index) {
     const artm::IntArray& topic_indices = topic_model->topic_indices(token_index);
     const artm::FloatArray& token_weights = topic_model->token_weights(token_index);
-    if (token_weights.value_size() == 0)
+    if (token_weights.value_size() == 0) {
       continue;
+    }
 
     for (int value_index = 0; value_index < topic_indices.value_size(); ++value_index) {
       coo_token_index.push_back(coo_token);
@@ -89,12 +91,17 @@ static void HandleSparseTopicModelRequest(::artm::TopicModel* topic_model, std::
     }
 
     coo_token++;
-    if (topic_model->token_size() > 0) token.Add()->assign(topic_model->token(token_index));
-    if (topic_model->class_id_size() > 0) class_id.Add()->assign(topic_model->class_id(token_index));
+    if (topic_model->token_size() > 0) {
+      token.Add()->assign(topic_model->token(token_index));
+    }
+    if (topic_model->class_id_size() > 0) {
+      class_id.Add()->assign(topic_model->class_id(token_index));
+    }
   }
 
-  if (coo_weight.empty())
+  if (coo_weight.empty()) {
     BOOST_THROW_EXCEPTION(InvalidOperation("No data to return for sparse phi matrix"));
+  }
 
   int64_t num_values = coo_weight.size();
   int64_t byte_size = sizeof(int32_t) * num_values;  // assert(sizeof(float) == sizeof(int32_t)
@@ -110,8 +117,9 @@ static void HandleSparseTopicModelRequest(::artm::TopicModel* topic_model, std::
 }
 
 static void HandleSparseThetaMatrixRequest(::artm::ThetaMatrix* theta_matrix, std::string* lm) {
-  if (theta_matrix->topic_indices_size() == 0)
+  if (theta_matrix->topic_indices_size() == 0) {
     BOOST_THROW_EXCEPTION(InternalError("theta_matrix->topic_indices_size() == 0"));
+  }
 
   int32_t coo_item = 0;
   std::vector<int32_t> coo_item_index;
@@ -123,8 +131,9 @@ static void HandleSparseThetaMatrixRequest(::artm::ThetaMatrix* theta_matrix, st
   for (int item_index = 0; item_index < theta_matrix->item_weights_size(); ++item_index) {
     const artm::IntArray& topic_indices = theta_matrix->topic_indices(item_index);
     const artm::FloatArray& item_weights = theta_matrix->item_weights(item_index);
-    if (item_weights.value_size() == 0)
+    if (item_weights.value_size() == 0) {
       continue;
+    }
 
     for (int value_index = 0; value_index < topic_indices.value_size(); ++value_index) {
       coo_item_index.push_back(coo_item);
@@ -133,12 +142,17 @@ static void HandleSparseThetaMatrixRequest(::artm::ThetaMatrix* theta_matrix, st
     }
 
     coo_item++;
-    if (theta_matrix->item_id_size() > 0) item_id.Add(theta_matrix->item_id(item_index));
-    if (theta_matrix->item_title_size() > 0) item_title.Add()->assign(theta_matrix->item_title(item_index));
+    if (theta_matrix->item_id_size() > 0) {
+      item_id.Add(theta_matrix->item_id(item_index));
+    }
+    if (theta_matrix->item_title_size() > 0) {
+      item_title.Add()->assign(theta_matrix->item_title(item_index));
+    }
   }
 
-  if (coo_weight.empty())
+  if (coo_weight.empty()) {
     BOOST_THROW_EXCEPTION(InvalidOperation("No data to return for sparse theta matrix"));
+  }
 
   int64_t num_values = coo_weight.size();
   int64_t byte_size = sizeof(int32_t) * num_values;  // assert(sizeof(float) == sizeof(int32_t)
@@ -160,12 +174,14 @@ void MasterComponent::CreateOrReconfigureMasterComponent(const MasterModelConfig
     instance_ = std::make_shared<Instance>(config);
   } else {
     auto old_config = instance_->config();
-    if (!change_topic_name && (old_config->topic_name_size() != config.topic_name_size()))
+    if (!change_topic_name && (old_config->topic_name_size() != config.topic_name_size())) {
       BOOST_THROW_EXCEPTION(InvalidOperation(
         "ArtmReconfigureMasterModel can not change number of topics; use ArtmReconfigureTopicName"));
-    if (old_config->ptd_name() != config.ptd_name())
+    }
+    if (old_config->ptd_name() != config.ptd_name()) {
       BOOST_THROW_EXCEPTION(InvalidOperation(
         "ArtmReconfigureMasterModel can not change MasterModelConfig.ptd_name"));
+    }
 
     instance_->Reconfigure(config);
 
@@ -177,12 +193,13 @@ void MasterComponent::CreateOrReconfigureMasterComponent(const MasterModelConfig
     //    Topic names will be set as new labels.
     if (!repeated_field_equals(old_config->topic_name(), config.topic_name())) {
       auto model_names = instance_->models()->keys();
-      for (auto model_name : model_names) {
+      for (const auto& model_name : model_names) {
         auto model = instance_->GetPhiMatrixSafe(model_name);
 
         // Ignore models where set of topics doesn't match the old config
-        if (!repeated_field_equals(model->topic_name(), old_config->topic_name()))
+        if (!repeated_field_equals(model->topic_name(), old_config->topic_name())) {
           continue;
+        }
 
         if (change_topic_name) {
           MergeModelArgs merge;
@@ -191,8 +208,9 @@ void MasterComponent::CreateOrReconfigureMasterComponent(const MasterModelConfig
           merge.set_nwt_target_name(model_name);
           MergeModel(merge);
         } else {
-          for (int topic_index = 0; topic_index < config.topic_name_size(); topic_index++)
+          for (int topic_index = 0; topic_index < config.topic_name_size(); topic_index++) {
             (const_cast<PhiMatrix*>(model.get()))->set_topic_name(topic_index, config.topic_name(topic_index));
+          }
         }
       }
     }
@@ -203,8 +221,9 @@ void MasterComponent::CreateOrReconfigureMasterComponent(const MasterModelConfig
   }
 
   // create (or re-create the regularizers)
-  for (int i = 0; i < config.regularizer_config_size(); ++i)
+  for (int i = 0; i < config.regularizer_config_size(); ++i) {
     CreateOrReconfigureRegularizer(config.regularizer_config(i));
+  }
 }
 
 MasterComponent::MasterComponent(const MasterModelConfig& config)
@@ -216,7 +235,7 @@ MasterComponent::MasterComponent(const MasterComponent& rhs)
     : instance_(rhs.instance_->Duplicate()) {
 }
 
-MasterComponent::~MasterComponent() {}
+MasterComponent::~MasterComponent() { }
 
 std::shared_ptr<MasterComponent> MasterComponent::Duplicate() const {
   return std::shared_ptr<MasterComponent>(new MasterComponent(*this));
@@ -260,17 +279,19 @@ void MasterComponent::CreateDictionary(const DictionaryData& data) {
 }
 
 void MasterComponent::DisposeDictionary(const std::string& name) {
-  if (name.empty())
+  if (name.empty()) {
     instance_->dictionaries()->clear();
-  else
+  } else {
     instance_->dictionaries()->erase(name);
+  }
 }
 
 void MasterComponent::ExportDictionary(const ExportDictionaryArgs& args) {
   std::shared_ptr<Dictionary> dict_ptr = instance_->dictionaries()->get(args.dictionary_name());
-  if (dict_ptr == nullptr)
+  if (dict_ptr == nullptr) {
     BOOST_THROW_EXCEPTION(InvalidOperation("Dictionary " +
-    args.dictionary_name() + " does not exist or has no tokens"));
+        args.dictionary_name() + " does not exist or has no tokens"));
+  }
 
   DictionaryOperations::Export(args, *dict_ptr);
 }
@@ -283,18 +304,20 @@ void MasterComponent::ImportDictionary(const ImportDictionaryArgs& args) {
 
 void MasterComponent::Request(::artm::MasterModelConfig* result) {
   std::shared_ptr<MasterModelConfig> config = instance_->config();
-  if (config == nullptr)
+  if (config == nullptr) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
-    "Invalid master_id; use ArtmCreateMasterModel instead of ArtmCreateMasterComponent"));
+        "Invalid master_id; use ArtmCreateMasterModel instead of ArtmCreateMasterComponent"));
+  }
 
   result->CopyFrom(*config);
 }
 
 void MasterComponent::Request(const GetDictionaryArgs& args, DictionaryData* result) {
   std::shared_ptr<Dictionary> dict_ptr = instance_->dictionaries()->get(args.dictionary_name());
-  if (dict_ptr == nullptr)
+  if (dict_ptr == nullptr) {
     BOOST_THROW_EXCEPTION(InvalidOperation("Dictionary " +
-      args.dictionary_name() + " does not exist or has no tokens"));
+        args.dictionary_name() + " does not exist or has no tokens"));
+  }
   DictionaryOperations::StoreIntoDictionaryData(*dict_ptr, result);
   result->set_name(args.dictionary_name());
 }
@@ -313,15 +336,20 @@ void MasterComponent::DisposeBatch(const std::string& name) {
 
 void MasterComponent::ExportModel(const ExportModelArgs& args) {
   std::shared_ptr<MasterModelConfig> config = instance_->config();
-  if (config != nullptr)
-    if (!args.has_model_name()) const_cast<ExportModelArgs*>(&args)->set_model_name(config->pwt_name());
+  if (config != nullptr) {
+    if (!args.has_model_name()) {
+      const_cast<ExportModelArgs*>(&args)->set_model_name(config->pwt_name());
+    }
+  }
 
-  if (boost::filesystem::exists(args.file_name()))
+  if (boost::filesystem::exists(args.file_name())) {
     BOOST_THROW_EXCEPTION(DiskWriteException("File already exists: " + args.file_name()));
+  }
 
   std::ofstream fout(args.file_name(), std::ofstream::binary);
-  if (!fout.is_open())
+  if (!fout.is_open()) {
     BOOST_THROW_EXCEPTION(DiskWriteException("Unable to create file " + args.file_name()));
+  }
 
   std::shared_ptr<const PhiMatrix> phi_matrix = instance_->GetPhiMatrixSafe(args.model_name());
   const PhiMatrix& n_wt = *phi_matrix;
@@ -329,8 +357,9 @@ void MasterComponent::ExportModel(const ExportModelArgs& args) {
   LOG(INFO) << "Exporting model " << args.model_name() << " to " << args.file_name();
 
   const int token_size = n_wt.token_size();
-  if (token_size == 0)
+  if (token_size == 0) {
     BOOST_THROW_EXCEPTION(InvalidOperation("Model " + args.model_name() + " has no tokens, export failed"));
+  }
 
   int tokens_per_chunk = std::min<int>(token_size, 100 * 1024 * 1024 / n_wt.topic_size());
 
@@ -365,12 +394,16 @@ void MasterComponent::ExportModel(const ExportModelArgs& args) {
 
 void MasterComponent::ImportModel(const ImportModelArgs& args) {
   std::shared_ptr<MasterModelConfig> config = instance_->config();
-  if (config != nullptr)
-    if (!args.has_model_name()) const_cast<ImportModelArgs*>(&args)->set_model_name(config->pwt_name());
+  if (config != nullptr) {
+    if (!args.has_model_name()) {
+      const_cast<ImportModelArgs*>(&args)->set_model_name(config->pwt_name());
+    }
+  }
 
   std::ifstream fin(args.file_name(), std::ifstream::binary);
-  if (!fin.is_open())
+  if (!fin.is_open()) {
     BOOST_THROW_EXCEPTION(DiskReadException("Unable to open file " + args.file_name()));
+  }
 
   LOG(INFO) << "Importing model " << args.model_name() << " from " << args.file_name();
 
@@ -386,45 +419,52 @@ void MasterComponent::ImportModel(const ImportModelArgs& args) {
   while (!fin.eof()) {
     int length;
     fin >> length;
-    if (fin.eof())
+    if (fin.eof()) {
       break;
+    }
 
-    if (length <= 0)
+    if (length <= 0) {
       BOOST_THROW_EXCEPTION(CorruptedMessageException(
-        "Unable to read from " + args.file_name() + ": message has negative length"));
+          "Unable to read from " + args.file_name() + ": message has negative length"));
+    }
 
     std::string buffer(length, '\0');
     fin.read(&buffer[0], length);
     ::artm::TopicModel topic_model;
-    if (!topic_model.ParseFromArray(buffer.c_str(), length))
+    if (!topic_model.ParseFromArray(buffer.c_str(), length)) {
       BOOST_THROW_EXCEPTION(CorruptedMessageException(
-        "Unable to read from " + args.file_name() + ": message parsing failed"));
+          "Unable to read from " + args.file_name() + ": message parsing failed"));
+    }
 
     topic_model.set_name(args.model_name());
 
-    if (target == nullptr)
+    if (target == nullptr) {
       target = std::make_shared<DensePhiMatrix>(args.model_name(), topic_model.topic_name());
+    }
 
     PhiMatrixOperations::ApplyTopicModelOperation(topic_model, 1.0f, /* add_missing_tokens = */ true, target.get());
   }
 
   fin.close();
 
-  if (target == nullptr)
+  if (target == nullptr) {
     BOOST_THROW_EXCEPTION(CorruptedMessageException("Unable to read from " + args.file_name()));
+  }
 
   instance_->SetPhiMatrix(args.model_name(), target);
   LOG(INFO) << "Import of model completed, token_size = " << target->token_size()
-    << ", topic_size = " << target->topic_size();
+            << ", topic_size = " << target->topic_size();
 }
 
 void MasterComponent::ExportScoreTracker(const ExportScoreTrackerArgs& args) {
-  if (boost::filesystem::exists(args.file_name()))
+  if (boost::filesystem::exists(args.file_name())) {
     BOOST_THROW_EXCEPTION(DiskWriteException("File already exists: " + args.file_name()));
+  }
 
   std::ofstream fout(args.file_name(), std::ofstream::binary);
-  if (!fout.is_open())
+  if (!fout.is_open()) {
     BOOST_THROW_EXCEPTION(DiskWriteException("Unable to create file " + args.file_name()));
+  }
 
   LOG(INFO) << "Exporting score tracker to " << args.file_name();
 
@@ -444,8 +484,9 @@ void MasterComponent::ExportScoreTracker(const ExportScoreTrackerArgs& args) {
 
 void MasterComponent::ImportScoreTracker(const ImportScoreTrackerArgs& args) {
   std::ifstream fin(args.file_name(), std::ifstream::binary);
-  if (!fin.is_open())
+  if (!fin.is_open()) {
     BOOST_THROW_EXCEPTION(DiskReadException("Unable to open file " + args.file_name()));
+  }
 
   LOG(INFO) << "Importing score tracker from " << args.file_name();
 
@@ -461,19 +502,22 @@ void MasterComponent::ImportScoreTracker(const ImportScoreTrackerArgs& args) {
   while (!fin.eof()) {
     int length;
     fin >> length;
-    if (fin.eof())
+    if (fin.eof()) {
       break;
+    }
 
-    if (length <= 0)
+    if (length <= 0) {
       BOOST_THROW_EXCEPTION(CorruptedMessageException(
-        "Unable to read from " + args.file_name() + ": message has negative length"));
+          "Unable to read from " + args.file_name() + ": message has negative length"));
+    }
 
     std::string buffer(length, '\0');
     fin.read(&buffer[0], length);
     ::artm::ScoreData score_data;
-    if (!score_data.ParseFromArray(buffer.c_str(), length))
+    if (!score_data.ParseFromArray(buffer.c_str(), length)) {
       BOOST_THROW_EXCEPTION(CorruptedMessageException(
-        "Unable to read from " + args.file_name() + ": message parsing failed"));
+          "Unable to read from " + args.file_name() + ": message parsing failed"));
+    }
 
     auto ptr = instance_->score_tracker()->Add();
     ptr->CopyFrom(score_data);
@@ -491,8 +535,9 @@ void MasterComponent::AttachModel(const AttachModelArgs& args, int address_lengt
   std::shared_ptr<const PhiMatrix> phi_matrix = instance_->GetPhiMatrixSafe(model_name);
 
   PhiMatrixFrame* frame = dynamic_cast<PhiMatrixFrame*>(const_cast<PhiMatrix*>(phi_matrix.get()));
-  if (frame == nullptr)
+  if (frame == nullptr) {
     BOOST_THROW_EXCEPTION(InvalidOperation("Unable to attach to model " + model_name));
+  }
 
   std::shared_ptr<AttachedPhiMatrix> attached = std::make_shared<AttachedPhiMatrix>(address_length, address, frame);
   instance_->SetPhiMatrix(model_name, attached);
@@ -502,8 +547,12 @@ void MasterComponent::InitializeModel(const InitializeModelArgs& args) {
   std::shared_ptr<MasterModelConfig> config = instance_->config();
   if (config != nullptr) {
     InitializeModelArgs* mutable_args = const_cast<InitializeModelArgs*>(&args);
-    if (!args.has_model_name()) mutable_args->set_model_name(config->pwt_name());
-    if (args.topic_name_size() == 0) mutable_args->mutable_topic_name()->CopyFrom(config->topic_name());
+    if (!args.has_model_name()) {
+      mutable_args->set_model_name(config->pwt_name());
+    }
+    if (args.topic_name_size() == 0) {
+      mutable_args->mutable_topic_name()->CopyFrom(config->topic_name());
+    }
     FixMessage(mutable_args);
   }
 
@@ -526,8 +575,9 @@ void MasterComponent::InitializeModel(const InitializeModelArgs& args) {
     new_ttm = std::make_shared< ::artm::core::DensePhiMatrix>(args.model_name(), args.topic_name());
     for (int index = 0; index < (int64_t) dict->size(); ++index) {
       ::artm::core::Token token = dict->entry(index)->token();
-      if (config->class_id_size() > 0 && !is_member(token.class_id, config->class_id()))
+      if (config->class_id_size() > 0 && !is_member(token.class_id, config->class_id())) {
         continue;
+      }
       new_ttm->AddToken(token);
     }
 
@@ -576,7 +626,7 @@ void MasterComponent::FilterDictionary(const FilterDictionaryArgs& args) {
   auto src_dictionary_ptr = instance_->dictionaries()->get(args.dictionary_name());
   if (src_dictionary_ptr == nullptr) {
     LOG(ERROR) << "Dictionary::Filter(): filter was requested for non-exists dictionary '"
-      << args.dictionary_name() << "', operation was aborted";
+               << args.dictionary_name() << "', operation was aborted";
   }
 
   AddDictionary(DictionaryOperations::Filter(args, *src_dictionary_ptr));
@@ -600,8 +650,11 @@ void MasterComponent::ReconfigureTopicName(const MasterModelConfig& config) {
 
 void MasterComponent::Request(const GetTopicModelArgs& args, ::artm::TopicModel* result) {
   std::shared_ptr<MasterModelConfig> config = instance_->config();
-  if (config != nullptr)
-    if (!args.has_model_name()) const_cast<GetTopicModelArgs*>(&args)->set_model_name(config->pwt_name());
+  if (config != nullptr) {
+    if (!args.has_model_name()) {
+      const_cast<GetTopicModelArgs*>(&args)->set_model_name(config->pwt_name());
+    }
+  }
 
   auto phi_matrix = instance_->GetPhiMatrixSafe(args.model_name());
   PhiMatrixOperations::RetrieveExternalTopicModel(*phi_matrix, args, result);
@@ -609,10 +662,11 @@ void MasterComponent::Request(const GetTopicModelArgs& args, ::artm::TopicModel*
 
 void MasterComponent::Request(const GetTopicModelArgs& args, ::artm::TopicModel* result, std::string* external) {
   Request(args, result);
-  if (args.matrix_layout() == artm::MatrixLayout_Sparse)
+  if (args.matrix_layout() == artm::MatrixLayout_Sparse) {
     HandleSparseTopicModelRequest(result, external);
-  else
+  } else {
     HandleExternalTopicModelRequest(result, external);
+  }
 }
 
 void MasterComponent::Request(const GetScoreValueArgs& args, ScoreData* result) {
@@ -637,15 +691,17 @@ void MasterComponent::Request(const ProcessBatchesArgs& args, ProcessBatchesResu
   const bool is_dense_theta = args.theta_matrix_type() == artm::ThetaMatrixType_Dense;
   const bool is_dense_ptdw = args.theta_matrix_type() == artm::ThetaMatrixType_DensePtdw;
   const bool is_sparse_theta = args.theta_matrix_type() == artm::ThetaMatrixType_Sparse;
-  if (!is_dense_theta && !is_dense_ptdw && !is_sparse_theta)
+  if (!is_dense_theta && !is_dense_ptdw && !is_sparse_theta) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
-      "Dense or Sparse matrix format is required for ArtmRequestProcessBatchesExternal"));
+        "Dense or Sparse matrix format is required for ArtmRequestProcessBatchesExternal"));
+  }
 
   Request(args, result);
-  if (is_sparse_theta)
+  if (is_sparse_theta) {
     HandleSparseThetaMatrixRequest(result->mutable_theta_matrix(), external);
-  else
+  } else {
     HandleExternalThetaMatrixRequest(result->mutable_theta_matrix(), external);
+  }
 }
 
 void MasterComponent::AsyncRequestProcessBatches(const ProcessBatchesArgs& process_batches_args,
@@ -661,26 +717,29 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
   const ProcessBatchesArgs& args = process_batches_args;  // short notation
   ModelName model_name = args.pwt_source_name();
 
-  if (instance_->processor_size() <= 0)
+  if (instance_->processor_size() <= 0) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
-    "Can't process batches because there are no processors. Check your MasterModelConfig.num_processors setting."));
+        "Can't process batches because there are no processors. Check  MasterModelConfig.num_processors setting."));
+  }
 
   std::shared_ptr<const PhiMatrix> phi_matrix = instance_->GetPhiMatrixSafe(model_name);
   const PhiMatrix& p_wt = *phi_matrix;
   const_cast<ProcessBatchesArgs*>(&args)->mutable_topic_name()->CopyFrom(p_wt.topic_name());
   if (args.has_nwt_target_name()) {
-    if (args.nwt_target_name() == args.pwt_source_name())
+    if (args.nwt_target_name() == args.pwt_source_name()) {
       BOOST_THROW_EXCEPTION(InvalidOperation(
-        "ProcessBatchesArgs.pwt_source_name == ProcessBatchesArgs.nwt_target_name"));
+          "ProcessBatchesArgs.pwt_source_name == ProcessBatchesArgs.nwt_target_name"));
+    }
 
     auto nwt_target(std::make_shared<DensePhiMatrix>(args.nwt_target_name(), p_wt.topic_name()));
     nwt_target->Reshape(p_wt);
     instance_->SetPhiMatrix(args.nwt_target_name(), nwt_target);
   }
 
-  if (async && args.theta_matrix_type() != ThetaMatrixType_None)
+  if (async && args.theta_matrix_type() != ThetaMatrixType_None) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
-    "ArtmAsyncProcessBatches require ProcessBatchesArgs.theta_matrix_type to be set to None"));
+        "ArtmAsyncProcessBatches require ProcessBatchesArgs.theta_matrix_type to be set to None"));
+  }
 
   // The code below must not use cache_manger in async mode.
   // Since cache_manager lives on stack it will be destroyed once we return from this function.
@@ -694,8 +753,9 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
   CacheManager* theta_cache_manager_ptr = nullptr;
   switch (args.theta_matrix_type()) {
     case ThetaMatrixType_Cache:
-      if (instance_->config()->cache_theta())
+      if (instance_->config()->cache_theta()) {
         theta_cache_manager_ptr = instance_->cache_manager();
+      }
       break;
     case ThetaMatrixType_Dense:
     case ThetaMatrixType_Sparse:
@@ -728,11 +788,13 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
     pi->mutable_args()->CopyFrom(args);
     pi->set_task_id(task_id);
 
-    if (args.reuse_theta())
+    if (args.reuse_theta()) {
       pi->set_reuse_theta_cache_manager(instance_->cache_manager());
+    }
 
-    if (args.has_nwt_target_name())
+    if (args.has_nwt_target_name()) {
       pi->set_nwt_target_name(args.nwt_target_name());
+    }
 
     return pi;
   };
@@ -753,8 +815,9 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
     instance_->processor_queue()->push(pi);
   }
 
-  if (async)
+  if (async) {
     return;
+  }
 
   while (!batch_manager->IsEverythingProcessed()) {
     boost::this_thread::sleep(boost::posix_time::milliseconds(kIdleLoopFrequency));
@@ -772,22 +835,27 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
       break;
   }
 
-  if (theta_matrix != nullptr && args.has_theta_matrix_type())
+  if (theta_matrix != nullptr && args.has_theta_matrix_type()) {
     cache_manager.RequestThetaMatrix(get_theta_matrix_args, theta_matrix);
+  }
 }
 
 void MasterComponent::MergeModel(const MergeModelArgs& merge_model_args) {
   VLOG(0) << "MasterComponent: start merging models";
-  if (merge_model_args.nwt_source_name_size() == 0)
+  if (merge_model_args.nwt_source_name_size() == 0) {
     BOOST_THROW_EXCEPTION(InvalidOperation("MergeModelArgs.nwt_source_name must not be empty"));
-  if (merge_model_args.nwt_source_name_size() != merge_model_args.source_weight_size())
+  }
+  if (merge_model_args.nwt_source_name_size() != merge_model_args.source_weight_size()) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
-      "MergeModelArgs.nwt_source_name_size() != MergeModelArgs.source_weight_size()"));
+        "MergeModelArgs.nwt_source_name_size() != MergeModelArgs.source_weight_size()"));
+  }
 
   std::shared_ptr<MasterModelConfig> config = instance_->config();
   if (config != nullptr) {
     MergeModelArgs* mutable_args = const_cast<MergeModelArgs*>(&merge_model_args);
-    if (merge_model_args.topic_name_size() == 0) mutable_args->mutable_topic_name()->CopyFrom(config->topic_name());
+    if (merge_model_args.topic_name_size() == 0) {
+      mutable_args->mutable_topic_name()->CopyFrom(config->topic_name());
+    }
     FixMessage(mutable_args);
   }
 
@@ -814,9 +882,9 @@ void MasterComponent::MergeModel(const MergeModelArgs& merge_model_args) {
         merge_model_args.dictionary_name() + " does not exist or has no tokens"));
     }
 
-    for (int token_index = 0; token_index < (int64_t) dictionary->size();
-            token_index++)
+    for (int token_index = 0; token_index < (int64_t) dictionary->size(); ++token_index) {
       nwt_target->AddToken(dictionary->entry(token_index)->token());
+    }
   }
 
   std::stringstream ss;
@@ -841,10 +909,11 @@ void MasterComponent::MergeModel(const MergeModelArgs& merge_model_args) {
     }
   }
 
-  if (nwt_target == nullptr)
+  if (nwt_target == nullptr) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
-      "ArtmMergeModel() have not found any models to merge. "
-      "Verify that at least one of the following models exist: " + ss.str()));
+        "ArtmMergeModel() have not found any models to merge. "
+        "Verify that at least one of the following models exist: " + ss.str()));
+  }
   instance_->SetPhiMatrix(merge_model_args.nwt_target_name(), nwt_target);
   VLOG(0) << "MasterComponent: complete merging models";
 }
@@ -855,12 +924,15 @@ void MasterComponent::RegularizeModel(const RegularizeModelArgs& regularize_mode
   const std::string& nwt_source_name = regularize_model_args.nwt_source_name();
   const std::string& rwt_target_name = regularize_model_args.rwt_target_name();
 
-  if (!regularize_model_args.has_pwt_source_name())
+  if (!regularize_model_args.has_pwt_source_name()) {
     BOOST_THROW_EXCEPTION(InvalidOperation("RegularizeModelArgs.pwt_source_name is missing"));
-  if (!regularize_model_args.has_nwt_source_name())
+  }
+  if (!regularize_model_args.has_nwt_source_name()) {
     BOOST_THROW_EXCEPTION(InvalidOperation("RegularizeModelArgs.nwt_source_name is missing"));
-  if (!regularize_model_args.has_rwt_target_name())
+  }
+  if (!regularize_model_args.has_rwt_target_name()) {
     BOOST_THROW_EXCEPTION(InvalidOperation("RegularizeModelArgs.rwt_target_name is missing"));
+  }
 
   std::shared_ptr<const PhiMatrix> nwt_phi_matrix = instance_->GetPhiMatrixSafe(nwt_source_name);
   const PhiMatrix& n_wt = *nwt_phi_matrix;
@@ -882,30 +954,37 @@ void MasterComponent::NormalizeModel(const NormalizeModelArgs& normalize_model_a
   const std::string& nwt_source_name = normalize_model_args.nwt_source_name();
   const std::string& rwt_source_name = normalize_model_args.rwt_source_name();
 
-  if (!normalize_model_args.has_pwt_target_name())
+  if (!normalize_model_args.has_pwt_target_name()) {
     BOOST_THROW_EXCEPTION(InvalidOperation("NormalizeModelArgs.pwt_target_name is missing"));
-  if (!normalize_model_args.has_nwt_source_name())
+  }
+  if (!normalize_model_args.has_nwt_source_name()) {
     BOOST_THROW_EXCEPTION(InvalidOperation("NormalizeModelArgs.pwt_target_name is missing"));
+  }
 
   std::shared_ptr<const PhiMatrix> nwt_phi_matrix = instance_->GetPhiMatrixSafe(nwt_source_name);
   const PhiMatrix& n_wt = *nwt_phi_matrix;
 
   std::shared_ptr<const PhiMatrix> rwt_phi_matrix;
-  if (normalize_model_args.has_rwt_source_name())
+  if (normalize_model_args.has_rwt_source_name()) {
     rwt_phi_matrix = instance_->GetPhiMatrixSafe(rwt_source_name);
+  }
 
   auto pwt_target(std::make_shared<DensePhiMatrix>(pwt_target_name, n_wt.topic_name()));
   pwt_target->Reshape(n_wt);
-  if (rwt_phi_matrix == nullptr) PhiMatrixOperations::FindPwt(n_wt, pwt_target.get());
-  else                           PhiMatrixOperations::FindPwt(n_wt, *rwt_phi_matrix, pwt_target.get());
+  if (rwt_phi_matrix == nullptr) {
+    PhiMatrixOperations::FindPwt(n_wt, pwt_target.get());
+  } else {
+    PhiMatrixOperations::FindPwt(n_wt, *rwt_phi_matrix, pwt_target.get());
+  }
   instance_->SetPhiMatrix(pwt_target_name, pwt_target);
   VLOG(0) << "MasterComponent: complete normalizing model " << normalize_model_args.nwt_source_name();
 }
 
 void MasterComponent::OverwriteTopicModel(const ::artm::TopicModel& args) {
   std::shared_ptr<MasterModelConfig> config = instance_->config();
-  if (config != nullptr)
-    if (!args.has_name()) const_cast< ::artm::TopicModel*>(&args)->set_name(config->pwt_name());
+  if (config != nullptr && !args.has_name()) {
+    const_cast< ::artm::TopicModel*>(&args)->set_name(config->pwt_name());
+  }
 
   auto target = std::make_shared<DensePhiMatrix>(args.name(), args.topic_name());
   PhiMatrixOperations::ApplyTopicModelOperation(args, 1.0f, /* add_missing_tokens = */ true, target.get());
@@ -924,57 +1003,72 @@ static void ValidateProcessedItems(std::string method_description, MasterCompone
   ::artm::ItemsProcessedScore items_processed;
   items_processed.ParseFromString(items_processed_data.data());
   LOG(INFO) << method_description << ": " << DescribeMessage(items_processed);
-  if (items_processed.num_batches() == 0)
+
+  if (items_processed.num_batches() == 0) {
     BOOST_THROW_EXCEPTION(InvalidOperation(method_description + ": no batches to process"));
-  if (items_processed.value() == 0)
+  }
+  if (items_processed.value() == 0) {
     BOOST_THROW_EXCEPTION(InvalidOperation(method_description + ": no items to process --- all batches were empty"));
-  if (items_processed.token_weight() == 0)
+  }
+  if (items_processed.token_weight() == 0) {
     BOOST_THROW_EXCEPTION(InvalidOperation(method_description + ": no tokens to process --- all items were empty"));
-  if (items_processed.token_weight_in_effect() == 0)
+  }
+  if (items_processed.token_weight_in_effect() == 0) {
     BOOST_THROW_EXCEPTION(InvalidOperation(method_description +
-      ": no tokens in effect --- either tokens not present in the model, or tokens were ignored due to class_id"));
+        ": no tokens in effect --- either tokens not present in the model, or tokens were ignored due to class_id"));
+  }
 }
 
 void MasterComponent::Request(const GetThetaMatrixArgs& args,
                               ::artm::ThetaMatrix* result,
                               std::string* external) {
   Request(args, result);
-  if (args.matrix_layout() == artm::MatrixLayout_Sparse)
+  if (args.matrix_layout() == artm::MatrixLayout_Sparse) {
     HandleSparseThetaMatrixRequest(result, external);
-  else
+  } else {
     HandleExternalThetaMatrixRequest(result, external);
+  }
 }
 
 // ToDo(sashafrey): what should be the default cache policy for TransformMasterModel?
 //                  Currently it saves the result in the cache. The result is then empty...
 void MasterComponent::Request(const TransformMasterModelArgs& args, ::artm::ThetaMatrix* result) {
   std::shared_ptr<MasterModelConfig> config = instance_->config();
-  if (config == nullptr)
+  if (config == nullptr) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
-    "Invalid master_id; use ArtmCreateMasterModel instead of ArtmCreateMasterComponent"));
+        "Invalid master_id; use ArtmCreateMasterModel instead of ArtmCreateMasterComponent"));
+  }
 
-  if (args.theta_matrix_type() == ThetaMatrixType_Cache)
+  if (args.theta_matrix_type() == ThetaMatrixType_Cache) {
     ClearThetaCache(ClearThetaCacheArgs());
+  }
   ClearScoreCache(ClearScoreCacheArgs());
 
   ProcessBatchesArgs process_batches_args;
   process_batches_args.mutable_batch_filename()->CopyFrom(args.batch_filename());
   process_batches_args.mutable_batch()->CopyFrom(args.batch());
   process_batches_args.set_pwt_source_name(config->pwt_name());
-  if (config->has_num_document_passes())
+  if (config->has_num_document_passes()) {
     process_batches_args.set_num_document_passes(config->num_document_passes());
-  for (auto& regularizer : config->regularizer_config()) {
+  }
+  for (const auto& regularizer : config->regularizer_config()) {
     process_batches_args.add_regularizer_name(regularizer.name());
     process_batches_args.add_regularizer_tau(regularizer.tau());
   }
 
-  if (config->has_opt_for_avx()) process_batches_args.set_opt_for_avx(config->opt_for_avx());
-  if (config->has_reuse_theta()) process_batches_args.set_reuse_theta(config->reuse_theta());
+  if (config->has_opt_for_avx()) {
+    process_batches_args.set_opt_for_avx(config->opt_for_avx());
+  }
+  if (config->has_reuse_theta()) {
+    process_batches_args.set_reuse_theta(config->reuse_theta());
+  }
 
   process_batches_args.mutable_class_id()->CopyFrom(config->class_id());
   process_batches_args.mutable_class_weight()->CopyFrom(config->class_weight());
   process_batches_args.set_theta_matrix_type(args.theta_matrix_type());
-  if (args.has_predict_class_id()) process_batches_args.set_predict_class_id(args.predict_class_id());
+  if (args.has_predict_class_id()) {
+    process_batches_args.set_predict_class_id(args.predict_class_id());
+  }
 
   FixMessage(&process_batches_args);
 
@@ -990,20 +1084,22 @@ void MasterComponent::Request(const TransformMasterModelArgs& args,
   const bool is_dense_theta = args.theta_matrix_type() == artm::ThetaMatrixType_Dense;
   const bool is_dense_ptdw = args.theta_matrix_type() == artm::ThetaMatrixType_DensePtdw;
   const bool is_sparse_theta = args.theta_matrix_type() == artm::ThetaMatrixType_Sparse;
-  if (!is_dense_theta && !is_dense_ptdw && !is_sparse_theta)
+  if (!is_dense_theta && !is_dense_ptdw && !is_sparse_theta) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
-      "Dense or sparse matrix format is required for ArtmRequestProcessBatchesExternal"));
+        "Dense or sparse matrix format is required for ArtmRequestProcessBatchesExternal"));
+  }
 
   Request(args, result);
-  if (is_sparse_theta)
+  if (is_sparse_theta) {
     HandleSparseThetaMatrixRequest(result, external);
-  else
+  } else {
     HandleExternalThetaMatrixRequest(result, external);
+  }
 }
 
 class BatchesIterator {
  public:
-  virtual ~BatchesIterator() {}
+  virtual ~BatchesIterator() { }
   virtual void move(ProcessBatchesArgs* args) = 0;
 };
 
@@ -1011,10 +1107,10 @@ class OfflineBatchesIterator : public BatchesIterator {
  public:
   OfflineBatchesIterator(const ::google::protobuf::RepeatedPtrField<std::string>& batch_filename,
                          const ::google::protobuf::RepeatedField<float>& batch_weight)
-      : batch_filename_(batch_filename),
-        batch_weight_(batch_weight) {}
+      : batch_filename_(batch_filename)
+      , batch_weight_(batch_weight) { }
 
-  virtual ~OfflineBatchesIterator() {}
+  virtual ~OfflineBatchesIterator() { }
 
  private:
   const ::google::protobuf::RepeatedPtrField<std::string>& batch_filename_;
@@ -1033,14 +1129,14 @@ class OnlineBatchesIterator : public BatchesIterator {
                         const ::google::protobuf::RepeatedField<int>& update_after,
                         const ::google::protobuf::RepeatedField<float>& apply_weight,
                         const ::google::protobuf::RepeatedField<float>& decay_weight)
-      : batch_filename_(batch_filename),
-        batch_weight_(batch_weight),
-        update_after_(update_after),
-        apply_weight_(apply_weight),
-        decay_weight_(decay_weight),
-        current_(0) {}
+      : batch_filename_(batch_filename)
+      , batch_weight_(batch_weight)
+      , update_after_(update_after)
+      , apply_weight_(apply_weight)
+      , decay_weight_(decay_weight)
+      , current_(0) { }
 
-  virtual ~OnlineBatchesIterator() {}
+  virtual ~OnlineBatchesIterator() { }
 
   bool more() const { return current_ < static_cast<int>(update_after_.size()); }
 
@@ -1048,8 +1144,9 @@ class OnlineBatchesIterator : public BatchesIterator {
     args->clear_batch_filename();
     args->clear_batch_weight();
 
-    if (static_cast<int>(current_) >= update_after_.size())
+    if (static_cast<int>(current_) >= update_after_.size()) {
       return;
+    }
 
     unsigned first = (current_ == 0) ? 0 : update_after_.Get(current_ - 1);
     unsigned last = update_after_.Get(current_);
@@ -1082,8 +1179,8 @@ class OnlineBatchesIterator : public BatchesIterator {
 
 class StringIndex {
  public:
-  explicit StringIndex(std::string prefix) : i_(0), prefix_(prefix) {}
-  StringIndex(std::string prefix, int i) : i_(i), prefix_(prefix) {}
+  explicit StringIndex(std::string prefix) : i_(0), prefix_(prefix) { }
+  StringIndex(std::string prefix, int i) : i_(i), prefix_(prefix) { }
   int get_index() { return i_; }
   operator std::string() const { return prefix_ + boost::lexical_cast<std::string>(i_); }
   StringIndex operator+(int offset) { return StringIndex(prefix_, i_ + offset); }
@@ -1104,27 +1201,33 @@ class ArtmExecutor {
         pwt_name_(master_model_config.pwt_name()),
         nwt_name_(master_model_config.nwt_name()),
         master_component_(master_component) {
-    if (master_model_config.has_num_document_passes())
+    if (master_model_config.has_num_document_passes()) {
       process_batches_args_.set_num_document_passes(master_model_config.num_document_passes());
+    }
+
     process_batches_args_.mutable_class_id()->CopyFrom(master_model_config.class_id());
     process_batches_args_.mutable_class_weight()->CopyFrom(master_model_config.class_weight());
-    for (auto& regularizer : master_model_config.regularizer_config()) {
+
+    for (const auto& regularizer : master_model_config.regularizer_config()) {
       process_batches_args_.add_regularizer_name(regularizer.name());
       process_batches_args_.add_regularizer_tau(regularizer.tau());
     }
 
-    for (auto& regularizer : master_model_config.regularizer_config()) {
+    for (const auto& regularizer : master_model_config.regularizer_config()) {
       RegularizerSettings* settings = regularize_model_args_.add_regularizer_settings();
       settings->set_tau(regularizer.tau());
       settings->set_name(regularizer.name());
-      if (regularizer.has_gamma())
+      if (regularizer.has_gamma()) {
         settings->set_gamma(regularizer.gamma());
+      }
     }
 
-    if (master_model_config.has_opt_for_avx())
+    if (master_model_config.has_opt_for_avx()) {
       process_batches_args_.set_opt_for_avx(master_model_config.opt_for_avx());
-    if (master_model_config.has_reuse_theta())
+    }
+    if (master_model_config.has_reuse_theta()) {
       process_batches_args_.set_reuse_theta(master_model_config.reuse_theta());
+    }
   }
 
   void ExecuteOfflineAlgorithm(int num_collection_passes, OfflineBatchesIterator* iter) {
@@ -1194,7 +1297,10 @@ class ArtmExecutor {
       float decay_weight = iter->decay_weight(op_id);
 
       int temp_op_id = op_id;
-      if (!is_last) op_id = AsyncProcessBatches(pwt_active, nwt_hat_index, iter);
+      if (!is_last) {
+        op_id = AsyncProcessBatches(pwt_active, nwt_hat_index, iter);
+      }
+
       Await(temp_op_id);
       Merge(nwt_name_, decay_weight, nwt_hat_index - 1, apply_weight);
       Dispose(nwt_hat_index - 1);
@@ -1204,8 +1310,12 @@ class ArtmExecutor {
       Normalize(pwt_active, nwt_name_, rwt_name);
 
       Dispose(pwt_index - 1);
-      if (is_last) Dispose(pwt_index);
-      if (is_last) break;
+      if (is_last) {
+        Dispose(pwt_index);
+      }
+      if (is_last) {
+        break;
+      }
     }
 
     iter->reset();
@@ -1272,8 +1382,10 @@ class ArtmExecutor {
 
   void Normalize(std::string pwt, std::string nwt, std::string rwt) {
     NormalizeModelArgs normalize_model_args;
-    if (regularize_model_args_.regularizer_settings_size() > 0)
+    if (regularize_model_args_.regularizer_settings_size() > 0) {
       normalize_model_args.set_rwt_source_name(rwt);
+    }
+
     normalize_model_args.set_nwt_source_name(nwt);
     normalize_model_args.set_pwt_target_name(pwt);
     LOG(INFO) << DescribeMessage(normalize_model_args);
@@ -1307,9 +1419,10 @@ class ArtmExecutor {
 
 void MasterComponent::FitOnline(const FitOnlineMasterModelArgs& args) {
   std::shared_ptr<MasterModelConfig> config = instance_->config();
-  if (config == nullptr)
+  if (config == nullptr) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
-    "Invalid master_id; use ArtmCreateMasterModel instead of ArtmCreateMasterComponent"));
+        "Invalid master_id; use ArtmCreateMasterModel instead of ArtmCreateMasterComponent"));
+  }
 
   ArtmExecutor artm_executor(*config, this);
   OnlineBatchesIterator iter(args.batch_filename(), args.batch_weight(), args.update_after(),
@@ -1325,9 +1438,10 @@ void MasterComponent::FitOnline(const FitOnlineMasterModelArgs& args) {
 
 void MasterComponent::FitOffline(const FitOfflineMasterModelArgs& args) {
   std::shared_ptr<MasterModelConfig> config = instance_->config();
-  if (config == nullptr)
+  if (config == nullptr) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
-    "Invalid master_id; use ArtmCreateMasterModel instead of ArtmCreateMasterComponent"));
+        "Invalid master_id; use ArtmCreateMasterModel instead of ArtmCreateMasterComponent"));
+  }
 
   if (args.batch_filename_size() == 0) {
     std::vector<std::string> batch_names;
@@ -1340,15 +1454,18 @@ void MasterComponent::FitOffline(const FitOfflineMasterModelArgs& args) {
           "Populate this field or provide batches via ArtmImportBatches API"));
       }
     } else {
-      for (auto& batch_path : artm::core::Helpers::ListAllBatches(args.batch_folder()))
+      for (const auto& batch_path : artm::core::Helpers::ListAllBatches(args.batch_folder())) {
         batch_names.push_back(batch_path.string());
-      if (batch_names.empty())
+      }
+      if (batch_names.empty()) {
         BOOST_THROW_EXCEPTION(InvalidOperation("No batches found in " + args.batch_folder() + " folder"));
+      }
     }
 
     FitOfflineMasterModelArgs* mutable_args = const_cast<FitOfflineMasterModelArgs*>(&args);
-    for (auto& batch_name : batch_names)
+    for (const auto& batch_name : batch_names) {
       mutable_args->add_batch_filename(batch_name);
+    }
     FixMessage(mutable_args);
   }
 

--- a/src/artm/core/master_component.cc
+++ b/src/artm/core/master_component.cc
@@ -1288,7 +1288,7 @@ class ArtmExecutor {
     }
   }
 
-  void Merge(std::string nwt, double decay_weight, std::string nwt_hat, double apply_weight) {
+  void Merge(std::string nwt, float decay_weight, std::string nwt_hat, float apply_weight) {
     MergeModelArgs merge_model_args;
     merge_model_args.add_nwt_source_name(nwt);
     merge_model_args.add_source_weight(decay_weight);

--- a/src/artm/core/master_component.h
+++ b/src/artm/core/master_component.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_MASTER_COMPONENT_H_
-#define SRC_ARTM_CORE_MASTER_COMPONENT_H_
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -122,5 +121,3 @@ class MasterComponent : boost::noncopyable {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_MASTER_COMPONENT_H_

--- a/src/artm/core/phi_matrix.h
+++ b/src/artm/core/phi_matrix.h
@@ -39,7 +39,7 @@ class PhiMatrix {
   virtual int AddToken(const Token& token) = 0;
 
   virtual std::shared_ptr<PhiMatrix> Duplicate() const = 0;
-  virtual ~PhiMatrix() {}
+  virtual ~PhiMatrix() { }
 };
 
 }  // namespace core

--- a/src/artm/core/phi_matrix.h
+++ b/src/artm/core/phi_matrix.h
@@ -1,8 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_PHI_MATRIX_H_
-#define SRC_ARTM_CORE_PHI_MATRIX_H_
-
+#pragma once
 
 #include <string>
 #include <vector>
@@ -44,9 +42,5 @@ class PhiMatrix {
   virtual ~PhiMatrix() {}
 };
 
-
 }  // namespace core
 }  // namespace artm
-
-
-#endif  // SRC_ARTM_CORE_PHI_MATRIX_H_

--- a/src/artm/core/phi_matrix_operations.cc
+++ b/src/artm/core/phi_matrix_operations.cc
@@ -212,7 +212,7 @@ void PhiMatrixOperations::InvokePhiRegularizers(
     }
 
     {
-      double tau = reg_iterator->tau();
+      float tau = reg_iterator->tau();
       bool relative_reg = reg_iterator->has_gamma();
 
       if (p_wt.token_size() != n_wt.token_size() || p_wt.topic_size() != n_wt.topic_size() ||
@@ -298,12 +298,12 @@ void PhiMatrixOperations::InvokePhiRegularizers(
           if (relative_reg) {
             if (!topics_to_regularize[topic_id]) continue;
 
-            double gamma = reg_iterator->gamma();
+            float gamma = reg_iterator->gamma();
             float n_t = iter->second.first.second[topic_id];
-            float n = iter->second.first.first;
+            double n = iter->second.first.first;
             float r_it = iter->second.second.second[topic_id];
-            float r_i = iter->second.second.first;
-            coefficient = static_cast<float>(gamma) * (n_t / r_it) + static_cast<float>(1 - gamma) * (n / r_i);
+            double r_i = iter->second.second.first;
+            coefficient = gamma * (n_t / r_it) + (1 - gamma) * static_cast<float>(n / r_i);
           }
           // update global r_wt using coefficient and tau
           float increment = coefficient * tau * local_r_wt.get(token_id, topic_id);

--- a/src/artm/core/phi_matrix_operations.cc
+++ b/src/artm/core/phi_matrix_operations.cc
@@ -138,7 +138,7 @@ void PhiMatrixOperations::ApplyTopicModelOperation(const ::artm::TopicModel& top
       int index = repeated_field_index_of(phi_matrix->topic_name(), topic_name);
       target_topic_index.push_back(index);
       if (index != -1) {
-        ok = true; 
+        ok = true;
       }
     }
     if (!ok) {
@@ -179,14 +179,14 @@ void PhiMatrixOperations::ApplyTopicModelOperation(const ::artm::TopicModel& top
       if (current_token_id == -1) {
         if (!add_missing_tokens) {
           continue;
-	}
+        }
         current_token_id = phi_matrix->AddToken(token);
       }
 
       if (optimized_execution && !has_sparse_format_local && (counters.value_size() == this_topic_size)) {
         for (int topic_index = 0; topic_index < this_topic_size; ++topic_index) {
           phi_matrix->increase(current_token_id, topic_index, counters.value(topic_index));
-	}
+        }
         continue;
       }
 
@@ -195,7 +195,7 @@ void PhiMatrixOperations::ApplyTopicModelOperation(const ::artm::TopicModel& top
         assert(topic_index < target_topic_index.size());
         if (target_topic_index[topic_index] == -1) {
           continue;
-	}
+        }
         phi_matrix->increase(current_token_id, target_topic_index[topic_index], apply_weight * counters.value(i));
       }
     }
@@ -256,17 +256,16 @@ void PhiMatrixOperations::InvokePhiRegularizers(
           auto class_ids_to_regularize = regularizer->class_ids_to_regularize();
           for (const auto& class_id : class_ids_to_regularize) {
             class_ids.push_back(class_id);
-	  }
+          }
         } else {
           boost::copy(n_t_all | boost::adaptors::map_keys, std::back_inserter(class_ids));
         }
 
         if (regularizer->topics_to_regularize().size() > 0) {
           topics_to_regularize = core::is_member(n_wt.topic_name(), regularizer->topics_to_regularize());
-	}
-        else {
+        } else {
           topics_to_regularize.assign(topic_size, true);
-	}
+        }
 
         for (const auto& class_id : class_ids) {
           auto iter = n_t_all.find(class_id);

--- a/src/artm/core/phi_matrix_operations.h
+++ b/src/artm/core/phi_matrix_operations.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_PHI_MATRIX_OPERATIONS_H_
-#define SRC_ARTM_CORE_PHI_MATRIX_OPERATIONS_H_
+#pragma once
 
 #include <map>
 #include <vector>
@@ -48,5 +47,3 @@ class PhiMatrixOperations {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_PHI_MATRIX_OPERATIONS_H_

--- a/src/artm/core/processor.cc
+++ b/src/artm/core/processor.cc
@@ -284,7 +284,7 @@ CreateRegularizerAgents(const Batch& batch, const ProcessBatchesArgs& args, Inst
                         RegularizeThetaAgentCollection* theta_agents, RegularizePtdwAgentCollection* ptdw_agents) {
   for (int reg_index = 0; reg_index < args.regularizer_name_size(); ++reg_index) {
     auto& reg_name = args.regularizer_name(reg_index);
-    double tau = args.regularizer_tau(reg_index);
+    float tau = args.regularizer_tau(reg_index);
     auto regularizer = instance->regularizers()->get(reg_name);
     if (regularizer == nullptr) {
       LOG(ERROR) << "Theta Regularizer with name <" << reg_name << "> does not exist.";

--- a/src/artm/core/processor.cc
+++ b/src/artm/core/processor.cc
@@ -51,20 +51,23 @@ class RegularizeThetaAgentCollection : public RegularizeThetaAgent {
 
  public:
   void AddAgent(std::shared_ptr<RegularizeThetaAgent> agent) {
-    if (agent != nullptr)
+    if (agent != nullptr) {
       agents_.push_back(agent);
+    }
   }
 
   bool empty() const { return agents_.empty(); }
 
   virtual void Apply(int item_index, int inner_iter, int topics_size, const float* n_td, float* r_td) const {
-    for (auto& agent : agents_)
+    for (auto& agent : agents_) {
       agent->Apply(item_index, inner_iter, topics_size, n_td, r_td);
+    }
   }
 
   virtual void Apply(int inner_iter, const LocalThetaMatrix<float>& n_td, LocalThetaMatrix<float>* r_td) const {
-    for (auto& agent : agents_)
+    for (auto& agent : agents_) {
       agent->Apply(inner_iter, n_td, r_td);
+    }
   }
 };
 
@@ -74,15 +77,17 @@ class RegularizePtdwAgentCollection : public RegularizePtdwAgent {
 
  public:
   void AddAgent(std::shared_ptr<RegularizePtdwAgent> agent) {
-    if (agent != nullptr)
+    if (agent != nullptr) {
       agents_.push_back(agent);
+    }
   }
 
   bool empty() const { return agents_.empty(); }
 
   virtual void Apply(int item_index, int inner_iter, LocalPhiMatrix<float>* ptdw) const {
-    for (auto& agent : agents_)
+    for (auto& agent : agents_) {
       agent->Apply(item_index, inner_iter, ptdw);
+    }
   }
 };
 
@@ -92,14 +97,17 @@ class NormalizeThetaAgent : public RegularizeThetaAgent {
     float sum = 0.0f;
     for (int topic_index = 0; topic_index < topics_size; ++topic_index) {
       float val = n_td[topic_index] + r_td[topic_index];
-      if (val > 0)
+      if (val > 0) {
         sum += val;
+      }
     }
 
     float sum_inv = sum > 0.0f ? (1.0f / sum) : 0.0f;
     for (int topic_index = 0; topic_index < topics_size; ++topic_index) {
       float val = sum_inv * (n_td[topic_index] + r_td[topic_index]);
-      if (val < 1e-16f) val = 0.0f;
+      if (val < 1e-16f) {
+        val = 0.0f;
+      }
 
       // Hack-hack, write normalized values back to n_td
       const_cast<float*>(n_td)[topic_index] = val;
@@ -112,7 +120,9 @@ static void CreateThetaCacheEntry(ThetaMatrix* new_cache_entry_ptr,
                                   const Batch& batch,
                                   const PhiMatrix& p_wt,
                                   const ProcessBatchesArgs& args) {
-  if (new_cache_entry_ptr == nullptr) return;
+  if (new_cache_entry_ptr == nullptr) {
+    return;
+  }
 
   const int topic_size = p_wt.topic_size();
   for (int item_index = 0; item_index < batch.item_size(); ++item_index) {
@@ -132,14 +142,16 @@ static void CreateThetaCacheEntry(ThetaMatrix* new_cache_entry_ptr,
     new_cache_entry_ptr->clear_topic_name();
     for (int token_index = 0; token_index < p_wt.token_size(); token_index++) {
       const Token& token = p_wt.token(token_index);
-      if (token.class_id != args.predict_class_id())
+      if (token.class_id != args.predict_class_id()) {
         continue;
+      }
 
       new_cache_entry_ptr->add_topic_name(token.keyword);
       for (int item_index = 0; item_index < batch.item_size(); ++item_index) {
         float weight = 0.0;
-        for (int topic_index = 0; topic_index < topic_size; ++topic_index)
+        for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
           weight += (*theta_matrix)(topic_index, item_index) * p_wt.get(token_index, topic_index);
+        }
         new_cache_entry_ptr->mutable_item_weights(item_index)->add_value(weight);
       }
     }
@@ -151,7 +163,9 @@ static void CreatePtdwCacheEntry(ThetaMatrix* new_cache_entry_ptr,
                                  const Batch& batch,
                                  int item_index,
                                  int topic_size) {
-  if (new_cache_entry_ptr == nullptr) return;
+  if (new_cache_entry_ptr == nullptr) {
+    return;
+  }
 
   const Item& item = batch.item(item_index);
   for (int token_index = 0; token_index < ptdw_matrix->num_tokens(); ++token_index) {
@@ -175,12 +189,12 @@ static void CreatePtdwCacheEntry(ThetaMatrix* new_cache_entry_ptr,
 class NwtWriteAdapter {
  public:
   virtual void Store(int batch_token_id, int pwt_token_id, const std::vector<float>& nwt_vector) = 0;
-  virtual ~NwtWriteAdapter() {}
+  virtual ~NwtWriteAdapter() { }
 };
 
 class PhiMatrixWriter : public NwtWriteAdapter {
  public:
-  explicit PhiMatrixWriter(PhiMatrix* n_wt) : n_wt_(n_wt) {}
+  explicit PhiMatrixWriter(PhiMatrix* n_wt) : n_wt_(n_wt) { }
 
   virtual void Store(int batch_token_id, int pwt_token_id, const std::vector<float>& nwt_vector) {
     assert(nwt_vector.size() == n_wt_->topic_size());
@@ -273,8 +287,9 @@ InitializePhi(const Batch& batch,
     }
   }
 
-  if (phi_is_empty)
+  if (phi_is_empty) {
     return nullptr;
+  }
 
   return phi_matrix;
 }
@@ -291,15 +306,18 @@ CreateRegularizerAgents(const Batch& batch, const ProcessBatchesArgs& args, Inst
       continue;
     }
 
-    if (theta_agents != nullptr)
+    if (theta_agents != nullptr) {
       theta_agents->AddAgent(regularizer->CreateRegularizeThetaAgent(batch, args, tau));
+    }
 
-    if (ptdw_agents != nullptr)
+    if (ptdw_agents != nullptr) {
       ptdw_agents->AddAgent(regularizer->CreateRegularizePtdwAgent(batch, args, tau));
+    }
   }
 
-  if (theta_agents != nullptr)
+  if (theta_agents != nullptr) {
     theta_agents->AddAgent(std::make_shared<NormalizeThetaAgent>());
+  }
 }
 
 static std::shared_ptr<CsrMatrix<float>>
@@ -355,8 +373,9 @@ InferThetaAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch,
   const int tokens_count = batch.token_size();
 
   std::vector<int> token_id(batch.token_size(), -1);
-  for (int token_index = 0; token_index < batch.token_size(); ++token_index)
+  for (int token_index = 0; token_index < batch.token_size(); ++token_index) {
     token_id[token_index] = p_wt.token_index(Token(batch.class_id(token_index), batch.token(token_index)));
+  }
 
   if (args.opt_for_avx()) {
   // This version is about 40% faster than the second alternative below.
@@ -387,34 +406,46 @@ InferThetaAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch,
     bool item_has_tokens = false;
     for (int i = begin_index; i < end_index; ++i) {
       int w = sparse_ndw.col_ind()[i];
-      if (token_id[w] == ::artm::core::PhiMatrix::kUndefIndex) continue;
+      if (token_id[w] == ::artm::core::PhiMatrix::kUndefIndex) {
+        continue;
+      }
       item_has_tokens = true;
       float* local_phi_ptr = &local_phi(i - begin_index, 0);
       p_wt.get(token_id[w], &helper_vector);
-      for (int k = 0; k < num_topics; ++k) local_phi_ptr[k] = helper_vector[k];
+      for (int k = 0; k < num_topics; ++k) {
+        local_phi_ptr[k] = helper_vector[k];
+      }
     }
 
-    if (!item_has_tokens) continue;  // continue to the next item
+    if (!item_has_tokens) {
+      continue;  // continue to the next item
+    }
 
     for (int inner_iter = 0; inner_iter < args.num_document_passes(); ++inner_iter) {
-      for (int k = 0; k < num_topics; ++k)
+      for (int k = 0; k < num_topics; ++k) {
         ntd_ptr[k] = 0.0f;
+      }
 
       for (int i = begin_index; i < end_index; ++i) {
         const float* phi_ptr = &local_phi(i - begin_index, 0);
 
         float p_dw_val = 0;
-        for (int k = 0; k < num_topics; ++k)
+        for (int k = 0; k < num_topics; ++k) {
           p_dw_val += phi_ptr[k] * theta_ptr[k];
-        if (p_dw_val == 0) continue;
+	}
+        if (p_dw_val == 0) {
+          continue;
+	}
 
         const float alpha = sparse_ndw.val()[i] / p_dw_val;
-        for (int k = 0; k < num_topics; ++k)
+        for (int k = 0; k < num_topics; ++k) {
           ntd_ptr[k] += alpha * phi_ptr[k];
+	}
       }
 
-      for (int k = 0; k < num_topics; ++k)
+      for (int k = 0; k < num_topics; ++k) {
         theta_ptr[k] *= ntd_ptr[k];
+      }
 
       r_td.InitializeZeros();
       theta_agents.Apply(d, inner_iter, num_topics, theta_ptr, r_td.get_data());
@@ -422,7 +453,9 @@ InferThetaAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch,
   }
   } else {
   std::shared_ptr<LocalPhiMatrix<float>> phi_matrix_ptr = InitializePhi(batch, p_wt);
-  if (phi_matrix_ptr == nullptr) return;
+  if (phi_matrix_ptr == nullptr) {
+    return;
+  }
   const LocalPhiMatrix<float>& phi_matrix = *phi_matrix_ptr;
   for (int inner_iter = 0; inner_iter < args.num_document_passes(); ++inner_iter) {
     // helper_td will represent either n_td or r_td, depending on the context - see code below
@@ -433,7 +466,9 @@ InferThetaAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch,
       for (int i = sparse_ndw.row_ptr()[d]; i < sparse_ndw.row_ptr()[d + 1]; ++i) {
         int w = sparse_ndw.col_ind()[i];
         float p_dw_val = blas->sdot(num_topics, &phi_matrix(w, 0), 1, &(*theta_matrix)(0, d), 1);  // NOLINT
-        if (p_dw_val == 0) continue;
+        if (p_dw_val == 0) {
+          continue;
+	}
         blas->saxpy(num_topics, sparse_ndw.val()[i] / p_dw_val, &phi_matrix(w, 0), 1, &helper_td(0, d), 1);
       }
     }
@@ -447,8 +482,9 @@ InferThetaAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch,
 
   CreateThetaCacheEntry(new_cache_entry_ptr, theta_matrix, batch, p_wt, args);
 
-  if (nwt_writer == nullptr)
+  if (nwt_writer == nullptr) {
     return;
+  }
 
   CsrMatrix<float> sparse_nwd(sparse_ndw);
   sparse_nwd.Transpose(blas);
@@ -456,13 +492,17 @@ InferThetaAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch,
   std::vector<float> p_wt_local(num_topics, 0.0f);
   std::vector<float> n_wt_local(num_topics, 0.0f);
   for (int w = 0; w < tokens_count; ++w) {
-    if (token_id[w] == -1) continue;
+    if (token_id[w] == -1) {
+      continue;
+    }
     p_wt.get(token_id[w], &p_wt_local);
 
     for (int i = sparse_nwd.row_ptr()[w]; i < sparse_nwd.row_ptr()[w + 1]; ++i) {
       int d = sparse_nwd.col_ind()[i];
       float p_wd_val = blas->sdot(num_topics, &p_wt_local[0], 1, &(*theta_matrix)(0, d), 1);  // NOLINT
-      if (p_wd_val == 0) continue;
+      if (p_wd_val == 0) {
+        continue;
+      }
       blas->saxpy(num_topics, sparse_nwd.val()[i] / p_wd_val,
         &(*theta_matrix)(0, d), 1, &n_wt_local[0], 1);  // NOLINT
     }
@@ -473,7 +513,9 @@ InferThetaAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch,
       n_wt_local[topic_index] = 0.0f;
     }
 
-    for (float& value : values) value *= batch_weight;
+    for (float& value : values) {
+      value *= batch_weight;
+    }
     nwt_writer->Store(w, token_id[w], values);
   }
 }
@@ -495,8 +537,9 @@ InferPtdwAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch, 
   const int docs_count = theta_matrix->num_items();
 
   std::vector<int> token_id(batch.token_size(), -1);
-  for (int token_index = 0; token_index < batch.token_size(); ++token_index)
+  for (int token_index = 0; token_index < batch.token_size(); ++token_index) {
     token_id[token_index] = p_wt.token_index(Token(batch.class_id(token_index), batch.token(token_index)));
+  }
 
   for (int d = 0; d < docs_count; ++d) {
     float* ntd_ptr = &n_td(0, d);
@@ -511,13 +554,19 @@ InferPtdwAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch, 
     bool item_has_tokens = false;
     for (int i = begin_index; i < end_index; ++i) {
       int w = sparse_ndw.col_ind()[i];
-      if (token_id[w] == ::artm::core::PhiMatrix::kUndefIndex) continue;
+      if (token_id[w] == ::artm::core::PhiMatrix::kUndefIndex) {
+        continue;
+      }
       item_has_tokens = true;
       float* local_phi_ptr = &local_phi(i - begin_index, 0);
-      for (int k = 0; k < num_topics; ++k) local_phi_ptr[k] = p_wt.get(token_id[w], k);
+      for (int k = 0; k < num_topics; ++k) {
+        local_phi_ptr[k] = p_wt.get(token_id[w], k);
+      }
     }
 
-    if (!item_has_tokens) continue;  // continue to the next item
+    if (!item_has_tokens) {
+      continue;  // continue to the next item
+    }
 
     for (int inner_iter = 0; inner_iter <= args.num_document_passes(); ++inner_iter) {
       const bool last_iteration = (inner_iter == args.num_document_passes());
@@ -532,26 +581,32 @@ InferPtdwAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch, 
           p_dw_val += p_tdw_val;
         }
 
-        if (p_dw_val == 0) continue;
+        if (p_dw_val == 0) {
+          continue;
+	}
         const float Z = 1.0f / p_dw_val;
-          for (int k = 0; k < num_topics; ++k)
-              ptdw_ptr[k] *= Z;
+        for (int k = 0; k < num_topics; ++k) {
+          ptdw_ptr[k] *= Z;
+	}
       }
 
       ptdw_agents.Apply(d, inner_iter, &local_ptdw);
 
       if (!last_iteration) {  // update theta matrix (except for the last iteration)
-        for (int k = 0; k < num_topics; ++k)
+        for (int k = 0; k < num_topics; ++k) {
           ntd_ptr[k] = 0.0f;
+	}
         for (int i = begin_index; i < end_index; ++i) {
           const float n_dw = sparse_ndw.val()[i];
           const float* ptdw_ptr = &local_ptdw(i - begin_index, 0);
-          for (int k = 0; k < num_topics; ++k)
+          for (int k = 0; k < num_topics; ++k) {
             ntd_ptr[k] += n_dw * ptdw_ptr[k];
+	  }
         }
 
-        for (int k = 0; k < num_topics; ++k)
+        for (int k = 0; k < num_topics; ++k) {
           theta_ptr[k] = ntd_ptr[k];
+	}
 
         r_td.InitializeZeros();
         theta_agents.Apply(d, inner_iter, num_topics, theta_ptr, r_td.get_data());
@@ -562,8 +617,9 @@ InferPtdwAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch, 
             const float n_dw = batch_weight * sparse_ndw.val()[i];
             const float* ptdw_ptr = &local_ptdw(i - begin_index, 0);
 
-            for (int k = 0; k < num_topics; ++k)
+            for (int k = 0; k < num_topics; ++k) {
               values[k] = ptdw_ptr[k] * n_dw;
+	    }
 
             int w = sparse_ndw.col_ind()[i];
             nwt_writer->Store(w, token_id[w], values);
@@ -579,8 +635,9 @@ InferPtdwAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch, 
 static std::shared_ptr<Score>
 CalcScores(ScoreCalculatorInterface* score_calc, const Batch& batch,
            const PhiMatrix& p_wt, const ProcessBatchesArgs& args, const LocalThetaMatrix<float>& theta_matrix) {
-  if (!score_calc->is_cumulative())
+  if (!score_calc->is_cumulative()) {
     return nullptr;
+  }
 
   std::vector<Token> token_dict;
   for (int token_index = 0; token_index < batch.token_size(); ++token_index) {
@@ -606,8 +663,9 @@ CalcScores(ScoreCalculatorInterface* score_calc, const Batch& batch,
 }
 
 bool fillTokensInBatch(const PhiMatrix& phi_matrix, Batch* batch) {
-  if (batch->token_size() > 0)
+  if (batch->token_size() > 0) {
     return true;
+  }
 
   // Verify that max token_id is compatible with topic model.
   const int token_size = phi_matrix.token_size();
@@ -702,9 +760,10 @@ void Processor::ThreadFunction() {
       const ModelName& model_name = part->model_name();
       const ProcessBatchesArgs& args = part->args();
       {
-        if (args.class_id_size() != args.class_weight_size())
+        if (args.class_id_size() != args.class_weight_size()) {
           BOOST_THROW_EXCEPTION(InternalError(
               "model.class_id_size() != model.class_weight_size()"));
+        }
 
         std::shared_ptr<const PhiMatrix> phi_matrix = instance_->GetPhiMatrix(model_name);
         if (phi_matrix == nullptr) {
@@ -735,10 +794,11 @@ void Processor::ThreadFunction() {
         }
 
         std::stringstream model_description;
-        if (part->has_nwt_target_name())
+        if (part->has_nwt_target_name()) {
           model_description << part->nwt_target_name();
-        else
+        } else {
           model_description << &p_wt;
+	}
         VLOG(0) << "Processor: start processing batch " << batch.id() << " into model " << model_description.str();
 
         std::shared_ptr<CsrMatrix<float>> sparse_ndw;
@@ -748,8 +808,9 @@ void Processor::ThreadFunction() {
         }
 
         std::shared_ptr<ThetaMatrix> cache;
-        if (part->has_reuse_theta_cache_manager())
+        if (part->has_reuse_theta_cache_manager()) {
           cache = part->reuse_theta_cache_manager()->FindCacheEntry(batch);
+	}
         std::shared_ptr<LocalThetaMatrix<float>> theta_matrix =
           InitializeTheta(p_wt.topic_size(), batch, args, cache.get());
 
@@ -760,16 +821,19 @@ void Processor::ThreadFunction() {
         }
 
         std::shared_ptr<NwtWriteAdapter> nwt_writer;
-        if (nwt_target != nullptr)
+        if (nwt_target != nullptr) {
           nwt_writer = std::make_shared<PhiMatrixWriter>(const_cast<PhiMatrix*>(nwt_target.get()));
+        }
 
         std::shared_ptr<ThetaMatrix> new_cache_entry_ptr(nullptr);
-        if (part->has_cache_manager())
+        if (part->has_cache_manager()) {
           new_cache_entry_ptr.reset(new ThetaMatrix());
+        }
 
         std::shared_ptr<ThetaMatrix> new_ptdw_cache_entry_ptr(nullptr);
-        if (part->has_ptdw_cache_manager())
+        if (part->has_ptdw_cache_manager()) {
           new_ptdw_cache_entry_ptr.reset(new ThetaMatrix());
+        }
 
         if (new_cache_entry_ptr != nullptr) {
           new_cache_entry_ptr->mutable_topic_name()->CopyFrom(p_wt.topic_name());
@@ -798,11 +862,13 @@ void Processor::ThreadFunction() {
           }
         }
 
-        if (new_cache_entry_ptr != nullptr)
+        if (new_cache_entry_ptr != nullptr) {
           part->cache_manager()->UpdateCacheEntry(batch.id(), *new_cache_entry_ptr);
+        }
 
-        if (new_ptdw_cache_entry_ptr != nullptr)
+        if (new_ptdw_cache_entry_ptr != nullptr) {
           part->ptdw_cache_manager()->UpdateCacheEntry(batch.id(), *new_ptdw_cache_entry_ptr);
+        }
 
         for (int score_index = 0; score_index < master_config->score_config_size(); ++score_index) {
           const ScoreName& score_name = master_config->score_config(score_index).name();
@@ -814,16 +880,18 @@ void Processor::ThreadFunction() {
             continue;
           }
 
-          if (!score_calc->is_cumulative())
+          if (!score_calc->is_cumulative()) {
             continue;
+          }
 
           CuckooWatch cuckoo2("CalculateScore(" + score_name + ")", &cuckoo, kTimeLoggingThreshold);
 
           auto score_value = CalcScores(score_calc.get(), batch, p_wt, args, *theta_matrix);
           if (score_value != nullptr) {
             instance_->score_manager()->Append(score_name, score_value->SerializeAsString());
-            if (part->score_manager() != nullptr)
+            if (part->score_manager() != nullptr) {
               part->score_manager()->Append(score_name, score_value->SerializeAsString());
+            }
           }
         }
 

--- a/src/artm/core/processor.cc
+++ b/src/artm/core/processor.cc
@@ -432,15 +432,15 @@ InferThetaAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch,
         float p_dw_val = 0;
         for (int k = 0; k < num_topics; ++k) {
           p_dw_val += phi_ptr[k] * theta_ptr[k];
-	}
+        }
         if (p_dw_val == 0) {
           continue;
-	}
+        }
 
         const float alpha = sparse_ndw.val()[i] / p_dw_val;
         for (int k = 0; k < num_topics; ++k) {
           ntd_ptr[k] += alpha * phi_ptr[k];
-	}
+        }
       }
 
       for (int k = 0; k < num_topics; ++k) {
@@ -468,7 +468,7 @@ InferThetaAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch,
         float p_dw_val = blas->sdot(num_topics, &phi_matrix(w, 0), 1, &(*theta_matrix)(0, d), 1);  // NOLINT
         if (p_dw_val == 0) {
           continue;
-	}
+        }
         blas->saxpy(num_topics, sparse_ndw.val()[i] / p_dw_val, &phi_matrix(w, 0), 1, &helper_td(0, d), 1);
       }
     }
@@ -583,11 +583,11 @@ InferPtdwAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch, 
 
         if (p_dw_val == 0) {
           continue;
-	}
+        }
         const float Z = 1.0f / p_dw_val;
         for (int k = 0; k < num_topics; ++k) {
           ptdw_ptr[k] *= Z;
-	}
+        }
       }
 
       ptdw_agents.Apply(d, inner_iter, &local_ptdw);
@@ -595,18 +595,18 @@ InferPtdwAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch, 
       if (!last_iteration) {  // update theta matrix (except for the last iteration)
         for (int k = 0; k < num_topics; ++k) {
           ntd_ptr[k] = 0.0f;
-	}
+        }
         for (int i = begin_index; i < end_index; ++i) {
           const float n_dw = sparse_ndw.val()[i];
           const float* ptdw_ptr = &local_ptdw(i - begin_index, 0);
           for (int k = 0; k < num_topics; ++k) {
             ntd_ptr[k] += n_dw * ptdw_ptr[k];
-	  }
+          }
         }
 
         for (int k = 0; k < num_topics; ++k) {
           theta_ptr[k] = ntd_ptr[k];
-	}
+        }
 
         r_td.InitializeZeros();
         theta_agents.Apply(d, inner_iter, num_topics, theta_ptr, r_td.get_data());
@@ -619,7 +619,7 @@ InferPtdwAndUpdateNwtSparse(const ProcessBatchesArgs& args, const Batch& batch, 
 
             for (int k = 0; k < num_topics; ++k) {
               values[k] = ptdw_ptr[k] * n_dw;
-	    }
+            }
 
             int w = sparse_ndw.col_ind()[i];
             nwt_writer->Store(w, token_id[w], values);
@@ -798,7 +798,7 @@ void Processor::ThreadFunction() {
           model_description << part->nwt_target_name();
         } else {
           model_description << &p_wt;
-	}
+        }
         VLOG(0) << "Processor: start processing batch " << batch.id() << " into model " << model_description.str();
 
         std::shared_ptr<CsrMatrix<float>> sparse_ndw;
@@ -810,7 +810,7 @@ void Processor::ThreadFunction() {
         std::shared_ptr<ThetaMatrix> cache;
         if (part->has_reuse_theta_cache_manager()) {
           cache = part->reuse_theta_cache_manager()->FindCacheEntry(batch);
-	}
+        }
         std::shared_ptr<LocalThetaMatrix<float>> theta_matrix =
           InitializeTheta(p_wt.topic_size(), batch, args, cache.get());
 

--- a/src/artm/core/processor.h
+++ b/src/artm/core/processor.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_PROCESSOR_H_
-#define SRC_ARTM_CORE_PROCESSOR_H_
+#pragma once
 
 #include <atomic>
 
@@ -36,6 +35,3 @@ class Processor : boost::noncopyable {
 
 }  // namespace core
 }  // namespace artm
-
-
-#endif  // SRC_ARTM_CORE_PROCESSOR_H_

--- a/src/artm/core/processor_input.h
+++ b/src/artm/core/processor_input.h
@@ -24,7 +24,7 @@ class ProcessorInput {
                      batch_filename_(), batch_weight_(1.0f), task_id_(), batch_manager_(nullptr),
                      score_manager_(nullptr), cache_manager_(nullptr),
                      ptdw_cache_manager_(nullptr),
-                     reuse_theta_cache_manager_(nullptr) {}
+                     reuse_theta_cache_manager_(nullptr) { }
 
   Batch* mutable_batch() { return &batch_; }
   const Batch& batch() const { return batch_; }

--- a/src/artm/core/processor_input.h
+++ b/src/artm/core/processor_input.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_PROCESSOR_INPUT_H_
-#define SRC_ARTM_CORE_PROCESSOR_INPUT_H_
+#pragma once
 
 #include <string>
 
@@ -85,5 +84,3 @@ class ProcessorInput {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_PROCESSOR_INPUT_H_

--- a/src/artm/core/protobuf_helpers.h
+++ b/src/artm/core/protobuf_helpers.h
@@ -48,12 +48,14 @@ std::vector<bool> is_member(const T& elements, const T& set) {
   retval.assign(elements.size(), false);
 
   if (elements.size() > 0) {
-    for (int j = 0; j < set.size(); ++j)
-      for (int i = 0; i < elements.size(); ++i)
+    for (int j = 0; j < set.size(); ++j) {
+      for (int i = 0; i < elements.size(); ++i) {
         if (set.Get(j) == elements.Get(i)) {
           retval[i] = true;
           break;
         }
+      }
+    }
   }
 
   return retval;
@@ -72,10 +74,14 @@ bool is_member(const V& value, const T& set) {
 
 template<class T>
 bool repeated_field_equals(const T& f1, const T& f2) {
-  if (f1.size() != f2.size()) return false;
-  for (int i = 0; i < f1.size(); i++)
-    if (f1.Get(i) != f2.Get(i))
+  if (f1.size() != f2.size()) {
+    return false;
+  }
+  for (int i = 0; i < f1.size(); i++) {
+    if (f1.Get(i) != f2.Get(i)) {
       return false;
+    }
+  }
   return true;
 }
 

--- a/src/artm/core/protobuf_helpers.h
+++ b/src/artm/core/protobuf_helpers.h
@@ -4,8 +4,7 @@
 // Most common tasks are to search for a value (or values) in a repeated protobuf field.
 // The name 'is_member' is motivated by MatLab method (http://se.mathworks.com/help/matlab/ref/ismember.html)
 
-#ifndef SRC_ARTM_CORE_PROTOBUF_HELPERS_H_
-#define SRC_ARTM_CORE_PROTOBUF_HELPERS_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -82,5 +81,3 @@ bool repeated_field_equals(const T& f1, const T& f2) {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_PROTOBUF_HELPERS_H_

--- a/src/artm/core/protobuf_serialization.cc
+++ b/src/artm/core/protobuf_serialization.cc
@@ -16,18 +16,21 @@ namespace core {
 void ProtobufSerialization::ParseFromString(const std::string& string, google::protobuf::Message* message) {
   if (use_json_format_) {
     VLOG(0) << string;
-    if (pb::util::JsonStringToMessage(string, message) != pb::util::Status::OK)
+    if (pb::util::JsonStringToMessage(string, message) != pb::util::Status::OK) {
       BOOST_THROW_EXCEPTION(::artm::core::CorruptedMessageException("Unable to parse the message from json format"));
+    }
     return;
   } else {
-    if (!message->ParseFromString(string))
+    if (!message->ParseFromString(string)) {
       BOOST_THROW_EXCEPTION(::artm::core::CorruptedMessageException("Unable to parse the message"));
+    }
   }
 }
 
 void ProtobufSerialization::ParseFromArray(const char* buffer, int64_t length, google::protobuf::Message* message) {
-  if (length < 0 || length >= 2147483647)
+  if (length < 0 || length >= 2147483647) {
     BOOST_THROW_EXCEPTION(CorruptedMessageException("Protobuf message is too long"));
+  }
   ParseFromString((length >= 0) ? std::string(buffer, length) : std::string(buffer), message);
 }
 
@@ -40,34 +43,40 @@ std::string ProtobufSerialization::SerializeAsString(const google::protobuf::Mes
 void ProtobufSerialization::SerializeToString(const google::protobuf::Message& message, std::string* output) {
   if (use_json_format_) {
     output->clear();
-    if (pb::util::MessageToJsonString(message, output) != pb::util::Status::OK)
+    if (pb::util::MessageToJsonString(message, output) != pb::util::Status::OK) {
       BOOST_THROW_EXCEPTION(::artm::core::InvalidOperation("Unable to serialize the message to json format"));
+    }
     VLOG(0) << *output;
   } else {
-    if (!message.SerializeToString(output))
+    if (!message.SerializeToString(output)) {
       BOOST_THROW_EXCEPTION(::artm::core::InvalidOperation("Unable to serialize the message"));
+    }
   }
 }
 
 std::string ProtobufSerialization::ConvertJsonToBinary(const std::string& json,
                                                        google::protobuf::Message* temporary) {
-  if (pb::util::JsonStringToMessage(json, temporary) != pb::util::Status::OK)
+  if (pb::util::JsonStringToMessage(json, temporary) != pb::util::Status::OK) {
     BOOST_THROW_EXCEPTION(::artm::core::CorruptedMessageException("Unable to parse the message from json format"));
+  }
 
   std::string output;
-  if (!temporary->SerializeToString(&output))
+  if (!temporary->SerializeToString(&output)) {
     BOOST_THROW_EXCEPTION(::artm::core::InvalidOperation("Unable to serialize the message"));
+  }
   return output;
 }
 
 std::string ProtobufSerialization::ConvertBinaryToJson(const std::string& binary,
                                                        google::protobuf::Message* temporary) {
-  if (!temporary->ParseFromString(binary))
+  if (!temporary->ParseFromString(binary)) {
     BOOST_THROW_EXCEPTION(::artm::core::CorruptedMessageException("Unable to parse the message"));
+  }
 
   std::string output;
-  if (pb::util::MessageToJsonString(*temporary, &output) != pb::util::Status::OK)
+  if (pb::util::MessageToJsonString(*temporary, &output) != pb::util::Status::OK) {
     BOOST_THROW_EXCEPTION(::artm::core::InvalidOperation("Unable to serialize the message to json format"));
+  }
 
   return output;
 }

--- a/src/artm/core/protobuf_serialization.h
+++ b/src/artm/core/protobuf_serialization.h
@@ -45,7 +45,7 @@ class ProtobufSerialization {
   static std::string ConvertBinaryToJson(const std::string& binary, google::protobuf::Message* temporary);
 
  private:
-  ProtobufSerialization() : use_json_format_(false) {}
+  ProtobufSerialization() : use_json_format_(false) { }
   bool use_json_format_;
 };
 

--- a/src/artm/core/protobuf_serialization.h
+++ b/src/artm/core/protobuf_serialization.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_PROTOBUF_SERIALIZATION_H_
-#define SRC_ARTM_CORE_PROTOBUF_SERIALIZATION_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -52,5 +51,3 @@ class ProtobufSerialization {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_PROTOBUF_SERIALIZATION_H_

--- a/src/artm/core/score_manager.cc
+++ b/src/artm/core/score_manager.cc
@@ -48,9 +48,10 @@ void ScoreManager::Clear() {
 bool ScoreManager::RequestScore(const ScoreName& score_name,
                                 ScoreData *score_data) const {
   auto score_calculator = instance_->scores_calculators()->get(score_name);
-  if (score_calculator == nullptr)
+  if (score_calculator == nullptr) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
       std::string("Attempt to request non-existing score: " + score_name)));
+  }
 
   if (score_calculator->is_cumulative()) {
     boost::lock_guard<boost::mutex> guard(lock_);
@@ -71,20 +72,23 @@ bool ScoreManager::RequestScore(const ScoreName& score_name,
 }
 
 void ScoreManager::RequestAllScores(::google::protobuf::RepeatedPtrField< ::artm::ScoreData>* score_data) const {
-  if (score_data == nullptr)
+  if (score_data == nullptr) {
     return;
+  }
 
   std::vector<ScoreName> score_names;
   {
     boost::lock_guard<boost::mutex> guard(lock_);
-    for (auto& elem : score_map_)
+    for (const auto& elem : score_map_) {
       score_names.push_back(elem.first);
+    }
   }
 
   for (auto& score_name : score_names) {
     ScoreData requested_score_data;
-    if (RequestScore(score_name, &requested_score_data))
+    if (RequestScore(score_name, &requested_score_data)) {
       score_data->Add()->Swap(&requested_score_data);
+    }
   }
 }
 

--- a/src/artm/core/score_manager.h
+++ b/src/artm/core/score_manager.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_SCORE_MANAGER_H_
-#define SRC_ARTM_CORE_SCORE_MANAGER_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -62,6 +61,3 @@ class ScoreTracker : boost::noncopyable {
 
 }  // namespace core
 }  // namespace artm
-
-
-#endif  // SRC_ARTM_CORE_SCORE_MANAGER_H_

--- a/src/artm/core/score_manager.h
+++ b/src/artm/core/score_manager.h
@@ -25,7 +25,7 @@ class Instance;
 // Its implementation is thread safe because it can be called simultaneoudly from multiple processor threads.
 class ScoreManager : boost::noncopyable {
  public:
-  explicit ScoreManager(Instance* instance) : instance_(instance), lock_(), score_map_() {}
+  explicit ScoreManager(Instance* instance) : instance_(instance), lock_(), score_map_() { }
 
   void Append(const ScoreName& score_name, const std::string& score_blob);
   void Clear();
@@ -46,7 +46,7 @@ class ScoreManager : boost::noncopyable {
 // This class stores both Phi-scores (non-cumulative) and Theta-scores (cumulative).
 class ScoreTracker : boost::noncopyable {
  public:
-  ScoreTracker() : lock_(), array_() {}
+  ScoreTracker() : lock_(), array_() { }
   void Clear();
   ScoreData* Add();
   void RequestScoreArray(const GetScoreArrayArgs& args, ScoreArray* score_data_array);

--- a/src/artm/core/template_manager.h
+++ b/src/artm/core/template_manager.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_TEMPLATE_MANAGER_H_
-#define SRC_ARTM_CORE_TEMPLATE_MANAGER_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -81,5 +80,3 @@ class TemplateManager : boost::noncopyable {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_TEMPLATE_MANAGER_H_

--- a/src/artm/core/template_manager.h
+++ b/src/artm/core/template_manager.h
@@ -70,7 +70,7 @@ class TemplateManager : boost::noncopyable {
 
  private:
   // Singleton (make constructor private)
-  TemplateManager() : lock_(), next_id_(1) {}
+  TemplateManager() : lock_(), next_id_(1) { }
 
   mutable boost::mutex lock_;
 

--- a/src/artm/core/thread_safe_holder.h
+++ b/src/artm/core/thread_safe_holder.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_THREAD_SAFE_HOLDER_H_
-#define SRC_ARTM_CORE_THREAD_SAFE_HOLDER_H_
+#pragma once
 
 #include <queue>
 #include <map>
@@ -191,5 +190,3 @@ class ThreadSafeQueue : boost::noncopyable {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_THREAD_SAFE_HOLDER_H_

--- a/src/artm/core/thread_safe_holder.h
+++ b/src/artm/core/thread_safe_holder.h
@@ -27,12 +27,12 @@ template<typename T>
 class ThreadSafeHolder : boost::noncopyable {
  public:
   ThreadSafeHolder()
-      : lock_(), object_(std::make_shared<T>()) {}
+      : lock_(), object_(std::make_shared<T>()) { }
 
   explicit ThreadSafeHolder(const std::shared_ptr<T>& object)
-      : lock_(), object_(object) {}
+      : lock_(), object_(object) { }
 
-  ~ThreadSafeHolder() {}
+  ~ThreadSafeHolder() { }
 
   std::shared_ptr<T> get() const {
     boost::lock_guard<boost::mutex> guard(lock_);
@@ -41,7 +41,9 @@ class ThreadSafeHolder : boost::noncopyable {
 
   std::shared_ptr<T> get_copy() const {
     boost::lock_guard<boost::mutex> guard(lock_);
-    if (object_ == nullptr) return std::make_shared<T>();
+    if (object_ == nullptr) {
+      return std::make_shared<T>();
+    }
     return std::make_shared<T>(*object_);
   }
 
@@ -59,7 +61,7 @@ template<typename K, typename T>
 class ThreadSafeCollectionHolder : boost::noncopyable {
  public:
   ThreadSafeCollectionHolder()
-      : lock_(), object_(std::map<K, std::shared_ptr<T>>()) {}
+      : lock_(), object_(std::map<K, std::shared_ptr<T>>()) { }
 
   static ThreadSafeCollectionHolder<K, T>& singleton() {
     // Mayers singleton is thread safe in C++11
@@ -68,7 +70,7 @@ class ThreadSafeCollectionHolder : boost::noncopyable {
     return holder;
   }
 
-  ~ThreadSafeCollectionHolder() {}
+  ~ThreadSafeCollectionHolder() { }
 
   std::shared_ptr<T> get(const K& key) const {
     boost::lock_guard<boost::mutex> guard(lock_);
@@ -143,12 +145,13 @@ class ThreadSafeCollectionHolder : boost::noncopyable {
 template<typename T>
 class ThreadSafeQueue : boost::noncopyable {
  public:
-  ThreadSafeQueue() : lock_(), queue_(), reserved_(0) {}
+  ThreadSafeQueue() : lock_(), queue_(), reserved_(0) { }
 
   bool try_pop(T* elem) {
     boost::lock_guard<boost::mutex> guard(lock_);
-    if (queue_.empty())
+    if (queue_.empty()) {
       return false;
+    }
 
     T tmp_elem = queue_.front();
     queue_.pop();
@@ -168,8 +171,9 @@ class ThreadSafeQueue : boost::noncopyable {
 
   void release() {
     boost::lock_guard<boost::mutex> guard(lock_);
-    if (reserved_ > 0)
+    if (reserved_ > 0) {
       reserved_--;
+    }
   }
 
   size_t size() const {

--- a/src/artm/core/token.h
+++ b/src/artm/core/token.h
@@ -19,8 +19,8 @@ const std::string DocumentsClass = "@documents_class";
 struct Token {
  public:
   Token(const ClassId& _class_id, const std::string& _keyword)
-      : keyword(_keyword), class_id(_class_id),
-        hash_(calcHash(_class_id, _keyword)) {}
+      : keyword(_keyword), class_id(_class_id)
+      , hash_(calcHash(_class_id, _keyword)) { }
 
   Token& operator=(const Token &rhs) {
     if (this != &rhs) {
@@ -33,13 +33,16 @@ struct Token {
   }
 
   bool operator<(const Token& token) const {
-    if (keyword != token.keyword)
+    if (keyword != token.keyword) {
       return keyword < token.keyword;
+    }
     return class_id < token.class_id;
   }
 
   bool operator==(const Token& token) const {
-    if (keyword == token.keyword && class_id == token.class_id) return true;
+    if (keyword == token.keyword && class_id == token.class_id) {
+      return true;
+    }
     return false;
   }
 

--- a/src/artm/core/token.h
+++ b/src/artm/core/token.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CORE_TOKEN_H_
-#define SRC_ARTM_CORE_TOKEN_H_
+#pragma once
 
 #include <string>
 
@@ -71,5 +70,3 @@ struct TokenHasher {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_TOKEN_H_

--- a/src/artm/core/transform_function.cc
+++ b/src/artm/core/transform_function.cc
@@ -32,17 +32,17 @@ std::shared_ptr<TransformFunction> TransformFunction::create() {
   return TransformFunction::create(config);
 }
 
-double LogarithmTransformFunction::apply(double value) {
+float LogarithmTransformFunction::apply(float value) {
   return value > 0 ? log(value) : 0.0;
 }
 
-PolynomialTransformFunction::PolynomialTransformFunction(double a, double n) : a_(a), n_(n) { }
+PolynomialTransformFunction::PolynomialTransformFunction(float a, float n) : a_(a), n_(n) { }
 
-double PolynomialTransformFunction::apply(double value) {
+float PolynomialTransformFunction::apply(float value) {
   return value > 0 ? a_ * pow(value, n_) : 0.0;
 }
 
-double ConstantTransformFunction::apply(double value) {
+float ConstantTransformFunction::apply(float value) {
   return 1.0;
 }
 

--- a/src/artm/core/transform_function.h
+++ b/src/artm/core/transform_function.h
@@ -2,8 +2,7 @@
 
 // Author: Murat Apishev (great-mel@yandex.ru)
 
-#ifndef SRC_ARTM_CORE_TRANSFORM_FUNCTION_H_
-#define SRC_ARTM_CORE_TRANSFORM_FUNCTION_H_
+#pragma once
 
 #include <memory>
 
@@ -43,5 +42,3 @@ class ConstantTransformFunction : public TransformFunction {
 
 }  // namespace core
 }  // namespace artm
-
-#endif  // SRC_ARTM_CORE_TRANSFORM_FUNCTION_H_

--- a/src/artm/core/transform_function.h
+++ b/src/artm/core/transform_function.h
@@ -17,28 +17,28 @@ class TransformFunction {
  public:
   static std::shared_ptr<TransformFunction> create(const TransformConfig& config);
   static std::shared_ptr<TransformFunction> create();
-  virtual double apply(double value) = 0;
+  virtual float apply(float value) = 0;
   virtual ~TransformFunction() { }
 };
 
 class LogarithmTransformFunction : public TransformFunction {
  public:
-  virtual double apply(double value);
+  virtual float apply(float value);
 };
 
 class PolynomialTransformFunction : public TransformFunction {
  public:
-  PolynomialTransformFunction(double a, double n);
-  virtual double apply(double value);
+  PolynomialTransformFunction(float a, float n);
+  virtual float apply(float value);
 
  private:
-  double a_;
-  double n_;
+  float a_;
+  float n_;
 };
 
 class ConstantTransformFunction : public TransformFunction {
  public:
-  double apply(double value);
+  float apply(float value);
 };
 
 }  // namespace core

--- a/src/artm/cpp_interface.cc
+++ b/src/artm/cpp_interface.cc
@@ -110,8 +110,9 @@ std::shared_ptr<ResultT> ArtmRequestShared(int master_id, const ArgsT& args, Fun
 }
 
 void ArtmRequestMatrix(int no_rows, int no_cols, Matrix* matrix) {
-  if (matrix == nullptr)
+  if (matrix == nullptr) {
     return;
+  }
 
   matrix->resize(no_rows, no_cols);
 
@@ -145,8 +146,9 @@ MasterModel::MasterModel(int id) : id_(id), is_weak_ref_(true) {
 }
 
 MasterModel::~MasterModel() {
-  if (is_weak_ref_)
+  if (is_weak_ref_) {
     return;
+  }
 
   ArtmDisposeMasterComponent(id_);
 }
@@ -313,8 +315,9 @@ Matrix::Matrix() : no_rows_(0), no_columns_(0), data_() {
 }
 
 Matrix::Matrix(int no_rows, int no_columns) : no_rows_(no_rows), no_columns_(no_columns), data_() {
-  if (no_rows <= 0 || no_columns <= 0)
+  if (no_rows <= 0 || no_columns <= 0) {
     throw ArgumentOutOfRangeException("no_rows and no_columns must be positive");
+  }
 
   data_.resize(static_cast<int64_t>(no_rows_) * no_columns_);
 }
@@ -330,8 +333,9 @@ const float& Matrix::operator() (int index_row, int index_col) const {
 void Matrix::resize(int no_rows, int no_columns) {
   no_rows_ = no_rows;
   no_columns_ = no_columns;
-  if (no_rows > 0 && no_columns > 0)
+  if (no_rows > 0 && no_columns > 0) {
     data_.resize(static_cast<int64_t>(no_rows_) * no_columns_);
+  }
 }
 
 int Matrix::no_rows() const { return no_rows_; }

--- a/src/artm/cpp_interface.h
+++ b/src/artm/cpp_interface.h
@@ -40,10 +40,10 @@ enum ArtmErrorCodes {
 namespace artm {
 
 // Exception handling in cpp_interface
-#define DEFINE_EXCEPTION_TYPE(Type, BaseType)                  \
-class Type : public BaseType { public:  /*NOLINT*/             \
-  Type() : BaseType("") {}                                     \
-  explicit Type(std::string message) : BaseType(message) {}    \
+#define DEFINE_EXCEPTION_TYPE(Type, BaseType)                   \
+class Type : public BaseType { public:  /*NOLINT*/              \
+  Type() : BaseType("") { }                                     \
+  explicit Type(std::string message) : BaseType(message) { }    \
 };
 
 DEFINE_EXCEPTION_TYPE(InternalError, std::runtime_error);

--- a/src/artm/cpp_interface.h
+++ b/src/artm/cpp_interface.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_CPP_INTERFACE_H_
-#define SRC_ARTM_CPP_INTERFACE_H_
+#pragma once
 
 #include <memory>
 #include <stdexcept>
@@ -177,5 +176,3 @@ std::vector<T> MasterModel::GetScoreArrayAs(const GetScoreArrayArgs& args) {
 }
 
 }  // namespace artm
-
-#endif  // SRC_ARTM_CPP_INTERFACE_H_

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -2,11 +2,6 @@ syntax = "proto2";
 // File messages.proto defines all messages that can be transefer in or out from BigARTM library.
 package artm;
 
-// Represents an array of double-precision floating point values
-message DoubleArray {
-  repeated double value = 1 [packed = true];
-}
-
 // Represents an array of single-precision floating point values
 message FloatArray {
   repeated float value = 1 [packed = true];
@@ -68,8 +63,8 @@ message Batch {
 
 message RegularizerSettings {
   optional string name = 1;
-  optional double tau = 2;
-  optional double gamma = 3;
+  optional float tau = 2;
+  optional float gamma = 3;
 }
 
 enum RegularizerType {
@@ -95,7 +90,7 @@ message RegularizerConfig {
   optional RegularizerType type = 2 [default = RegularizerType_Unknown];
   optional bytes config = 3;
   optional float tau = 4;
-  optional double gamma = 5;
+  optional float gamma = 5;
   optional string config_json = 6;
 }
 
@@ -105,7 +100,7 @@ message SmoothSparseThetaConfig {
   repeated float alpha_iter = 2;
   optional TransformConfig transform_config = 3;
   repeated string item_title = 4;
-  repeated DoubleArray item_topic_multiplier = 5;
+  repeated FloatArray item_topic_multiplier = 5;
 }
 
 // Represents a configuration of a SmoothSparse Phi regularizer
@@ -164,7 +159,7 @@ message SmoothPtdwConfig {
 
   optional SmoothType type = 1 [default = MovingAverage];
   optional int32 window = 3 [default = 10];
-  optional double threshold = 4 [default = 1.0];
+  optional float threshold = 4 [default = 1.0];
 }
 
 // Represents a configuration of a TopicSelection Theta regularizer
@@ -192,7 +187,7 @@ message HierarchySparsingThetaConfig {
 message TopicSegmentationPtdwConfig {
   repeated string background_topic_names = 1;
   optional int32 window = 3 [default = 10];
-  optional double threshold = 4 [default = 0.5];
+  optional float threshold = 4 [default = 0.5];
 }
 
 // Represents a configuration of a SmoothTimeInTopics Phi regularizer
@@ -210,8 +205,8 @@ message TransformConfig {
   }
 
   optional TransformType type = 1 [default = Constant];
-  optional double n = 2 [default = 1];
-  optional double a = 3 [default = 1];
+  optional float n = 2 [default = 1];
+  optional float a = 3 [default = 1];
 }
 
 enum ScoreType {
@@ -265,13 +260,16 @@ message PerplexityScoreConfig {
 message PerplexityScore {
   message ClassIdInfo {
     optional string class_id = 1;
+
+    // here and below we sum a lot of small values,
+    // so double type is required
     optional double raw = 2;
     optional double normalizer = 3;
     optional int64 zero_words = 4;
   }
 
   // general perplexity value for all cases
-  optional double value = 1;
+  optional float value = 1;
   
   // fields for case of all class ids
   optional double raw = 2;
@@ -290,7 +288,7 @@ message SparsityThetaScoreConfig {
 
 // Represents a result of calculation of a theta sparsity score
 message SparsityThetaScore {
-  optional double value = 1;
+  optional float value = 1;
   optional int64 zero_topics = 2;
   optional int64 total_topics = 3;
 }
@@ -304,7 +302,7 @@ message SparsityPhiScoreConfig {
 
 // Represents a result of calculation of a phi sparsity score
 message SparsityPhiScore {
-  optional double value = 1;
+  optional float value = 1;
   optional int64 zero_tokens = 2;
   optional int64 total_tokens = 3;
 }
@@ -317,8 +315,8 @@ message ItemsProcessedScoreConfig {
 message ItemsProcessedScore {
   optional int32 value = 1 [default = 0];
   optional int32 num_batches = 2 [default = 0];
-  optional double token_weight = 3 [default = 0];
-  optional double token_weight_in_effect = 4 [default = 0];
+  optional float token_weight = 3 [default = 0];
+  optional float token_weight_in_effect = 4 [default = 0];
 }
 
 // Represents a configuration of a top tokens score
@@ -358,19 +356,19 @@ message TopicKernelScoreConfig {
   optional float eps = 1 [default = 1e-37];
   optional string class_id = 2 [default = "@default_class"];
   repeated string topic_name = 3;
-  optional double probability_mass_threshold = 4 [default = 0.1];
+  optional float probability_mass_threshold = 4 [default = 0.1];
   optional string cooccurrence_dictionary_name = 5;
 }
 
 // Represents a result of calculation of a topic kernel score
 message TopicKernelScore {
-  repeated double kernel_size = 1;
-  repeated double kernel_purity = 2;
-  repeated double kernel_contrast = 3;
-  optional double average_kernel_size = 4;
-  optional double average_kernel_purity = 5;
-  optional double average_kernel_contrast = 6;
-  repeated double coherence = 7;
+  repeated float kernel_size = 1;
+  repeated float kernel_purity = 2;
+  repeated float kernel_contrast = 3;
+  optional float average_kernel_size = 4;
+  optional float average_kernel_purity = 5;
+  optional float average_kernel_contrast = 6;
+  repeated float coherence = 7;
   optional float average_coherence = 8;
   repeated StringArray kernel_tokens = 9;
   repeated string topic_name = 10;
@@ -385,10 +383,10 @@ message TopicMassPhiScoreConfig {
 
 // Represents a result of calculation of a topic part in nwt score
 message TopicMassPhiScore {
-  optional double value = 1;
+  optional float value = 1;
   repeated string topic_name = 2;
-  repeated double topic_ratio = 3;
-  repeated double topic_mass = 4;
+  repeated float topic_ratio = 3;
+  repeated float topic_mass = 4;
 }
 
 // Represents a configuration of a class precision score
@@ -397,9 +395,9 @@ message ClassPrecisionScoreConfig {
 
 // Represents a result of calculation of a class precision score
 message ClassPrecisionScore {
-  optional double value = 1;
-  optional double error = 2;
-  optional double total = 3;
+  optional float value = 1;
+  optional float error = 2;
+  optional float total = 3;
 }
 
 // Represents a configuration of a class precision score
@@ -600,7 +598,7 @@ message ProcessBatchesArgs {
   optional string pwt_source_name = 3;
   optional int32 num_document_passes = 4 [default = 10];
   repeated string regularizer_name = 6;
-  repeated double regularizer_tau = 7;
+  repeated float regularizer_tau = 7;
   repeated string class_id = 8;
   repeated float class_weight = 9;
   optional bool reuse_theta = 10 [default = false];

--- a/src/artm/regularizer/biterms_phi.cc
+++ b/src/artm/regularizer/biterms_phi.cc
@@ -12,20 +12,21 @@
 namespace artm {
 namespace regularizer {
 
-BitermsPhi::BitermsPhi(const BitermsPhiConfig& config)
-    : config_(config) { }
+BitermsPhi::BitermsPhi(const BitermsPhiConfig& config) : config_(config) { }
 
 bool BitermsPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
                                const ::artm::core::PhiMatrix& n_wt,
                                ::artm::core::PhiMatrix* result) {
+  // prepare parameters
   const int topic_size = n_wt.topic_size();
   const int token_size = n_wt.token_size();
 
   std::vector<bool> topics_to_regularize;
-  if (config_.topic_name().size() == 0)
+  if (config_.topic_name().size() == 0) {
     topics_to_regularize.assign(topic_size, true);
-  else
+  } else {
     topics_to_regularize = core::is_member(n_wt.topic_name(), config_.topic_name());
+  }
 
   bool use_all_classes = false;
   if (config_.class_id_size() == 0) {
@@ -33,13 +34,13 @@ bool BitermsPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   }
 
   if (!config_.has_dictionary_name()) {
-    LOG(WARNING) << "There's no dictionary for Biterms regularizer. Cancel it's launch.";
+    LOG(ERROR) << "There's no dictionary for Biterms regularizer. Cancel it's launch.";
     return false;
   }
 
   auto dictionary_ptr = dictionary(config_.dictionary_name());
   if (dictionary_ptr == nullptr) {
-    LOG(WARNING) << "There's no dictionary for Biterms regularizer. Cancel it's launch.";
+    LOG(ERROR) << "There's no dictionary for Biterms regularizer. Cancel it's launch.";
     return false;
   }
 
@@ -52,7 +53,7 @@ bool BitermsPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   }
 
   // compute n_t
-  std::vector<float> n_t(topic_size, 0.0);
+  std::vector<float> n_t(topic_size, 0.0f);
   for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
     for (int token_index = 0; token_index < token_size; ++token_index) {
       n_t[topic_index] += n_wt.get(token_index, topic_index);
@@ -62,10 +63,14 @@ bool BitermsPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   // proceed the regularization
   for (int token_id = 0; token_id < token_size; ++token_id) {
     auto token = n_wt.token(token_id);
-    if (!use_all_classes && !core::is_member(token.class_id, config_.class_id())) continue;
+    if (!use_all_classes && !core::is_member(token.class_id, config_.class_id())) {
+      continue;
+    }
 
     auto cooc_tokens_info = dictionary_ptr->token_cooc_values(token);
-    if (cooc_tokens_info == nullptr) continue;
+    if (cooc_tokens_info == nullptr) {
+      continue;
+    }
 
     std::vector<float> n_t_p_wt(topic_size, 0.0f);  // n_t * p_wt
     for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
@@ -76,19 +81,25 @@ bool BitermsPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
     for (const auto& elem : *cooc_tokens_info) {
       float mult_coef = elem.second;
       int cooc_token_index = dict_to_phi_indices[elem.first];
-      if (cooc_token_index == -1) continue;
+      if (cooc_token_index == -1) {
+        continue;
+      }
 
       float p_tuw_norm = 0.0f;
       std::vector<float> p_tuw(n_t_p_wt);
       for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
-        if (!topics_to_regularize[topic_id]) continue;
+        if (!topics_to_regularize[topic_id]) {
+          continue;
+        }
 
         p_tuw[topic_id] *= p_wt.get(cooc_token_index, topic_id);
         p_tuw_norm += p_tuw[topic_id];
       }
 
       for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
-        if (!topics_to_regularize[topic_id]) continue;
+        if (!topics_to_regularize[topic_id]) {
+          continue;
+        }
 
         float p_t_uw = p_tuw_norm > 0.0f && p_tuw[topic_id] > 0.0f ?
           p_tuw[topic_id] / p_tuw_norm : 0.0f;

--- a/src/artm/regularizer/biterms_phi.cc
+++ b/src/artm/regularizer/biterms_phi.cc
@@ -52,10 +52,10 @@ bool BitermsPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   }
 
   // compute n_t
-  std::vector<double> n_t(topic_size, 0.0);
+  std::vector<float> n_t(topic_size, 0.0);
   for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
     for (int token_index = 0; token_index < token_size; ++token_index) {
-      n_t[topic_index] += static_cast<double>(n_wt.get(token_index, topic_index));
+      n_t[topic_index] += n_wt.get(token_index, topic_index);
     }
   }
 

--- a/src/artm/regularizer/biterms_phi.h
+++ b/src/artm/regularizer/biterms_phi.h
@@ -20,8 +20,7 @@
 
 */
 
-#ifndef SRC_ARTM_REGULARIZER_BITERMS_PHI_H_
-#define SRC_ARTM_REGULARIZER_BITERMS_PHI_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -51,5 +50,3 @@ class BitermsPhi : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_BITERMS_PHI_H_

--- a/src/artm/regularizer/decorrelator_phi.cc
+++ b/src/artm/regularizer/decorrelator_phi.cc
@@ -60,7 +60,7 @@ bool DecorrelatorPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
         // create general normalizer
         for (const auto& pair : topics_to_regularize) {
           weights_sum += p_wt.get(token_id, pair.second);
-	}
+        }
 
         // process every topic from topic_names
         for (const auto& pair : topics_to_regularize) {

--- a/src/artm/regularizer/decorrelator_phi.cc
+++ b/src/artm/regularizer/decorrelator_phi.cc
@@ -24,7 +24,7 @@ bool DecorrelatorPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
 
   std::unordered_map<std::string, int> topics_to_regularize;
   if (!use_topic_pairs) {
-    for (auto& s : (config_.topic_name().size() ? config_.topic_name() : p_wt.topic_name())) {
+    for (const auto& s : (config_.topic_name().size() ? config_.topic_name() : p_wt.topic_name())) {
       bool valid_topic = false;
       for (int i = 0; i < p_wt.topic_name().size(); ++i) {
         if (p_wt.topic_name(i) == s) {
@@ -57,29 +57,31 @@ bool DecorrelatorPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
       // simple case (without topic_pairs)
       if (!use_topic_pairs) {
         // create general normalizer
-        for (auto& pair : topics_to_regularize)
+        for (const auto& pair : topics_to_regularize)
           weights_sum += p_wt.get(token_id, pair.second);
 
         // process every topic from topic_names
-        for (auto& pair : topics_to_regularize) {
+        for (const auto& pair : topics_to_regularize) {
           float weight = p_wt.get(token_id, pair.second);
           float value = static_cast<float>(-weight * (weights_sum - weight));
           result->set(token_id, pair.second, value);
         }
       } else {  // complex case
-        for (auto& pair : topic_pairs_) {
+        for (const auto& pair : topic_pairs_) {
           weights_sum = 0.0f;
 
           // check given topic exists in model
           auto first_iter = all_topics.find(pair.first);
-          if (first_iter == all_topics.end())
+          if (first_iter == all_topics.end()) {
             continue;
+          }
 
           // create custom normilizer for this topic
-          for (auto topic_and_value : pair.second) {
+          for (const auto& topic_and_value : pair.second) {
             auto second_iter = all_topics.find(topic_and_value.first);
-            if (second_iter == all_topics.end())
+            if (second_iter == all_topics.end()) {
               continue;
+            }
 
             weights_sum += p_wt.get(token_id, second_iter->second) * topic_and_value.second;
           }
@@ -124,8 +126,7 @@ void DecorrelatorPhi::UpdateTopicPairs(const DecorrelatorPhiConfig& config) {
         topic_pairs_.insert(std::make_pair(first_name, std::unordered_map<std::string, float>()));
         iter = topic_pairs_.find(first_name);
       }
-      iter->second.insert(std::make_pair(config.second_topic_name(i),
-        config.value(i)));
+      iter->second.insert(std::make_pair(config.second_topic_name(i), config.value(i)));
     }
   }
 }

--- a/src/artm/regularizer/decorrelator_phi.cc
+++ b/src/artm/regularizer/decorrelator_phi.cc
@@ -18,7 +18,6 @@ bool DecorrelatorPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
                                     const ::artm::core::PhiMatrix& n_wt,
                                     ::artm::core::PhiMatrix* result) {
   // read the parameters from config and control their correctness
-  const int topic_size = p_wt.topic_size();
   const int token_size = p_wt.token_size();
   const bool use_topic_pairs = (topic_pairs_.size() > 0);
 

--- a/src/artm/regularizer/decorrelator_phi.cc
+++ b/src/artm/regularizer/decorrelator_phi.cc
@@ -32,14 +32,16 @@ bool DecorrelatorPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
           break;
         }
       }
-      if (!valid_topic)
+      if (!valid_topic) {
         LOG(WARNING) << "Topic name " << s << " is not presented into model and will be ignored";
+      }
     }
   }
 
   std::unordered_map<std::string, int> all_topics;
-  for (int i = 0; i < p_wt.topic_name().size(); ++i)
+  for (int i = 0; i < p_wt.topic_name().size(); ++i) {
     all_topics.insert(std::make_pair(p_wt.topic_name(i), i));
+  }
 
   bool use_all_classes = false;
   if (config_.class_id_size() == 0) {
@@ -56,8 +58,9 @@ bool DecorrelatorPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
       // simple case (without topic_pairs)
       if (!use_topic_pairs) {
         // create general normalizer
-        for (const auto& pair : topics_to_regularize)
+        for (const auto& pair : topics_to_regularize) {
           weights_sum += p_wt.get(token_id, pair.second);
+	}
 
         // process every topic from topic_names
         for (const auto& pair : topics_to_regularize) {

--- a/src/artm/regularizer/decorrelator_phi.h
+++ b/src/artm/regularizer/decorrelator_phi.h
@@ -20,8 +20,7 @@
 Note, that in case of topic_pairs usage the topic_names parameter will be ignored.
 */
 
-#ifndef SRC_ARTM_REGULARIZER_DECORRELATOR_PHI_H_
-#define SRC_ARTM_REGULARIZER_DECORRELATOR_PHI_H_
+#pragma once
 
 #include <unordered_map>
 #include <string>
@@ -58,5 +57,3 @@ class DecorrelatorPhi : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_DECORRELATOR_PHI_H_

--- a/src/artm/regularizer/hierarchy_sparsing_theta.cc
+++ b/src/artm/regularizer/hierarchy_sparsing_theta.cc
@@ -20,40 +20,43 @@ void HierarchySparsingThetaAgent::Apply(int item_index, int inner_iter, int topi
 }
 
 void HierarchySparsingThetaAgent::Apply(int inner_iter,
-  const ::artm::utility::LocalThetaMatrix<float>& n_td,
-  ::artm::utility::LocalThetaMatrix<float>* r_td) const {
-  if (!(regularization_on)) return;
+                                        const ::artm::utility::LocalThetaMatrix<float>& n_td,
+                                        ::artm::utility::LocalThetaMatrix<float>* r_td) const {
+  if (!(regularization_on)) {
+    return;
+  }
 
   std::vector<float> n_d, n_t;
-  int topics_num = n_td.num_topics();
-  int items_num = n_td.num_items();
+  int topic_size = n_td.num_topics();
+  int item_size = n_td.num_items();
   float item_sum = 0.0f;
   float topic_sum = 0.0f;
 
   // count n_d
-  for (int item_id = 0; item_id < items_num; ++item_id) {
+  for (int item_id = 0; item_id < item_size; ++item_id) {
     item_sum = 0;
-    for (int topic_id = 0; topic_id < topics_num; ++topic_id) {
+    for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
       item_sum += n_td(topic_id, item_id);
     }
     n_d.push_back(item_sum);
   }
 
   // count topics proportion (n_t)
-  for (int topic_id = 0; topic_id < topics_num; ++topic_id) {
+  for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
     topic_sum = 0;
-    for (int item_id = 0; item_id < items_num; ++item_id) {
+    for (int item_id = 0; item_id < item_size; ++item_id) {
       topic_sum += parent_topic_proportion[item_id] * n_td(topic_id, item_id) / n_d[item_id];
     }
     n_t.push_back(topic_sum);
   }
 
-  // make regularization
-  if (topics_num != topic_weight.size()) return;
-  if (inner_iter >= alpha_weight.size()) return;
+  // proceed regularization
+  if (topic_size != topic_weight.size() || inner_iter >= alpha_weight.size()) {
+    return;
+  }
 
-  for (int item_id = 0; item_id < items_num; ++item_id)
-    for (int topic_id = 0; topic_id < topics_num; ++topic_id) {
+  for (int item_id = 0; item_id < item_size; ++item_id) {
+    for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
       if (n_td(topic_id, item_id) > 0.0f)
         (*r_td)(topic_id, item_id) += alpha_weight[inner_iter] * topic_weight[topic_id] *
         (prior_parent_topic_probability
@@ -61,13 +64,14 @@ void HierarchySparsingThetaAgent::Apply(int inner_iter,
         * parent_topic_proportion[item_id]
         / n_t[topic_id]);
     }
+  }
 }
 
-HierarchySparsingTheta::HierarchySparsingTheta(const HierarchySparsingThetaConfig& config) : config_(config) {}
+HierarchySparsingTheta::HierarchySparsingTheta(const HierarchySparsingThetaConfig& config) : config_(config) { }
 
 std::shared_ptr<RegularizeThetaAgent>
-  HierarchySparsingTheta::CreateRegularizeThetaAgent(const Batch& batch,
-  const ProcessBatchesArgs& args, float tau) {
+HierarchySparsingTheta::CreateRegularizeThetaAgent(const Batch& batch,
+                                                   const ProcessBatchesArgs& args, float tau) {
   HierarchySparsingThetaAgent* agent = new HierarchySparsingThetaAgent();
   std::shared_ptr<HierarchySparsingThetaAgent> retval(agent);
 
@@ -88,11 +92,13 @@ std::shared_ptr<RegularizeThetaAgent>
       return nullptr;
     }
 
-    for (int i = 0; i < config_.alpha_iter_size(); ++i)
+    for (int i = 0; i < config_.alpha_iter_size(); ++i) {
       agent->alpha_weight.push_back(config_.alpha_iter(i));
+    }
   } else {
-    for (int i = 0; i < args.num_document_passes(); ++i)
+    for (int i = 0; i < args.num_document_passes(); ++i) {
       agent->alpha_weight.push_back(1.0f);
+    }
   }
 
   if (config_.parent_topic_proportion_size()) {
@@ -101,17 +107,19 @@ std::shared_ptr<RegularizeThetaAgent>
       return nullptr;
     }
 
-    for (int i = 0; i < config_.parent_topic_proportion_size(); ++i)
+    for (int i = 0; i < config_.parent_topic_proportion_size(); ++i) {
       agent->parent_topic_proportion.push_back(config_.parent_topic_proportion(i));
+    }
   } else {
-    for (int i = 0; i < item_size; ++i)
+    for (int i = 0; i < item_size; ++i) {
       agent->parent_topic_proportion.push_back(1.0f);
+    }
   }
 
   agent->topic_weight.resize(topic_size, 0.0f);
   if (config_.topic_name_size() == 0) {
     for (int i = 0; i < topic_size; ++i)
-      agent->topic_weight[i] = static_cast<float>(-tau);
+      agent->topic_weight[i] = -tau;
   } else {
     if (topic_size != args.topic_name_size()) {
       LOG(ERROR) << "args.num_topics() != args.topic_name_size()";
@@ -121,7 +129,9 @@ std::shared_ptr<RegularizeThetaAgent>
     for (int topic_id = 0; topic_id < config_.topic_name_size(); ++topic_id) {
       int topic_index = ::artm::core::repeated_field_index_of(
         args.topic_name(), config_.topic_name(topic_id));
-      if (topic_index != -1) agent->topic_weight[topic_index] = static_cast<float>(-tau);
+      if (topic_index != -1) {
+        agent->topic_weight[topic_index] = -tau;
+      }
     }
   }
 

--- a/src/artm/regularizer/hierarchy_sparsing_theta.cc
+++ b/src/artm/regularizer/hierarchy_sparsing_theta.cc
@@ -57,12 +57,13 @@ void HierarchySparsingThetaAgent::Apply(int inner_iter,
 
   for (int item_id = 0; item_id < item_size; ++item_id) {
     for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
-      if (n_td(topic_id, item_id) > 0.0f)
+      if (n_td(topic_id, item_id) > 0.0f) {
         (*r_td)(topic_id, item_id) += alpha_weight[inner_iter] * topic_weight[topic_id] *
         (prior_parent_topic_probability
         - n_td(topic_id, item_id) / n_d[item_id]
         * parent_topic_proportion[item_id]
         / n_t[topic_id]);
+      }
     }
   }
 }
@@ -118,8 +119,9 @@ HierarchySparsingTheta::CreateRegularizeThetaAgent(const Batch& batch,
 
   agent->topic_weight.resize(topic_size, 0.0f);
   if (config_.topic_name_size() == 0) {
-    for (int i = 0; i < topic_size; ++i)
+    for (int i = 0; i < topic_size; ++i) {
       agent->topic_weight[i] = -tau;
+    }
   } else {
     if (topic_size != args.topic_name_size()) {
       LOG(ERROR) << "args.num_topics() != args.topic_name_size()";

--- a/src/artm/regularizer/hierarchy_sparsing_theta.cc
+++ b/src/artm/regularizer/hierarchy_sparsing_theta.cc
@@ -24,9 +24,11 @@ void HierarchySparsingThetaAgent::Apply(int inner_iter,
   ::artm::utility::LocalThetaMatrix<float>* r_td) const {
   if (!(regularization_on)) return;
 
-  std::vector<double> n_d, n_t;
-  int topics_num = n_td.num_topics(), items_num = n_td.num_items();
-  double item_sum = 0, topic_sum = 0;
+  std::vector<float> n_d, n_t;
+  int topics_num = n_td.num_topics();
+  int items_num = n_td.num_items();
+  float item_sum = 0.0f;
+  float topic_sum = 0.0f;
 
   // count n_d
   for (int item_id = 0; item_id < items_num; ++item_id) {
@@ -65,7 +67,7 @@ HierarchySparsingTheta::HierarchySparsingTheta(const HierarchySparsingThetaConfi
 
 std::shared_ptr<RegularizeThetaAgent>
   HierarchySparsingTheta::CreateRegularizeThetaAgent(const Batch& batch,
-  const ProcessBatchesArgs& args, double tau) {
+  const ProcessBatchesArgs& args, float tau) {
   HierarchySparsingThetaAgent* agent = new HierarchySparsingThetaAgent();
   std::shared_ptr<HierarchySparsingThetaAgent> retval(agent);
 

--- a/src/artm/regularizer/hierarchy_sparsing_theta.h
+++ b/src/artm/regularizer/hierarchy_sparsing_theta.h
@@ -69,7 +69,7 @@ class HierarchySparsingTheta : public RegularizerInterface {
   explicit HierarchySparsingTheta(const HierarchySparsingThetaConfig& config);
 
   virtual std::shared_ptr<RegularizeThetaAgent>
-    CreateRegularizeThetaAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau);
+  CreateRegularizeThetaAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau);
 
   virtual google::protobuf::RepeatedPtrField<std::string> topics_to_regularize();
 

--- a/src/artm/regularizer/hierarchy_sparsing_theta.h
+++ b/src/artm/regularizer/hierarchy_sparsing_theta.h
@@ -60,7 +60,7 @@ class HierarchySparsingThetaAgent : public RegularizeThetaAgent {
   std::vector<float> topic_weight;              // tau for every topic
   std::vector<float> alpha_weight;              // iteration coef
   std::vector<float> parent_topic_proportion;   // p(supertopic)
-  double prior_parent_topic_probability;        // 1.0 / count(supertopics)
+  float prior_parent_topic_probability;         // 1.0 / count(supertopics)
   bool regularization_on = true;                // true if current batch is parent phi batch
 };
 
@@ -69,7 +69,7 @@ class HierarchySparsingTheta : public RegularizerInterface {
   explicit HierarchySparsingTheta(const HierarchySparsingThetaConfig& config);
 
   virtual std::shared_ptr<RegularizeThetaAgent>
-    CreateRegularizeThetaAgent(const Batch& batch, const ProcessBatchesArgs& args, double tau);
+    CreateRegularizeThetaAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau);
 
   virtual google::protobuf::RepeatedPtrField<std::string> topics_to_regularize();
 

--- a/src/artm/regularizer/hierarchy_sparsing_theta.h
+++ b/src/artm/regularizer/hierarchy_sparsing_theta.h
@@ -36,8 +36,8 @@ remember to take these values into account when computing p(topic)
 in formula (*)!
 */
 
-#ifndef SRC_ARTM_REGULARIZER_HIERARCHY_SPARSING_THETA_H_
-#define SRC_ARTM_REGULARIZER_HIERARCHY_SPARSING_THETA_H_
+#pragma once
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -81,6 +81,3 @@ class HierarchySparsingTheta : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_HIERARCHY_SPARSING_THETA_H_
-

--- a/src/artm/regularizer/improve_coherence_phi.cc
+++ b/src/artm/regularizer/improve_coherence_phi.cc
@@ -20,10 +20,11 @@ bool ImproveCoherencePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   const int token_size = n_wt.token_size();
 
   std::vector<bool> topics_to_regularize;
-  if (config_.topic_name().size() == 0)
+  if (config_.topic_name().size() == 0) {
     topics_to_regularize.assign(topic_size, true);
-  else
+  } else {
     topics_to_regularize = core::is_member(n_wt.topic_name(), config_.topic_name());
+  }
 
   bool use_all_classes = false;
   if (config_.class_id_size() == 0) {
@@ -45,26 +46,34 @@ bool ImproveCoherencePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   // -1 means that token from dictionary doesn't present in Phi matrix
   std::vector<int> dict_to_phi_indices(dictionary_ptr->size(), -1);
   for (int index = 0; index < dictionary_ptr->size(); ++index) {
-    auto& entry = dictionary_ptr->entries()[index];
+    const auto& entry = dictionary_ptr->entries()[index];
     dict_to_phi_indices[index] = n_wt.token_index(entry.token());
   }
 
   // proceed the regularization
   for (int token_id = 0; token_id < token_size; ++token_id) {
-    auto token = n_wt.token(token_id);
-    if (!use_all_classes && !core::is_member(token.class_id, config_.class_id())) continue;
+    const auto& token = n_wt.token(token_id);
+    if (!use_all_classes && !core::is_member(token.class_id, config_.class_id())) {
+      continue;
+    }
 
     auto cooc_tokens_info = dictionary_ptr->token_cooc_values(token);
-    if (cooc_tokens_info == nullptr) continue;
+    if (cooc_tokens_info == nullptr) {
+      continue;
+    }
 
     std::vector<float> values(topic_size, 0.0);
-    for (auto& elem : *cooc_tokens_info) {
+    for (const auto& elem : *cooc_tokens_info) {
       float mult_coef = elem.second;
       int cooc_token_index = dict_to_phi_indices[elem.first];
-      if (cooc_token_index == -1) continue;
+      if (cooc_token_index == -1) {
+        continue;
+      }
 
       for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
-        if (!topics_to_regularize[topic_id]) continue;
+        if (!topics_to_regularize[topic_id]) {
+          continue;
+        }
 
         values[topic_id] += n_wt.get(cooc_token_index, topic_id) * mult_coef;
       }

--- a/src/artm/regularizer/improve_coherence_phi.h
+++ b/src/artm/regularizer/improve_coherence_phi.h
@@ -31,7 +31,7 @@ namespace regularizer {
 class ImproveCoherencePhi : public RegularizerInterface {
  public:
   explicit ImproveCoherencePhi(const ImproveCoherencePhiConfig& config)
-    : config_(config) {}
+    : config_(config) { }
 
   virtual bool RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
                              const ::artm::core::PhiMatrix& n_wt,

--- a/src/artm/regularizer/improve_coherence_phi.h
+++ b/src/artm/regularizer/improve_coherence_phi.h
@@ -18,8 +18,7 @@
 
 */
 
-#ifndef SRC_ARTM_REGULARIZER_IMPROVE_COHERENCE_PHI_H_
-#define SRC_ARTM_REGULARIZER_IMPROVE_COHERENCE_PHI_H_
+#pragma once
 
 #include <string>
 
@@ -48,5 +47,3 @@ class ImproveCoherencePhi : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_IMPROVE_COHERENCE_PHI_H_

--- a/src/artm/regularizer/label_regularization_phi.cc
+++ b/src/artm/regularizer/label_regularization_phi.cc
@@ -22,10 +22,11 @@ bool LabelRegularizationPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   const int token_size = n_wt.token_size();
 
   std::vector<bool> topics_to_regularize;
-  if (config_.topic_name().size() == 0)
+  if (config_.topic_name().size() == 0) {
     topics_to_regularize.assign(topic_size, true);
-  else
+  } else {
     topics_to_regularize = core::is_member(n_wt.topic_name(), config_.topic_name());
+  }
 
   bool use_all_classes = false;
   if (config_.class_id_size() == 0) {
@@ -33,13 +34,14 @@ bool LabelRegularizationPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   }
 
   std::shared_ptr<core::Dictionary> dictionary_ptr = nullptr;
-  if (config_.has_dictionary_name())
+  if (config_.has_dictionary_name()) {
     dictionary_ptr = dictionary(config_.dictionary_name());
+  }
   bool has_dictionary = dictionary_ptr != nullptr;
 
   // proceed the regularization
   for (int token_id = 0; token_id < token_size; ++token_id) {
-    const ::artm::core::Token& token = n_wt.token(token_id);
+    const auto& token = n_wt.token(token_id);
 
     float coefficient = 1.0f;
     if (has_dictionary) {
@@ -51,7 +53,9 @@ bool LabelRegularizationPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
       }
     }
 
-    if (!use_all_classes && !core::is_member(token.class_id, config_.class_id())) continue;
+    if (!use_all_classes && !core::is_member(token.class_id, config_.class_id())) {
+      continue;
+    }
 
     // count sum of weights
     float weights_sum = 0.0f;

--- a/src/artm/regularizer/label_regularization_phi.h
+++ b/src/artm/regularizer/label_regularization_phi.h
@@ -32,8 +32,7 @@ namespace regularizer {
 
 class LabelRegularizationPhi : public RegularizerInterface {
  public:
-  explicit LabelRegularizationPhi(const LabelRegularizationPhiConfig& config)
-    : config_(config) {}
+  explicit LabelRegularizationPhi(const LabelRegularizationPhiConfig& config) : config_(config) { }
 
   virtual bool RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
                              const ::artm::core::PhiMatrix& n_wt,

--- a/src/artm/regularizer/label_regularization_phi.h
+++ b/src/artm/regularizer/label_regularization_phi.h
@@ -20,8 +20,7 @@
 
 */
 
-#ifndef SRC_ARTM_REGULARIZER_LABEL_REGULARIZATION_PHI_H_
-#define SRC_ARTM_REGULARIZER_LABEL_REGULARIZATION_PHI_H_
+#pragma once
 
 #include <string>
 
@@ -49,5 +48,3 @@ class LabelRegularizationPhi : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_LABEL_REGULARIZATION_PHI_H_

--- a/src/artm/regularizer/multilanguage_phi.h
+++ b/src/artm/regularizer/multilanguage_phi.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_REGULARIZER_MULTILANGUAGE_PHI_H_
-#define SRC_ARTM_REGULARIZER_MULTILANGUAGE_PHI_H_
+#pragma once
 
 #include "artm/regularizer_interface.h"
 
@@ -27,5 +26,3 @@ class MultiLanguagePhi : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_MULTILANGUAGE_PHI_H_

--- a/src/artm/regularizer/multilanguage_phi.h
+++ b/src/artm/regularizer/multilanguage_phi.h
@@ -12,7 +12,7 @@ class MultiLanguagePhi : public RegularizerInterface {
  public:
   explicit MultiLanguagePhi(const MultiLanguagePhiConfig& config)
     : config_(config)
-    , no_regularization_calls_(0) {}
+    , no_regularization_calls_(0) { }
 
   virtual bool RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
                              const ::artm::core::PhiMatrix& n_wt,

--- a/src/artm/regularizer/smooth_ptdw.cc
+++ b/src/artm/regularizer/smooth_ptdw.cc
@@ -15,7 +15,8 @@ namespace regularizer {
 
 void SmoothPtdwAgent::Apply(int item_index, int inner_iter, ::artm::utility::LocalPhiMatrix<float>* ptdw) const {
   int local_token_size = ptdw->num_tokens();
-  int num_topics = ptdw->num_topics();
+  int topic_size = ptdw->num_topics();
+
   if (config_.type() == SmoothPtdwConfig_SmoothType_MovingAverage) {
     // 1. evaluate wich tokens are background
     float threshold = config_.threshold();
@@ -24,7 +25,7 @@ void SmoothPtdwAgent::Apply(int item_index, int inner_iter, ::artm::utility::Loc
     for (int i = 0; i < local_token_size; ++i) {
       const float* local_ptdw_ptr = &(*ptdw)(i, 0);  // NOLINT
       float sum_background = 0.0;
-      for (int k = 0; k < num_topics; ++k) {
+      for (int k = 0; k < topic_size; ++k) {
         char b = 'b';
         if (args_.topic_name(k)[0] == b) {  // background topic
           sum_background += local_ptdw_ptr[k];
@@ -35,32 +36,40 @@ void SmoothPtdwAgent::Apply(int item_index, int inner_iter, ::artm::utility::Loc
         ++count_background;
       }
     }
-    // LOG(WARNING) << 1.0 * count_background / local_token_size;
 
     // 2. prepare ptdw copy and smoothing profile
     int h = config_.window() / 2;
     ::artm::utility::LocalPhiMatrix<float> copy_ptdw(*ptdw);
-    ::artm::utility::LocalPhiMatrix<float> smoothed(1, num_topics);
+    ::artm::utility::LocalPhiMatrix<float> smoothed(1, topic_size);
     smoothed.InitializeZeros();
     float* smoothed_ptr = &smoothed(0, 0);
+
     for (int i = 0; i < h && i < local_token_size; ++i) {
-      if (is_background[i]) continue;
+      if (is_background[i]) {
+        continue;
+      }
+
       const float* copy_ptdw_ptr = &copy_ptdw(i, 0);
-      for (int k = 0; k < num_topics; ++k) {
+      for (int k = 0; k < topic_size; ++k) {
         smoothed_ptr[k] += copy_ptdw_ptr[k];
       }
     }
 
     // 3. regularize
     for (int i = 0; i < local_token_size; ++i) {
-      if (is_background[i]) continue;
+      if (is_background[i]) {
+        continue;
+      }
+
       float* local_ptdw_ptr = &(*ptdw)(i, 0);  // NOLINT
-      for (int k = 0; k < num_topics; ++k) {
+      for (int k = 0; k < topic_size; ++k) {
         local_ptdw_ptr[k] += tau_ * smoothed_ptr[k];
-        if (i + h < local_token_size && !is_background[i + h])
+        if (i + h < local_token_size && !is_background[i + h]) {
           smoothed_ptr[k] += copy_ptdw(i + h, k);
-        if (i - h >= 0 && !is_background[i - h])
+        }
+        if (i - h >= 0 && !is_background[i - h]) {
           smoothed_ptr[k] -= copy_ptdw(i - h, k);
+        }
       }
     }
   }
@@ -70,11 +79,13 @@ void SmoothPtdwAgent::Apply(int item_index, int inner_iter, ::artm::utility::Loc
     ::artm::utility::LocalPhiMatrix<float> copy_ptdw(*ptdw);
     for (int i = 0; i < local_token_size; ++i) {
       float* local_ptdw_ptr = &(*ptdw)(i, 0);  // NOLINT
-      for (int k = 0; k < num_topics; ++k) {
-        if (i + 1 < local_token_size)
+      for (int k = 0; k < topic_size; ++k) {
+        if (i + 1 < local_token_size) {
           local_ptdw_ptr[k] *= copy_ptdw(i + 1, k);
-        if (i - 1 >= 0)
+        }
+        if (i - 1 >= 0) {
           local_ptdw_ptr[k] *= copy_ptdw(i - 1, k);
+        }
       }
     }
   }

--- a/src/artm/regularizer/smooth_ptdw.cc
+++ b/src/artm/regularizer/smooth_ptdw.cc
@@ -18,12 +18,12 @@ void SmoothPtdwAgent::Apply(int item_index, int inner_iter, ::artm::utility::Loc
   int num_topics = ptdw->num_topics();
   if (config_.type() == SmoothPtdwConfig_SmoothType_MovingAverage) {
     // 1. evaluate wich tokens are background
-    double threshold = config_.threshold();
+    float threshold = config_.threshold();
     std::vector<bool> is_background(local_token_size, false);
     int count_background = 0;
     for (int i = 0; i < local_token_size; ++i) {
       const float* local_ptdw_ptr = &(*ptdw)(i, 0);  // NOLINT
-      double sum_background = 0.0;
+      float sum_background = 0.0;
       for (int k = 0; k < num_topics; ++k) {
         char b = 'b';
         if (args_.topic_name(k)[0] == b) {  // background topic
@@ -82,7 +82,7 @@ void SmoothPtdwAgent::Apply(int item_index, int inner_iter, ::artm::utility::Loc
 
 std::shared_ptr<RegularizePtdwAgent>
 SmoothPtdw::CreateRegularizePtdwAgent(const Batch& batch,
-                                      const ProcessBatchesArgs& args, double tau) {
+                                      const ProcessBatchesArgs& args, float tau) {
   SmoothPtdwAgent* agent = new SmoothPtdwAgent(config_, args, tau);
   std::shared_ptr<RegularizePtdwAgent> retval(agent);
   return retval;

--- a/src/artm/regularizer/smooth_ptdw.h
+++ b/src/artm/regularizer/smooth_ptdw.h
@@ -25,15 +25,16 @@ class SmoothPtdwAgent : public RegularizePtdwAgent {
 
  public:
   SmoothPtdwAgent(const SmoothPtdwConfig& config, const ProcessBatchesArgs& args, float tau)
-      : config_(config), args_(args), tau_(tau) {}
+    : config_(config)
+    , args_(args)
+    , tau_(tau) { }
 
   virtual void Apply(int item_index, int inner_iter, ::artm::utility::LocalPhiMatrix<float>* ptdw) const;
 };
 
 class SmoothPtdw : public RegularizerInterface {
  public:
-  explicit SmoothPtdw(const SmoothPtdwConfig& config)
-    : config_(config) {}
+  explicit SmoothPtdw(const SmoothPtdwConfig& config) : config_(config) { }
 
   virtual std::shared_ptr<RegularizePtdwAgent>
   CreateRegularizePtdwAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau);

--- a/src/artm/regularizer/smooth_ptdw.h
+++ b/src/artm/regularizer/smooth_ptdw.h
@@ -21,10 +21,10 @@ class SmoothPtdwAgent : public RegularizePtdwAgent {
   friend class SmoothPtdw;
   SmoothPtdwConfig config_;
   ProcessBatchesArgs args_;
-  double tau_;
+  float tau_;
 
  public:
-  SmoothPtdwAgent(const SmoothPtdwConfig& config, const ProcessBatchesArgs& args, double tau)
+  SmoothPtdwAgent(const SmoothPtdwConfig& config, const ProcessBatchesArgs& args, float tau)
       : config_(config), args_(args), tau_(tau) {}
 
   virtual void Apply(int item_index, int inner_iter, ::artm::utility::LocalPhiMatrix<float>* ptdw) const;
@@ -36,7 +36,7 @@ class SmoothPtdw : public RegularizerInterface {
     : config_(config) {}
 
   virtual std::shared_ptr<RegularizePtdwAgent>
-  CreateRegularizePtdwAgent(const Batch& batch, const ProcessBatchesArgs& args, double tau);
+  CreateRegularizePtdwAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau);
 
   virtual bool Reconfigure(const RegularizerConfig& config);
 

--- a/src/artm/regularizer/smooth_ptdw.h
+++ b/src/artm/regularizer/smooth_ptdw.h
@@ -5,8 +5,7 @@
    Work in progress, description will be provided later.
 */
 
-#ifndef SRC_ARTM_REGULARIZER_SMOOTH_PTDW_H_
-#define SRC_ARTM_REGULARIZER_SMOOTH_PTDW_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -47,5 +46,3 @@ class SmoothPtdw : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_SMOOTH_PTDW_H_

--- a/src/artm/regularizer/smooth_ptdw.h
+++ b/src/artm/regularizer/smooth_ptdw.h
@@ -24,9 +24,9 @@ class SmoothPtdwAgent : public RegularizePtdwAgent {
 
  public:
   SmoothPtdwAgent(const SmoothPtdwConfig& config, const ProcessBatchesArgs& args, float tau)
-    : config_(config)
-    , args_(args)
-    , tau_(tau) { }
+      : config_(config)
+      , args_(args)
+      , tau_(tau) { }
 
   virtual void Apply(int item_index, int inner_iter, ::artm::utility::LocalPhiMatrix<float>* ptdw) const;
 };

--- a/src/artm/regularizer/smooth_sparse_phi.cc
+++ b/src/artm/regularizer/smooth_sparse_phi.cc
@@ -15,10 +15,11 @@ namespace regularizer {
 SmoothSparsePhi::SmoothSparsePhi(const SmoothSparsePhiConfig& config)
     : config_(config),
       transform_function_(nullptr) {
-  if (config.has_transform_config())
+  if (config.has_transform_config()) {
     transform_function_ = artm::core::TransformFunction::create(config.transform_config());
-  else
+  } else {
     transform_function_ = artm::core::TransformFunction::create();
+  }
 }
 
 bool SmoothSparsePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
@@ -29,10 +30,11 @@ bool SmoothSparsePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   const int token_size = p_wt.token_size();
 
   std::vector<bool> topics_to_regularize;
-  if (config_.topic_name().size() == 0)
+  if (config_.topic_name().size() == 0) {
     topics_to_regularize.assign(topic_size, true);
-  else
+  } else {
     topics_to_regularize = core::is_member(p_wt.topic_name(), config_.topic_name());
+  }
 
   bool use_all_classes = false;
   if (config_.class_id_size() == 0) {
@@ -40,14 +42,15 @@ bool SmoothSparsePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   }
 
   std::shared_ptr<core::Dictionary> dictionary_ptr = nullptr;
-  if (config_.has_dictionary_name())
+  if (config_.has_dictionary_name()) {
     dictionary_ptr = dictionary(config_.dictionary_name());
+  }
   bool has_dictionary = dictionary_ptr != nullptr;
 
   // proceed the regularization
   for (int token_id = 0; token_id < token_size; ++token_id) {
     float coefficient = 1.0f;
-    const ::artm::core::Token& token = p_wt.token(token_id);
+    const auto& token = p_wt.token(token_id);
     if (has_dictionary) {
       if (use_all_classes ||
           core::is_member(token.class_id, config_.class_id())) {
@@ -87,10 +90,11 @@ bool SmoothSparsePhi::Reconfigure(const RegularizerConfig& config) {
 
   config_.CopyFrom(regularizer_config);
 
-  if (config_.has_transform_config())
+  if (config_.has_transform_config()) {
     transform_function_ = artm::core::TransformFunction::create(config_.transform_config());
-  else
+  } else {
     transform_function_ = artm::core::TransformFunction::create();
+  }
 
   return true;
 }

--- a/src/artm/regularizer/smooth_sparse_phi.cc
+++ b/src/artm/regularizer/smooth_sparse_phi.cc
@@ -60,7 +60,7 @@ bool SmoothSparsePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
     if (!use_all_classes && !core::is_member(token.class_id, config_.class_id())) continue;
     for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
       if (topics_to_regularize[topic_id]) {
-        double value = transform_function_->apply(p_wt.get(token_id, topic_id));
+        float value = transform_function_->apply(p_wt.get(token_id, topic_id));
         result->set(token_id, topic_id, coefficient * value);
       }
     }

--- a/src/artm/regularizer/smooth_sparse_phi.cc
+++ b/src/artm/regularizer/smooth_sparse_phi.cc
@@ -13,8 +13,8 @@ namespace artm {
 namespace regularizer {
 
 SmoothSparsePhi::SmoothSparsePhi(const SmoothSparsePhiConfig& config)
-    : config_(config),
-      transform_function_(nullptr) {
+    : config_(config)
+    , transform_function_(nullptr) {
   if (config.has_transform_config()) {
     transform_function_ = artm::core::TransformFunction::create(config.transform_config());
   } else {
@@ -60,7 +60,10 @@ bool SmoothSparsePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
       }
     }
 
-    if (!use_all_classes && !core::is_member(token.class_id, config_.class_id())) continue;
+    if (!use_all_classes && !core::is_member(token.class_id, config_.class_id())) {
+      continue;
+    }
+
     for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
       if (topics_to_regularize[topic_id]) {
         float value = transform_function_->apply(p_wt.get(token_id, topic_id));

--- a/src/artm/regularizer/smooth_sparse_phi.h
+++ b/src/artm/regularizer/smooth_sparse_phi.h
@@ -22,8 +22,7 @@
 
 */
 
-#ifndef SRC_ARTM_REGULARIZER_SMOOTH_SPARSE_PHI_H_
-#define SRC_ARTM_REGULARIZER_SMOOTH_SPARSE_PHI_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -54,5 +53,3 @@ class SmoothSparsePhi : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_SMOOTH_SPARSE_PHI_H_

--- a/src/artm/regularizer/smooth_sparse_theta.cc
+++ b/src/artm/regularizer/smooth_sparse_theta.cc
@@ -47,15 +47,15 @@ void SmoothSparseThetaAgent::Apply(int item_index, int inner_iter,
     }
 
     for (int topic_id = 0; topic_id < topics_size; ++topic_id) {
-      double mult = use_specific_multiplier ? iter->second[topic_id] :
+      float mult = use_specific_multiplier ? iter->second[topic_id] :
         (use_universal_multiplier ? (*universal_topic_multiplier_)[topic_id]: 1.0);
-      double value = transform_function_->apply(n_td[topic_id]);
+      float value = transform_function_->apply(n_td[topic_id]);
       r_td[topic_id] += value > 0.0f ? mult * alpha_weight[inner_iter] * topic_weight[topic_id] * value : 0.0f;
     }
   } else {
     for (int topic_id = 0; topic_id < topics_size; ++topic_id) {
-      double mult = use_universal_multiplier ? (*universal_topic_multiplier_)[topic_id] : 1.0;
-      double value = transform_function_->apply(n_td[topic_id]);
+      float mult = use_universal_multiplier ? (*universal_topic_multiplier_)[topic_id] : 1.0;
+      float value = transform_function_->apply(n_td[topic_id]);
       r_td[topic_id] += value > 0.0f ? mult * alpha_weight[inner_iter] * topic_weight[topic_id] * value : 0.0f;
     }
   }
@@ -71,7 +71,7 @@ SmoothSparseTheta::SmoothSparseTheta(const SmoothSparseThetaConfig& config)
 
 std::shared_ptr<RegularizeThetaAgent>
 SmoothSparseTheta::CreateRegularizeThetaAgent(const Batch& batch,
-                                              const ProcessBatchesArgs& args, double tau) {
+                                              const ProcessBatchesArgs& args, float tau) {
   SmoothSparseThetaAgent* agent = new SmoothSparseThetaAgent(batch,
                                                              transform_function_,
                                                              item_topic_multiplier_,
@@ -121,7 +121,7 @@ void SmoothSparseTheta::ReconfigureImpl() {
 
   if (config_.item_topic_multiplier_size() == 1) {
     universal_topic_multiplier_.reset(
-      new std::vector<double>(config_.item_topic_multiplier(0).value().begin(),
+      new std::vector<float>(config_.item_topic_multiplier(0).value().begin(),
                               config_.item_topic_multiplier(0).value().end()));
   }
 
@@ -130,7 +130,7 @@ void SmoothSparseTheta::ReconfigureImpl() {
     if (config_.item_topic_multiplier_size() == config_.item_title_size()) {
       for (int i = 0; i < config_.item_title_size(); ++i) {
         item_topic_multiplier_->insert(std::make_pair(config_.item_title(i),
-                                       std::vector<double>(config_.item_topic_multiplier(i).value().begin(),
+                                       std::vector<float>(config_.item_topic_multiplier(i).value().begin(),
                                        config_.item_topic_multiplier(i).value().end())));
         auto m_ptr = config_.mutable_item_topic_multiplier(i);
         m_ptr->clear_value();
@@ -138,7 +138,7 @@ void SmoothSparseTheta::ReconfigureImpl() {
     } else {
       LOG(WARNING) << "SmoothSparseThetaConfig.item_topic_multilplier has incorrect size or is empty";
       for (int i = 0; i < config_.item_title_size(); ++i) {
-        item_topic_multiplier_->insert(std::make_pair(config_.item_title(i), std::vector<double>()));
+        item_topic_multiplier_->insert(std::make_pair(config_.item_title(i), std::vector<float>()));
       }
     }
   }

--- a/src/artm/regularizer/smooth_sparse_theta.cc
+++ b/src/artm/regularizer/smooth_sparse_theta.cc
@@ -101,14 +101,14 @@ SmoothSparseTheta::CreateRegularizeThetaAgent(const Batch& batch,
   agent->topic_weight.resize(topic_size, 0.0f);
   if (config_.topic_name_size() == 0) {
     for (int i = 0; i < topic_size; ++i) {
-      agent->topic_weight[i] = static_cast<float>(tau);
+      agent->topic_weight[i] = tau;
     }
   } else {
     for (int topic_id = 0; topic_id < config_.topic_name_size(); ++topic_id) {
       int topic_index = ::artm::core::repeated_field_index_of(
         args.topic_name(), config_.topic_name(topic_id));
-      if (topic_index != -1) { 
-        agent->topic_weight[topic_index] = static_cast<float>(tau);
+      if (topic_index != -1) {
+        agent->topic_weight[topic_index] = tau;
       }
     }
   }

--- a/src/artm/regularizer/smooth_sparse_theta.cc
+++ b/src/artm/regularizer/smooth_sparse_theta.cc
@@ -18,8 +18,10 @@ void SmoothSparseThetaAgent::Apply(int item_index, int inner_iter,
   assert(item_index >= 0 && item_index < batch_.item_size());
   assert(topics_size == topic_weight.size());
   assert(inner_iter < alpha_weight.size());
-  if (topics_size != topic_weight.size()) return;
-  if (inner_iter >= alpha_weight.size()) return;
+
+  if (topics_size != topic_weight.size() || inner_iter >= alpha_weight.size()) {
+    return;
+  }
 
   const Item& item = batch_.item(item_index);
   const std::string& item_title = item.has_title() ? item.title() : std::string();
@@ -37,8 +39,9 @@ void SmoothSparseThetaAgent::Apply(int item_index, int inner_iter,
 
   if (use_specific_items) {
     auto iter = item_topic_multiplier_->find(item_title);
-    if (item_title.empty() || iter == item_topic_multiplier_->end())
+    if (item_title.empty() || iter == item_topic_multiplier_->end()) {
       return;
+    }
 
     if (use_specific_multiplier && iter->second.size() != topics_size) {
       LOG(ERROR) << "Topic coefs vector for item " << iter->first << " has length != topic_size ("
@@ -86,22 +89,27 @@ SmoothSparseTheta::CreateRegularizeThetaAgent(const Batch& batch,
       return nullptr;
     }
 
-    for (int i = 0; i < config_.alpha_iter_size(); ++i)
+    for (int i = 0; i < config_.alpha_iter_size(); ++i) {
       agent->alpha_weight.push_back(config_.alpha_iter(i));
+    }
   } else {
-    for (int i = 0; i < args.num_document_passes(); ++i)
+    for (int i = 0; i < args.num_document_passes(); ++i) {
       agent->alpha_weight.push_back(1.0f);
+    }
   }
 
   agent->topic_weight.resize(topic_size, 0.0f);
   if (config_.topic_name_size() == 0) {
-    for (int i = 0; i < topic_size; ++i)
+    for (int i = 0; i < topic_size; ++i) {
       agent->topic_weight[i] = static_cast<float>(tau);
+    }
   } else {
     for (int topic_id = 0; topic_id < config_.topic_name_size(); ++topic_id) {
       int topic_index = ::artm::core::repeated_field_index_of(
         args.topic_name(), config_.topic_name(topic_id));
-      if (topic_index != -1) agent->topic_weight[topic_index] = static_cast<float>(tau);
+      if (topic_index != -1) { 
+        agent->topic_weight[topic_index] = static_cast<float>(tau);
+      }
     }
   }
 

--- a/src/artm/regularizer/smooth_sparse_theta.h
+++ b/src/artm/regularizer/smooth_sparse_theta.h
@@ -24,8 +24,7 @@
 
 */
 
-#ifndef SRC_ARTM_REGULARIZER_SMOOTH_SPARSE_THETA_H_
-#define SRC_ARTM_REGULARIZER_SMOOTH_SPARSE_THETA_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -87,5 +86,3 @@ class SmoothSparseTheta : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_SMOOTH_SPARSE_THETA_H_

--- a/src/artm/regularizer/smooth_sparse_theta.h
+++ b/src/artm/regularizer/smooth_sparse_theta.h
@@ -19,7 +19,7 @@
      inner iterations)
    - item_title (an array of string. If not empty => only items with
      titles from this array will be regularized)
-   - item_topic_multiplier (an array of arrays of doubles. Should have
+   - item_topic_multiplier (an array of arrays of floats. Should have
      length 1 or equal to length of item_title)
 
 */
@@ -38,14 +38,14 @@
 namespace artm {
 namespace regularizer {
 
-typedef std::unordered_map<std::string, std::vector<double> > ItemTopicMultiplier;
+typedef std::unordered_map<std::string, std::vector<float> > ItemTopicMultiplier;
 
 class SmoothSparseThetaAgent : public RegularizeThetaAgent {
  public:
   explicit SmoothSparseThetaAgent(const Batch& batch,
                                   std::shared_ptr<artm::core::TransformFunction> func,
                                   std::shared_ptr<ItemTopicMultiplier> item_topic_multiplier,
-                                  std::shared_ptr<std::vector<double> > universal_topic_multiplier)
+                                  std::shared_ptr<std::vector<float> > universal_topic_multiplier)
     : batch_(batch)
     , transform_function_(func)
     , item_topic_multiplier_(item_topic_multiplier)
@@ -62,7 +62,7 @@ class SmoothSparseThetaAgent : public RegularizeThetaAgent {
 
   std::shared_ptr<artm::core::TransformFunction> transform_function_;
   std::shared_ptr<ItemTopicMultiplier> item_topic_multiplier_;
-  std::shared_ptr<std::vector<double> > universal_topic_multiplier_;
+  std::shared_ptr<std::vector<float> > universal_topic_multiplier_;
 };
 
 class SmoothSparseTheta : public RegularizerInterface {
@@ -70,7 +70,7 @@ class SmoothSparseTheta : public RegularizerInterface {
   explicit SmoothSparseTheta(const SmoothSparseThetaConfig& config);
 
   virtual std::shared_ptr<RegularizeThetaAgent>
-  CreateRegularizeThetaAgent(const Batch& batch, const ProcessBatchesArgs& args, double tau);
+  CreateRegularizeThetaAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau);
 
   virtual google::protobuf::RepeatedPtrField<std::string> topics_to_regularize();
 
@@ -82,7 +82,7 @@ class SmoothSparseTheta : public RegularizerInterface {
   SmoothSparseThetaConfig config_;
   std::shared_ptr<artm::core::TransformFunction> transform_function_;
   std::shared_ptr<ItemTopicMultiplier> item_topic_multiplier_;
-  std::shared_ptr<std::vector<double> > universal_topic_multiplier_;
+  std::shared_ptr<std::vector<float> > universal_topic_multiplier_;
 };
 
 }  // namespace regularizer

--- a/src/artm/regularizer/smooth_time_in_topics_phi.cc
+++ b/src/artm/regularizer/smooth_time_in_topics_phi.cc
@@ -47,7 +47,7 @@ bool SmoothTimeInTopicsPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
 
     for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
       if (topics_to_regularize[topic_id]) {
-        double value = p_wt.get(index_prev, topic_id);
+        float value = p_wt.get(index_prev, topic_id);
 
         value *= ((p_wt.get(index_prev_prev, topic_id) - value) > 0.0 ? 1.0 : -1.0) +
                  ((p_wt.get(token_id, topic_id) - value) > 0.0 ? 1.0 : -1.0);

--- a/src/artm/regularizer/smooth_time_in_topics_phi.cc
+++ b/src/artm/regularizer/smooth_time_in_topics_phi.cc
@@ -20,20 +20,22 @@ bool SmoothTimeInTopicsPhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   const int token_size = p_wt.token_size();
 
   std::vector<bool> topics_to_regularize;
-  if (config_.topic_name().size() == 0)
+  if (config_.topic_name().size() == 0) {
     topics_to_regularize.assign(topic_size, true);
-  else
+  } else {
     topics_to_regularize = core::is_member(p_wt.topic_name(), config_.topic_name());
+  }
 
   // proceed the regularization
   // will update only tokens of given modality, that have prev and post tokens of this modality
   int index_prev_prev = -1;
   int index_prev = -1;
   for (int token_id = 0; token_id < token_size; ++token_id) {
-    const ::artm::core::Token& token = p_wt.token(token_id);
+    const auto& token = p_wt.token(token_id);
 
-    if (token.class_id != config_.class_id())
+    if (token.class_id != config_.class_id()) {
       continue;
+    }
 
     if (index_prev_prev < 0) {
       index_prev_prev = token_id;

--- a/src/artm/regularizer/smooth_time_in_topics_phi.h
+++ b/src/artm/regularizer/smooth_time_in_topics_phi.h
@@ -18,8 +18,7 @@
    Note: regularizer ignores first and last tokens of given modality.
 */
 
-#ifndef SRC_ARTM_REGULARIZER_SMOOTH_TIME_IN_TOPICS_PHI_H_
-#define SRC_ARTM_REGULARIZER_SMOOTH_TIME_IN_TOPICS_PHI_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -48,5 +47,3 @@ class SmoothTimeInTopicsPhi : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_SMOOTH_TIME_IN_TOPICS_PHI_H_

--- a/src/artm/regularizer/specified_sparse_phi.cc
+++ b/src/artm/regularizer/specified_sparse_phi.cc
@@ -15,9 +15,9 @@ namespace artm {
 namespace regularizer {
 
 struct Comparator {
-    bool operator() (std::pair<int, float> left, std::pair<int, float> right) {
-        return left.second > right.second;
-    }
+  bool operator() (std::pair<int, float> left, std::pair<int, float> right) {
+    return left.second > right.second;
+  }
 };
 
 bool SpecifiedSparsePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
@@ -28,21 +28,26 @@ bool SpecifiedSparsePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
   const int token_size = n_wt.token_size();
 
   std::vector<bool> topics_to_regularize;
-  if (config_.topic_name().size() == 0)
+  if (config_.topic_name().size() == 0) {
     topics_to_regularize.assign(topic_size, true);
-  else
+  } else {
     topics_to_regularize = core::is_member(n_wt.topic_name(), config_.topic_name());
+  }
 
-  // proceed the regularization
-  bool mode_topics = config_.mode() == artm::SpecifiedSparsePhiConfig_SparseMode_SparseTopics;
+  const  bool mode_topics = config_.mode() == artm::SpecifiedSparsePhiConfig_SparseMode_SparseTopics;
   const int global_end = mode_topics ? topic_size : token_size;
   const int local_end = !mode_topics ? topic_size : token_size;
 
+  // proceed the regularization
   for (int global_index = 0; global_index < global_end; ++global_index) {
     if (mode_topics) {
-      if (!topics_to_regularize[global_index]) continue;
+      if (!topics_to_regularize[global_index]) {
+        continue;
+      }
     } else {
-      if (n_wt.token(global_index).class_id != config_.class_id()) continue;
+      if (n_wt.token(global_index).class_id != config_.class_id()) {
+        continue;
+      }
     }
 
     google::protobuf::RepeatedField<int> indices_of_max;
@@ -54,12 +59,16 @@ bool SpecifiedSparsePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
 
     for (int local_index = 0; local_index < local_end; ++local_index) {
       if (mode_topics) {
-        if (n_wt.token(local_index).class_id != config_.class_id()) continue;
+        if (n_wt.token(local_index).class_id != config_.class_id()) {
+          continue;
+	}
       } else {
-        if (!topics_to_regularize[local_index]) continue;
+        if (!topics_to_regularize[local_index]) {
+          continue;
+	}
       }
 
-      auto value = std::pair<int, float>(local_index,
+      const auto value = std::pair<int, float>(local_index,
           mode_topics ? n_wt.get(local_index, global_index) : n_wt.get(global_index, local_index));
       normalizer += value.second;
 

--- a/src/artm/regularizer/specified_sparse_phi.cc
+++ b/src/artm/regularizer/specified_sparse_phi.cc
@@ -61,11 +61,11 @@ bool SpecifiedSparsePhi::RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
       if (mode_topics) {
         if (n_wt.token(local_index).class_id != config_.class_id()) {
           continue;
-	}
+        }
       } else {
         if (!topics_to_regularize[local_index]) {
           continue;
-	}
+        }
       }
 
       const auto value = std::pair<int, float>(local_index,

--- a/src/artm/regularizer/specified_sparse_phi.h
+++ b/src/artm/regularizer/specified_sparse_phi.h
@@ -19,8 +19,7 @@
 
 */
 
-#ifndef SRC_ARTM_REGULARIZER_SPECIFIED_SPARSE_PHI_H_
-#define SRC_ARTM_REGULARIZER_SPECIFIED_SPARSE_PHI_H_
+#pragma once
 
 #include <string>
 
@@ -48,5 +47,3 @@ class SpecifiedSparsePhi : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_SPECIFIED_SPARSE_PHI_H_

--- a/src/artm/regularizer/specified_sparse_phi.h
+++ b/src/artm/regularizer/specified_sparse_phi.h
@@ -31,8 +31,7 @@ namespace regularizer {
 
 class SpecifiedSparsePhi : public RegularizerInterface {
  public:
-  explicit SpecifiedSparsePhi(const SpecifiedSparsePhiConfig& config)
-    : config_(config) {}
+  explicit SpecifiedSparsePhi(const SpecifiedSparsePhiConfig& config) : config_(config) { }
 
   virtual bool RegularizePhi(const ::artm::core::PhiMatrix& p_wt,
                              const ::artm::core::PhiMatrix& n_wt,

--- a/src/artm/regularizer/topic_segmentation_ptdw.cc
+++ b/src/artm/regularizer/topic_segmentation_ptdw.cc
@@ -1,6 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-// Author: Anastasia Bayandina
+// Author: Anastasia Bayandina (anast.bayandina@gmail.com)
 
 #include <vector>
 #include <algorithm>
@@ -18,7 +18,7 @@ void TopicSegmentationPtdwAgent::Apply(int item_index, int inner_iter,
                                        ::artm::utility::LocalPhiMatrix<float>* ptdw) const {
   int local_token_size = ptdw->no_rows();
   int num_topics = ptdw->no_columns();
-  std::vector<double> background_probability(local_token_size, 0.0);
+  std::vector<float> background_probability(local_token_size, 0.0f);
   // if background topics are given, count probability for each word to be background
   if (config_.background_topic_names().size()) {
     std::vector<bool> is_background_topic = core::is_member(args_.topic_name(), config_.background_topic_names());
@@ -33,12 +33,12 @@ void TopicSegmentationPtdwAgent::Apply(int item_index, int inner_iter,
   }
 
   int h = config_.window();
-  double threshold_topic_change = config_.threshold();
+  float threshold_topic_change = config_.threshold();
   ::artm::utility::DenseMatrix<float> copy_ptdw(*ptdw);
-  std::vector<double> left_distribution(num_topics, 0.0);
-  std::vector<double> right_distribution(num_topics, 0.0);
-  double left_weights = 0.0;
-  double right_weights = 0.0;
+  std::vector<float> left_distribution(num_topics, 0.0f);
+  std::vector<float> right_distribution(num_topics, 0.0f);
+  float left_weights = 0.0f;
+  float right_weights = 0.0f;
   int l_topic, r_topic;  // topic ids on which maximum of the distribution is reached
   bool changes_topic = false;
   int main_topic = 0;
@@ -88,10 +88,10 @@ void TopicSegmentationPtdwAgent::Apply(int item_index, int inner_iter,
     auto re = right_distribution.end();
     l_topic = std::distance(lb, std::max_element(lb, le));
     r_topic = std::distance(rb, std::max_element(rb, re));
-    double ll =  left_distribution[l_topic];
-    double rl = right_distribution[l_topic];
-    double rr = right_distribution[r_topic];
-    double lr =  left_distribution[r_topic];
+    float ll =  left_distribution[l_topic];
+    float rl = right_distribution[l_topic];
+    float rr = right_distribution[r_topic];
+    float lr =  left_distribution[r_topic];
     changes_topic = ((ll / left_weights  - rl / right_weights) / 2 +
                      (rr / right_weights - lr / left_weights)  / 2 > threshold_topic_change);
     if (changes_topic) {
@@ -109,7 +109,7 @@ void TopicSegmentationPtdwAgent::Apply(int item_index, int inner_iter,
 
 std::shared_ptr<RegularizePtdwAgent>
 TopicSegmentationPtdw::CreateRegularizePtdwAgent(const Batch& batch,
-                                                 const ProcessBatchesArgs& args, double tau) {
+                                                 const ProcessBatchesArgs& args, float tau) {
   TopicSegmentationPtdwAgent* agent = new TopicSegmentationPtdwAgent(config_, args, tau);
   std::shared_ptr<RegularizePtdwAgent> retval(agent);
   return retval;

--- a/src/artm/regularizer/topic_segmentation_ptdw.cc
+++ b/src/artm/regularizer/topic_segmentation_ptdw.cc
@@ -16,15 +16,16 @@ namespace regularizer {
 
 void TopicSegmentationPtdwAgent::Apply(int item_index, int inner_iter,
                                        ::artm::utility::LocalPhiMatrix<float>* ptdw) const {
-  int local_token_size = ptdw->no_rows();
-  int num_topics = ptdw->no_columns();
+  const int local_token_size = ptdw->no_rows();
+  const int topic_size = ptdw->no_columns();
   std::vector<float> background_probability(local_token_size, 0.0f);
+
   // if background topics are given, count probability for each word to be background
   if (config_.background_topic_names().size()) {
     std::vector<bool> is_background_topic = core::is_member(args_.topic_name(), config_.background_topic_names());
     for (int i = 0; i < local_token_size; ++i) {
       const float* local_ptdw_ptr = &(*ptdw)(i, 0);  // NOLINT
-      for (int k = 0; k < num_topics; ++k) {
+      for (int k = 0; k < topic_size; ++k) {
         if (is_background_topic[k]) {
           background_probability[i] += local_ptdw_ptr[k];
         }
@@ -35,49 +36,51 @@ void TopicSegmentationPtdwAgent::Apply(int item_index, int inner_iter,
   int h = config_.window();
   float threshold_topic_change = config_.threshold();
   ::artm::utility::DenseMatrix<float> copy_ptdw(*ptdw);
-  std::vector<float> left_distribution(num_topics, 0.0f);
-  std::vector<float> right_distribution(num_topics, 0.0f);
+  std::vector<float> left_distribution(topic_size, 0.0f);
+  std::vector<float> right_distribution(topic_size, 0.0f);
+
   float left_weights = 0.0f;
   float right_weights = 0.0f;
   int l_topic, r_topic;  // topic ids on which maximum of the distribution is reached
   bool changes_topic = false;
   int main_topic = 0;
+
   auto main_topic_density = (*ptdw)(0, 0);
-  for (int k = 0; k < num_topics; ++k) {
+  for (int k = 0; k < topic_size; ++k) {
     auto cur_topic_density = (*ptdw)(0, k);
     if (main_topic_density < cur_topic_density) {
       main_topic_density = cur_topic_density;
       main_topic = k;
     }
   }
-  for (int k = 0; k < num_topics; ++k) {
+  for (int k = 0; k < topic_size; ++k) {
     if (k == main_topic) {
-      (*ptdw)(0, k) = 1;
+      (*ptdw)(0, k) = 1.0f;
     } else {
-      (*ptdw)(0, k) = 0;
+      (*ptdw)(0, k) = 0.0f;
     }
   }
   for (int i = 0; i < h && i < local_token_size; ++i) {
-    for (int k = 0; k < num_topics; ++k) {
+    for (int k = 0; k < topic_size; ++k) {
       right_distribution[k] += copy_ptdw(i, k) * (1 - background_probability[i]);
     }
     right_weights += 1 - background_probability[i];
   }
   for (int i = 1; i < local_token_size; ++i) {
-    for (int k = 0; k < num_topics; ++k) {
+    for (int k = 0; k < topic_size; ++k) {
       left_distribution[k] += copy_ptdw(i - 1, k) * (1 - background_probability[i - 1]);
       right_distribution[k] -= copy_ptdw(i - 1, k) * (1 - background_probability[i - 1]);
     }
     left_weights += 1 - background_probability[i - 1];
     right_weights -= 1 - background_probability[i - 1];
     if (i <= local_token_size - h) {
-      for (int k = 0; k < num_topics; ++k) {
+      for (int k = 0; k < topic_size; ++k) {
         right_distribution[k] += copy_ptdw(i + h - 1, k) * (1 - background_probability[i + h - 1]);
       }
       right_weights += 1 - background_probability[i + h - 1];
     }
     if (i > h) {
-      for (int k = 0; k < num_topics; ++k) {
+      for (int k = 0; k < topic_size; ++k) {
         left_distribution[k] -= copy_ptdw(i - h - 1, k) * (1 - background_probability[i - h - 1]);
       }
       left_weights -= 1 - background_probability[i - h - 1];
@@ -86,22 +89,25 @@ void TopicSegmentationPtdwAgent::Apply(int item_index, int inner_iter,
     auto le = left_distribution.end();
     auto rb = right_distribution.begin();
     auto re = right_distribution.end();
+
     l_topic = std::distance(lb, std::max_element(lb, le));
     r_topic = std::distance(rb, std::max_element(rb, re));
+
     float ll =  left_distribution[l_topic];
     float rl = right_distribution[l_topic];
     float rr = right_distribution[r_topic];
     float lr =  left_distribution[r_topic];
+
     changes_topic = ((ll / left_weights  - rl / right_weights) / 2 +
                      (rr / right_weights - lr / left_weights)  / 2 > threshold_topic_change);
     if (changes_topic) {
       main_topic = r_topic;
     }
-    for (int k = 0; k < num_topics; ++k) {
+    for (int k = 0; k < topic_size; ++k) {
       if (k == main_topic) {
-        (*ptdw)(i, k) = 1;
+        (*ptdw)(i, k) = 1.0f;
       } else {
-        (*ptdw)(i, k) = 0;
+        (*ptdw)(i, k) = 0.0f;
       }
     }
   }

--- a/src/artm/regularizer/topic_segmentation_ptdw.h
+++ b/src/artm/regularizer/topic_segmentation_ptdw.h
@@ -23,8 +23,8 @@ class TopicSegmentationPtdwAgent : public RegularizePtdwAgent {
 
  public:
   TopicSegmentationPtdwAgent(const TopicSegmentationPtdwConfig& config, const ProcessBatchesArgs& args, float tau)
-    : config_(config)
-    , args_(args) { }
+      : config_(config)
+      , args_(args) { }
 
   virtual void Apply(int item_index, int inner_iter, ::artm::utility::LocalPhiMatrix<float>* ptdw) const;
 };

--- a/src/artm/regularizer/topic_segmentation_ptdw.h
+++ b/src/artm/regularizer/topic_segmentation_ptdw.h
@@ -23,7 +23,7 @@ class TopicSegmentationPtdwAgent : public RegularizePtdwAgent {
   ProcessBatchesArgs args_;
 
  public:
-  TopicSegmentationPtdwAgent(const TopicSegmentationPtdwConfig& config, const ProcessBatchesArgs& args, double tau)
+  TopicSegmentationPtdwAgent(const TopicSegmentationPtdwConfig& config, const ProcessBatchesArgs& args, float tau)
     : config_(config), args_(args) {}
 
   virtual void Apply(int item_index, int inner_iter, ::artm::utility::LocalPhiMatrix<float>* ptdw) const;
@@ -35,7 +35,7 @@ class TopicSegmentationPtdw : public RegularizerInterface {
   : config_(config) {}
 
   virtual std::shared_ptr<RegularizePtdwAgent>
-  CreateRegularizePtdwAgent(const Batch& batch, const ProcessBatchesArgs& args, double tau);
+  CreateRegularizePtdwAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau);
 
   virtual bool Reconfigure(const RegularizerConfig& config);
 

--- a/src/artm/regularizer/topic_segmentation_ptdw.h
+++ b/src/artm/regularizer/topic_segmentation_ptdw.h
@@ -1,12 +1,11 @@
 /* Copyright 2017, Additive Regularization of Topic Models.
 
-   Author: Anastasia Bayandina
+   Author: Anastasia Bayandina (anast.bayandina@gmail.com)
 
    ToDo: Description will be updated later
 */
 
-#ifndef SRC_ARTM_REGULARIZER_TOPIC_SEGMENTATION_PTDW_H_
-#define SRC_ARTM_REGULARIZER_TOPIC_SEGMENTATION_PTDW_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -45,5 +44,3 @@ class TopicSegmentationPtdw : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_TOPIC_SEGMENTATION_PTDW_H_

--- a/src/artm/regularizer/topic_segmentation_ptdw.h
+++ b/src/artm/regularizer/topic_segmentation_ptdw.h
@@ -24,15 +24,15 @@ class TopicSegmentationPtdwAgent : public RegularizePtdwAgent {
 
  public:
   TopicSegmentationPtdwAgent(const TopicSegmentationPtdwConfig& config, const ProcessBatchesArgs& args, float tau)
-    : config_(config), args_(args) {}
+    : config_(config)
+    , args_(args) { }
 
   virtual void Apply(int item_index, int inner_iter, ::artm::utility::LocalPhiMatrix<float>* ptdw) const;
 };
 
 class TopicSegmentationPtdw : public RegularizerInterface {
  public:
-  explicit TopicSegmentationPtdw(const TopicSegmentationPtdwConfig& config)
-  : config_(config) {}
+  explicit TopicSegmentationPtdw(const TopicSegmentationPtdwConfig& config) : config_(config) { }
 
   virtual std::shared_ptr<RegularizePtdwAgent>
   CreateRegularizePtdwAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau);

--- a/src/artm/regularizer/topic_selection_theta.cc
+++ b/src/artm/regularizer/topic_selection_theta.cc
@@ -43,7 +43,7 @@ void TopicSelectionThetaAgent::Apply(int inner_iter,
 
   auto local_topic_value = topic_value;
   if (local_topic_value.empty()) {
-    std::vector<double> n_t(topics_num, 0.0);
+    std::vector<float> n_t(topics_num, 0.0);
     double n = 0.0;
 
     // count n_t
@@ -56,7 +56,7 @@ void TopicSelectionThetaAgent::Apply(int inner_iter,
       n += n_t[topic_id];
 
     for (int topic_id = 0; topic_id < topics_num; ++topic_id) {
-      double val = n_t[topic_id] * topics_num;
+      float val = n_t[topic_id] * topics_num;
       local_topic_value.push_back((val > 0) ? static_cast<float>(n / val) : 0.0f);
     }
   }
@@ -74,7 +74,7 @@ TopicSelectionTheta::TopicSelectionTheta(const TopicSelectionThetaConfig& config
 
 std::shared_ptr<RegularizeThetaAgent>
 TopicSelectionTheta::CreateRegularizeThetaAgent(const Batch& batch,
-                                                const ProcessBatchesArgs& args, double tau) {
+                                                const ProcessBatchesArgs& args, float tau) {
   TopicSelectionThetaAgent* agent = new TopicSelectionThetaAgent();
   std::shared_ptr<TopicSelectionThetaAgent> retval(agent);
 

--- a/src/artm/regularizer/topic_selection_theta.cc
+++ b/src/artm/regularizer/topic_selection_theta.cc
@@ -28,8 +28,9 @@ void TopicSelectionThetaAgent::Apply(int item_index, int inner_iter, int topics_
   }
 
   for (int topic_id = 0; topic_id < topics_size; ++topic_id) {
-    if (n_td[topic_id] > 0.0f)
+    if (n_td[topic_id] > 0.0f) {
       r_td[topic_id] += alpha_weight[inner_iter] * topic_weight[topic_id] * topic_value[topic_id] * n_td[topic_id];
+    }
   }
 }
 

--- a/src/artm/regularizer/topic_selection_theta.cc
+++ b/src/artm/regularizer/topic_selection_theta.cc
@@ -22,8 +22,10 @@ void TopicSelectionThetaAgent::Apply(int item_index, int inner_iter, int topics_
 
   assert(topics_size == topic_weight.size());
   assert(inner_iter < alpha_weight.size());
-  if (topics_size != topic_weight.size()) return;
-  if (inner_iter >= alpha_weight.size()) return;
+
+  if (topics_size != topic_weight.size() || inner_iter >= alpha_weight.size()) {
+    return;
+  }
 
   for (int topic_id = 0; topic_id < topics_size; ++topic_id) {
     if (n_td[topic_id] > 0.0f)
@@ -34,40 +36,49 @@ void TopicSelectionThetaAgent::Apply(int item_index, int inner_iter, int topics_
 void TopicSelectionThetaAgent::Apply(int inner_iter,
                                      const ::artm::utility::LocalThetaMatrix<float>& n_td,
                                      ::artm::utility::LocalThetaMatrix<float>* r_td) const {
-  int topics_num = n_td.num_topics(), items_num = n_td.num_items();
+  const int topic_size = n_td.num_topics();
+  const int item_size = n_td.num_items();
 
-  assert(topics_num == topic_weight.size());
+  assert(topic_size == topic_weight.size());
   assert(inner_iter < alpha_weight.size());
-  if (topics_num != topic_weight.size()) return;
-  if (inner_iter >= alpha_weight.size()) return;
+
+  if (topic_size != topic_weight.size() || inner_iter >= alpha_weight.size()) {
+    return;
+  }
 
   auto local_topic_value = topic_value;
   if (local_topic_value.empty()) {
-    std::vector<float> n_t(topics_num, 0.0);
+    std::vector<float> n_t(topic_size, 0.0f);
     double n = 0.0;
 
     // count n_t
-    for (int item_id = 0; item_id < items_num; ++item_id)
-      for (int topic_id = 0; topic_id < topics_num; ++topic_id)
+    for (int item_id = 0; item_id < item_size; ++item_id) {
+      for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
         n_t[topic_id] += n_td(topic_id, item_id);
+      }
+    }
 
     // count n = sum(n_t)
-    for (int topic_id = 0; topic_id < topics_num; ++topic_id)
+    for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
       n += n_t[topic_id];
+    }
 
-    for (int topic_id = 0; topic_id < topics_num; ++topic_id) {
-      float val = n_t[topic_id] * topics_num;
+    for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
+      float val = n_t[topic_id] * topic_size;
       local_topic_value.push_back((val > 0) ? static_cast<float>(n / val) : 0.0f);
     }
   }
 
-  for (int item_id = 0; item_id < items_num; ++item_id)
-    for (int topic_id = 0; topic_id < topics_num; ++topic_id)
-      if (n_td(topic_id, item_id) > 0.0f)
+  for (int item_id = 0; item_id < item_size; ++item_id) {
+    for (int topic_id = 0; topic_id < topic_size; ++topic_id) {
+      if (n_td(topic_id, item_id) > 0.0f) {
         (*r_td)(topic_id, item_id) += alpha_weight[inner_iter] *
                                       topic_weight[topic_id] *
                                       local_topic_value[topic_id] *
                                       n_td(topic_id, item_id);
+      }
+    }
+  }
 }
 
 TopicSelectionTheta::TopicSelectionTheta(const TopicSelectionThetaConfig& config) : config_(config) { }
@@ -86,21 +97,24 @@ TopicSelectionTheta::CreateRegularizeThetaAgent(const Batch& batch,
       return nullptr;
     }
 
-    for (int i = 0; i < config_.alpha_iter_size(); ++i)
+    for (int i = 0; i < config_.alpha_iter_size(); ++i) {
       agent->alpha_weight.push_back(config_.alpha_iter(i));
+    }
   } else {
-    for (int i = 0; i < args.num_document_passes(); ++i)
+    for (int i = 0; i < args.num_document_passes(); ++i) {
       agent->alpha_weight.push_back(1.0f);
+    }
   }
 
   if (config_.topic_value_size()) {
     if (topic_size != config_.topic_value_size()) {
-      LOG(ERROR) << "ProcessBatchesArgs.num_topics() != TopicSelectionThetaConfig.topic_value_size()";
+      LOG(ERROR) << "ProcessBatchesArgs.topic_name_size() != TopicSelectionThetaConfig.topic_value_size()";
       return nullptr;
     }
 
-    for (int i = 0; i < topic_size; ++i)
+    for (int i = 0; i < topic_size; ++i) {
       agent->topic_value.push_back(config_.topic_value(i));
+    }
   } else {
     // Keep topic_value empty, and assume we are running in opt_for_avx mode.
     // Then topic_value will be calculated from local theta matrix (per batch).
@@ -108,8 +122,9 @@ TopicSelectionTheta::CreateRegularizeThetaAgent(const Batch& batch,
 
   agent->topic_weight.resize(topic_size, 0.0f);
   if (config_.topic_name_size() == 0) {
-    for (int i = 0; i < topic_size; ++i)
-      agent->topic_weight[i] = static_cast<float>(-tau);
+    for (int i = 0; i < topic_size; ++i) {
+      agent->topic_weight[i] = -tau;
+    }
   } else {
     if (topic_size != args.topic_name_size()) {
       LOG(ERROR) << "args.num_topics() != args.topic_name_size()";
@@ -119,7 +134,9 @@ TopicSelectionTheta::CreateRegularizeThetaAgent(const Batch& batch,
     for (int topic_id = 0; topic_id < config_.topic_name_size(); ++topic_id) {
       int topic_index = ::artm::core::repeated_field_index_of(
         args.topic_name(), config_.topic_name(topic_id));
-      if (topic_index != -1) agent->topic_weight[topic_index] = static_cast<float>(-tau);
+      if (topic_index != -1) {
+        agent->topic_weight[topic_index] = -tau;
+      }
     }
   }
 

--- a/src/artm/regularizer/topic_selection_theta.h
+++ b/src/artm/regularizer/topic_selection_theta.h
@@ -20,8 +20,7 @@
 
 */
 
-#ifndef SRC_ARTM_REGULARIZER_TOPIC_SELECTION_THETA_H_
-#define SRC_ARTM_REGULARIZER_TOPIC_SELECTION_THETA_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -63,5 +62,3 @@ class TopicSelectionTheta : public RegularizerInterface {
 
 }  // namespace regularizer
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_TOPIC_SELECTION_THETA_H_

--- a/src/artm/regularizer/topic_selection_theta.h
+++ b/src/artm/regularizer/topic_selection_theta.h
@@ -51,7 +51,7 @@ class TopicSelectionTheta : public RegularizerInterface {
   explicit TopicSelectionTheta(const TopicSelectionThetaConfig& config);
 
   virtual std::shared_ptr<RegularizeThetaAgent>
-  CreateRegularizeThetaAgent(const Batch& batch, const ProcessBatchesArgs& args, double tau);
+  CreateRegularizeThetaAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau);
 
   virtual google::protobuf::RepeatedPtrField<std::string> topics_to_regularize();
 

--- a/src/artm/regularizer_interface.cc
+++ b/src/artm/regularizer_interface.cc
@@ -13,13 +13,15 @@ std::shared_ptr< ::artm::core::Dictionary> RegularizerInterface::dictionary(cons
 void RegularizeThetaAgent::Apply(int inner_iter,
                                  const ::artm::utility::LocalThetaMatrix<float>& n_td,
                                  ::artm::utility::LocalThetaMatrix<float>* r_td) const {
-  if (!n_td.is_equal_size(*r_td))
+  if (!n_td.is_equal_size(*r_td)) {
     LOG(ERROR) << "Size mismatch between n_td and r_rd";
+  }
 
   // The default implementation just calls Apply() for all items
   // Custom implementation may implement any other method that jointly acts on all items within a batch.
-  for (int item_index = 0; item_index < n_td.num_items(); ++item_index)
+  for (int item_index = 0; item_index < n_td.num_items(); ++item_index) {
     this->Apply(item_index, inner_iter, n_td.num_topics(), &(n_td)(0, item_index), &(*r_td)(0, item_index));  // NOLINT
+  }
 }
 
 }  // namespace artm

--- a/src/artm/regularizer_interface.h
+++ b/src/artm/regularizer_interface.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_REGULARIZER_INTERFACE_H_
-#define SRC_ARTM_REGULARIZER_INTERFACE_H_
+#pragma once
 
 #include <vector>
 #include <map>
@@ -95,5 +94,3 @@ class RegularizerInterface {
 };
 
 }  // namespace artm
-
-#endif  // SRC_ARTM_REGULARIZER_INTERFACE_H_

--- a/src/artm/regularizer_interface.h
+++ b/src/artm/regularizer_interface.h
@@ -65,12 +65,12 @@ class RegularizerInterface {
   virtual ~RegularizerInterface() { }
 
   virtual std::shared_ptr<RegularizeThetaAgent>
-  CreateRegularizeThetaAgent(const Batch& batch, const ProcessBatchesArgs& args, double tau) {
+  CreateRegularizeThetaAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau) {
     return nullptr;
   }
 
   virtual std::shared_ptr<RegularizePtdwAgent>
-  CreateRegularizePtdwAgent(const Batch& batch, const ProcessBatchesArgs& args, double tau) {
+  CreateRegularizePtdwAgent(const Batch& batch, const ProcessBatchesArgs& args, float tau) {
     return nullptr;
   }
 

--- a/src/artm/regularizer_interface.h
+++ b/src/artm/regularizer_interface.h
@@ -26,10 +26,10 @@ typedef ThreadSafeCollectionHolder<std::string, Dictionary> ThreadSafeDictionary
 
 class RegularizeThetaAgent {
  public:
-  virtual ~RegularizeThetaAgent() {}
+  virtual ~RegularizeThetaAgent() { }
 
   // Define how theta regularizer applies to an individual item.
-  virtual void Apply(int item_index, int inner_iter, int topics_size, const float* n_td, float* r_td) const {}
+  virtual void Apply(int item_index, int inner_iter, int topics_size, const float* n_td, float* r_td) const { }
 
   // The following method allows to calculate regularization for all elements of the theta matrix.
   // This seems convenient, however we do not recommended to overwrite this method.
@@ -44,7 +44,7 @@ class RegularizeThetaAgent {
 
 class RegularizePtdwAgent {
  public:
-  virtual ~RegularizePtdwAgent() {}
+  virtual ~RegularizePtdwAgent() { }
   virtual void Apply(int item_index, int inner_iter, ::artm::utility::LocalPhiMatrix<float>* ptdw) const = 0;
 };
 
@@ -60,7 +60,7 @@ class RegularizePtdwAgent {
 // to avoid looking at strings (topic_name) during processing of each individual item.
 class RegularizerInterface {
  public:
-  RegularizerInterface() {}
+  RegularizerInterface() { }
   virtual ~RegularizerInterface() { }
 
   virtual std::shared_ptr<RegularizeThetaAgent>

--- a/src/artm/score/background_tokens_ratio.cc
+++ b/src/artm/score/background_tokens_ratio.cc
@@ -13,7 +13,7 @@ namespace artm {
 namespace score {
 
 std::shared_ptr<Score> BackgroundTokensRatio::CalculateScore(const artm::core::PhiMatrix& p_wt) {
-  // parameters preparation 
+  // parameters preparation
   const int topic_size = p_wt.topic_size();
   const int token_size = p_wt.token_size();
 
@@ -70,14 +70,14 @@ std::shared_ptr<Score> BackgroundTokensRatio::CalculateScore(const artm::core::P
 
           if (p_tw > 0.0f) {
             kl_value += direct_kl ? (p_t * log(p_t / p_tw)) : (p_tw * log(p_tw / p_t));
-	  }
+          }
         }
 
         if (kl_value > delta_threshold) {
-          num_bgr_tokens++;
+          ++num_bgr_tokens;
           if (save_tokens) {
             bcg_tokens.push_back(token);
-	  }
+          }
         }
       }
     }

--- a/src/artm/score/background_tokens_ratio.cc
+++ b/src/artm/score/background_tokens_ratio.cc
@@ -13,29 +13,30 @@ namespace artm {
 namespace score {
 
 std::shared_ptr<Score> BackgroundTokensRatio::CalculateScore(const artm::core::PhiMatrix& p_wt) {
-  int topic_size = p_wt.topic_size();
-  int token_size = p_wt.token_size();
+  // parameters preparation 
+  const int topic_size = p_wt.topic_size();
+  const int token_size = p_wt.token_size();
 
-  // parameters preparation
-  float delta_threshold = config_.delta_threshold();
+  const float delta_threshold = config_.delta_threshold();
   if (delta_threshold < 0.0f) {
     BOOST_THROW_EXCEPTION(artm::core::ArgumentOutOfRangeException(
       "BackgroundTokensRatioScoreConfig.delta_threshold",
       config_.delta_threshold()));
   }
 
-  bool direct_kl = config_.direct_kl();
-  bool save_tokens = config_.save_tokens();
+  const bool direct_kl = config_.direct_kl();
+  const bool save_tokens = config_.save_tokens();
 
   ::artm::core::ClassId class_id = ::artm::core::DefaultClass;
-  if (config_.has_class_id())
+  if (config_.has_class_id()) {
     class_id = config_.class_id();
+  }
 
   // count score
   auto btp_score = new BackgroundTokensRatioScore();
   std::shared_ptr<Score> retval(btp_score);
 
-  auto n_wt = GetPhiMatrix(instance_->config()->nwt_name());
+  const auto& n_wt = GetPhiMatrix(instance_->config()->nwt_name());
   std::vector<float> n_t(topic_size, 0.0f);
   std::vector<std::vector<core::Token> > topic_kernel_tokens(
     topic_size, std::vector<core::Token>());
@@ -52,11 +53,12 @@ std::shared_ptr<Score> BackgroundTokensRatio::CalculateScore(const artm::core::P
   int num_bgr_tokens = 0;
   std::vector<artm::core::Token> bcg_tokens;
   for (int token_index = 0; token_index < token_size; ++token_index) {
-    auto token = p_wt.token(token_index);
+    const auto& token = p_wt.token(token_index);
     if (token.class_id == class_id) {
       float p_w = 0.0f;
-      for (int topic_index = 0; topic_index < topic_size; ++topic_index)
+      for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
         p_w += p_wt.get(token_index, topic_index) * n_t[topic_index];
+      }
       p_w = (n > 0.0f) ? p_w / n : 0.0f;
 
       float kl_value = 0.0f;
@@ -66,22 +68,25 @@ std::shared_ptr<Score> BackgroundTokensRatio::CalculateScore(const artm::core::P
           float p_t = n_t[topic_index] / n;
           float p_tw = value * p_t / p_w;
 
-          if (p_tw > 0.0f)
+          if (p_tw > 0.0f) {
             kl_value += direct_kl ? (p_t * log(p_t / p_tw)) : (p_tw * log(p_tw / p_t));
+	  }
         }
 
         if (kl_value > delta_threshold) {
           num_bgr_tokens++;
-          if (save_tokens)
+          if (save_tokens) {
             bcg_tokens.push_back(token);
+	  }
         }
       }
     }
   }
 
   btp_score->set_value(token_size > 0 ? (static_cast<float>(num_bgr_tokens) / token_size) : 0.0f);
-  for (const auto& token : bcg_tokens)
+  for (const auto& token : bcg_tokens) {
     btp_score->add_token(token.keyword);
+  }
 
   return retval;
 }

--- a/src/artm/score/background_tokens_ratio.h
+++ b/src/artm/score/background_tokens_ratio.h
@@ -17,8 +17,7 @@
                 default true)
 */
 
-#ifndef SRC_ARTM_SCORE_BACKGROUND_TOKENS_RATIO_H_
-#define SRC_ARTM_SCORE_BACKGROUND_TOKENS_RATIO_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -47,5 +46,3 @@ class BackgroundTokensRatio : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_BACKGROUND_TOKENS_RATIO_H_

--- a/src/artm/score/class_precision.cc
+++ b/src/artm/score/class_precision.cc
@@ -20,21 +20,24 @@ void ClassPrecision::AppendScore(
     const artm::ProcessBatchesArgs& args,
     const std::vector<float>& theta,
     Score* score) {
-  if (!args.has_predict_class_id())
+  if (!args.has_predict_class_id()) {
     return;
+  }
 
-  int topic_size = p_wt.topic_size();
+  const int topic_size = p_wt.topic_size();
 
   float max_token_weight = 0.0f;
   std::string keyword;
   for (int token_index = 0; token_index < p_wt.token_size(); token_index++) {
-    const ::artm::core::Token& token = p_wt.token(token_index);
-    if (token.class_id != args.predict_class_id())
+    const auto& token = p_wt.token(token_index);
+    if (token.class_id != args.predict_class_id()) {
       continue;
+    }
 
-    float weight = 0.0;
-    for (int topic_index = 0; topic_index < topic_size; ++topic_index)
+    float weight = 0.0f;
+    for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
       weight += theta[topic_index] * p_wt.get(token_index, topic_index);
+    }
 
     if (weight >= max_token_weight) {
       keyword = token.keyword;
@@ -43,8 +46,8 @@ void ClassPrecision::AppendScore(
   }
 
   bool error = true;
-  for (auto& token_id : item.token_id()) {
-    const artm::core::Token& token = token_dict[token_id];
+  for (const auto& token_id : item.token_id()) {
+    const auto& token = token_dict[token_id];
     if (token.class_id == args.predict_class_id() && token.keyword == keyword) {
       error = false;
       break;
@@ -52,8 +55,8 @@ void ClassPrecision::AppendScore(
   }
 
   ClassPrecisionScore class_prediction_score;
-  class_prediction_score.set_error(error ? 1 : 0);
-  class_prediction_score.set_total(1);
+  class_prediction_score.set_error(error ? 1.0f : 0.0f);
+  class_prediction_score.set_total(1.0f);
   AppendScore(class_prediction_score, score);
 }
 
@@ -77,8 +80,8 @@ void ClassPrecision::AppendScore(const Score& score, Score* target) {
                                     class_precision_score->error());
   class_precision_target->set_total(class_precision_target->total() +
                                     class_precision_score->total());
-  class_precision_target->set_value(1.0 - class_precision_target->error() /
-                                          class_precision_target->total());
+  class_precision_target->set_value(1.0f - class_precision_target->error() /
+                                           class_precision_target->total());
 }
 
 }  // namespace score

--- a/src/artm/score/class_precision.h
+++ b/src/artm/score/class_precision.h
@@ -15,8 +15,7 @@
 
 */
 
-#ifndef SRC_ARTM_SCORE_CLASS_PRECISION_H_
-#define SRC_ARTM_SCORE_CLASS_PRECISION_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -54,5 +53,3 @@ class ClassPrecision : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_CLASS_PRECISION_H_

--- a/src/artm/score/items_processed.cc
+++ b/src/artm/score/items_processed.cc
@@ -15,8 +15,8 @@ void ItemsProcessed::AppendScore(
     const artm::core::PhiMatrix& p_wt,
     const artm::ProcessBatchesArgs& args,
     Score* score) {
-  double token_weight = 0.0;
-  double token_weight_in_effect = 0.0;
+  float token_weight = 0.0f;
+  float token_weight_in_effect = 0.0f;
   for (auto& item : batch.item()) {
     for (int token_index = 0; token_index < item.token_id_size(); token_index++) {
       int token_id = item.token_id(token_index);

--- a/src/artm/score/items_processed.cc
+++ b/src/artm/score/items_processed.cc
@@ -15,9 +15,10 @@ void ItemsProcessed::AppendScore(
     const artm::core::PhiMatrix& p_wt,
     const artm::ProcessBatchesArgs& args,
     Score* score) {
-  float token_weight = 0.0f;
-  float token_weight_in_effect = 0.0f;
-  for (auto& item : batch.item()) {
+    float token_weight = 0.0f;
+    float token_weight_in_effect = 0.0f;
+
+  for (const auto& item : batch.item()) {
     for (int token_index = 0; token_index < item.token_id_size(); token_index++) {
       int token_id = item.token_id(token_index);
       token_weight += item.token_weight(token_index);
@@ -25,10 +26,13 @@ void ItemsProcessed::AppendScore(
       const std::string& class_id = batch.class_id(token_id);
 
       // Check whether token is in effect (e.g. present in the model, and belongs to relevant modality)
-      if (!p_wt.has_token(::artm::core::Token(class_id, token)))
+      if (!p_wt.has_token(::artm::core::Token(class_id, token))) {
         continue;
-      if (args.class_id_size() > 0 && !::artm::core::is_member(class_id, args.class_id()))
+      }
+
+      if (args.class_id_size() > 0 && !::artm::core::is_member(class_id, args.class_id())) {
         continue;
+      }
       token_weight_in_effect += item.token_weight(token_index);
     }
   }

--- a/src/artm/score/items_processed.cc
+++ b/src/artm/score/items_processed.cc
@@ -10,13 +10,12 @@
 namespace artm {
 namespace score {
 
-void ItemsProcessed::AppendScore(
-    const Batch& batch,
-    const artm::core::PhiMatrix& p_wt,
-    const artm::ProcessBatchesArgs& args,
-    Score* score) {
-    float token_weight = 0.0f;
-    float token_weight_in_effect = 0.0f;
+void ItemsProcessed::AppendScore(const Batch& batch,
+                                 const artm::core::PhiMatrix& p_wt,
+                                 const artm::ProcessBatchesArgs& args,
+                                 Score* score) {
+  float token_weight = 0.0f;
+  float token_weight_in_effect = 0.0f;
 
   for (const auto& item : batch.item()) {
     for (int token_index = 0; token_index < item.token_id_size(); token_index++) {

--- a/src/artm/score/items_processed.h
+++ b/src/artm/score/items_processed.h
@@ -8,8 +8,7 @@
    This score has no input parameters.
 */
 
-#ifndef SRC_ARTM_SCORE_ITEMS_PROCESSED_H_
-#define SRC_ARTM_SCORE_ITEMS_PROCESSED_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -45,5 +44,3 @@ class ItemsProcessed : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_ITEMS_PROCESSED_H_

--- a/src/artm/score/peak_memory.cc
+++ b/src/artm/score/peak_memory.cc
@@ -28,6 +28,7 @@ std::shared_ptr<Score> PeakMemory::CalculateScore(const artm::core::PhiMatrix& p
   GetProcessMemoryInfo( GetCurrentProcess( ), &info, sizeof(info) );
   peak_memory_score->set_value((size_t)info.PeakWorkingSetSize);
 #else
+  // ToDo(ofrei): find and use some *nix tool for memory usage calculation
   peak_memory_score->set_value(0);
 #endif
 

--- a/src/artm/score/peak_memory.h
+++ b/src/artm/score/peak_memory.h
@@ -18,7 +18,7 @@ namespace score {
 
 class PeakMemory : public ScoreCalculatorInterface {
  public:
-  explicit PeakMemory(const ScoreConfig& config) : ScoreCalculatorInterface(config) {}
+  explicit PeakMemory(const ScoreConfig& config) : ScoreCalculatorInterface(config) { }
 
   virtual bool is_cumulative() const { return false; }
 

--- a/src/artm/score/peak_memory.h
+++ b/src/artm/score/peak_memory.h
@@ -8,8 +8,7 @@
 
 */
 
-#ifndef SRC_ARTM_SCORE_PEAK_MEMORY_H_
-#define SRC_ARTM_SCORE_PEAK_MEMORY_H_
+#pragma once
 
 #include "artm/score_calculator_interface.h"
 
@@ -29,5 +28,3 @@ class PeakMemory : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_PEAK_MEMORY_H_

--- a/src/artm/score/perplexity.h
+++ b/src/artm/score/perplexity.h
@@ -13,8 +13,7 @@
 
 */
 
-#ifndef SRC_ARTM_SCORE_PERPLEXITY_H_
-#define SRC_ARTM_SCORE_PERPLEXITY_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -50,5 +49,3 @@ class Perplexity : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_PERPLEXITY_H_

--- a/src/artm/score/sparsity_phi.cc
+++ b/src/artm/score/sparsity_phi.cc
@@ -13,11 +13,11 @@ namespace artm {
 namespace score {
 
 std::shared_ptr<Score> SparsityPhi::CalculateScore(const artm::core::PhiMatrix& p_wt) {
-  int topic_size = p_wt.topic_size();
-  int token_size = p_wt.token_size();
+  // parameters preparation
+  const int topic_size = p_wt.topic_size();
+  const int token_size = p_wt.token_size();
   ::google::protobuf::int64 zero_tokens_count = 0;
 
-  // parameters preparation
   std::vector<bool> topics_to_score;
   ::google::protobuf::int64 topics_to_score_size = topic_size;
   if (config_.topic_name_size() == 0) {
@@ -28,8 +28,9 @@ std::shared_ptr<Score> SparsityPhi::CalculateScore(const artm::core::PhiMatrix& 
   }
 
   ::artm::core::ClassId class_id = ::artm::core::DefaultClass;
-  if (config_.has_class_id())
+  if (config_.has_class_id()) {
     class_id = config_.class_id();
+  }
 
   ::google::protobuf::int64 class_tokens_count = 0;
   for (int token_index = 0; token_index < token_size; token_index++) {

--- a/src/artm/score/sparsity_phi.cc
+++ b/src/artm/score/sparsity_phi.cc
@@ -49,8 +49,8 @@ std::shared_ptr<Score> SparsityPhi::CalculateScore(const artm::core::PhiMatrix& 
 
   sparsity_phi_score->set_zero_tokens(zero_tokens_count);
   sparsity_phi_score->set_total_tokens(class_tokens_count * topics_to_score_size);
-  sparsity_phi_score->set_value(static_cast<double>(sparsity_phi_score->zero_tokens()) /
-                                static_cast<double>(sparsity_phi_score->total_tokens()));
+  sparsity_phi_score->set_value(static_cast<float>(sparsity_phi_score->zero_tokens()) /
+                                static_cast<float>(sparsity_phi_score->total_tokens()));
 
   return retval;
 }

--- a/src/artm/score/sparsity_phi.h
+++ b/src/artm/score/sparsity_phi.h
@@ -11,8 +11,7 @@
 
 */
 
-#ifndef SRC_ARTM_SCORE_SPARSITY_PHI_H_
-#define SRC_ARTM_SCORE_SPARSITY_PHI_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -40,5 +39,3 @@ class SparsityPhi : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_SPARSITY_PHI_H_

--- a/src/artm/score/sparsity_theta.cc
+++ b/src/artm/score/sparsity_theta.cc
@@ -19,7 +19,7 @@ void SparsityTheta::AppendScore(
     const artm::ProcessBatchesArgs& args,
     const std::vector<float>& theta,
     Score* score) {
-  int topic_size = p_wt.topic_size();
+  const int topic_size = p_wt.topic_size();
 
   std::vector<bool> topics_to_score;
   ::google::protobuf::int64 topics_to_score_size = topic_size;

--- a/src/artm/score/sparsity_theta.cc
+++ b/src/artm/score/sparsity_theta.cc
@@ -64,7 +64,7 @@ void SparsityTheta::AppendScore(const Score& score, Score* target) {
                                          sparsity_theta_score->zero_topics());
   sparsity_theta_target->set_total_topics(sparsity_theta_target->total_topics() +
                                           sparsity_theta_score->total_topics());
-  sparsity_theta_target->set_value(static_cast<double>(sparsity_theta_target->zero_topics()) /
+  sparsity_theta_target->set_value(static_cast<float>(sparsity_theta_target->zero_topics()) /
                                     sparsity_theta_target->total_topics());
 }
 

--- a/src/artm/score/sparsity_theta.h
+++ b/src/artm/score/sparsity_theta.h
@@ -10,8 +10,7 @@
 
 */
 
-#ifndef SRC_ARTM_SCORE_SPARSITY_THETA_H_
-#define SRC_ARTM_SCORE_SPARSITY_THETA_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -49,5 +48,3 @@ class SparsityTheta : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_SPARSITY_THETA_H_

--- a/src/artm/score/theta_snippet.cc
+++ b/src/artm/score/theta_snippet.cc
@@ -17,7 +17,7 @@ void ThetaSnippet::AppendScore(
     const artm::ProcessBatchesArgs& args,
     const std::vector<float>& theta,
     Score* score) {
-  int topic_size = p_wt.topic_size();
+  const int topic_size = p_wt.topic_size();
 
   ThetaSnippetScore theta_snippet_score;
   theta_snippet_score.add_item_id(item.id());
@@ -45,20 +45,23 @@ void ThetaSnippet::AppendScore(const Score& score, Score* target) {
     BOOST_THROW_EXCEPTION(::artm::core::InternalError(error_message));
   }
 
-  if (config_.num_items() <= 0 || theta_snippet_score->values_size() == 0)
+  if (config_.num_items() <= 0 || theta_snippet_score->values_size() == 0) {
     return;
+  }
 
   while (theta_snippet_target->values_size() < config_.num_items()) {
     theta_snippet_target->add_item_id(-1);
     artm::FloatArray* values_target = theta_snippet_target->add_values();
-    for (int i = 0; i < theta_snippet_score->values(0).value_size(); ++i)
+    for (int i = 0; i < theta_snippet_score->values(0).value_size(); ++i) {
       values_target->add_value(0.0f);
+    }
   }
 
   for (int item_index = 0; item_index < theta_snippet_score->item_id_size(); item_index++) {
     int item_id = theta_snippet_score->item_id(item_index);
-    if (item_id < 0)
+    if (item_id < 0) {
       continue;
+    }
 
     theta_snippet_target->set_item_id(item_id % config_.num_items(), item_id);
     artm::FloatArray* values_target = theta_snippet_target->mutable_values(item_id % config_.num_items());

--- a/src/artm/score/theta_snippet.h
+++ b/src/artm/score/theta_snippet.h
@@ -11,8 +11,7 @@
 
 */
 
-#ifndef SRC_ARTM_SCORE_THETA_SNIPPET_H_
-#define SRC_ARTM_SCORE_THETA_SNIPPET_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -50,5 +49,3 @@ class ThetaSnippet : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_THETA_SNIPPET_H_

--- a/src/artm/score/top_tokens.cc
+++ b/src/artm/score/top_tokens.cc
@@ -16,12 +16,13 @@ namespace artm {
 namespace score {
 
 std::shared_ptr<Score> TopTokens::CalculateScore(const artm::core::PhiMatrix& p_wt) {
-  int topic_size = p_wt.topic_size();
-  int token_size = p_wt.token_size();
+  const int topic_size = p_wt.topic_size();
+  const int token_size = p_wt.token_size();
 
   std::shared_ptr<core::Dictionary> dictionary_ptr = nullptr;
-  if (config_.has_cooccurrence_dictionary_name())
+  if (config_.has_cooccurrence_dictionary_name()) {
     dictionary_ptr = dictionary(config_.cooccurrence_dictionary_name());
+  }
   bool count_coherence = dictionary_ptr != nullptr;
 
   std::vector<int> topic_ids;
@@ -42,8 +43,9 @@ std::shared_ptr<Score> TopTokens::CalculateScore(const artm::core::PhiMatrix& p_
   }
 
   ::artm::core::ClassId class_id = ::artm::core::DefaultClass;
-  if (config_.has_class_id())
+  if (config_.has_class_id()) {
     class_id = config_.class_id();
+  }
 
   std::vector<artm::core::Token> tokens;
   for (int token_index = 0; token_index < token_size; token_index++) {
@@ -63,9 +65,10 @@ std::shared_ptr<Score> TopTokens::CalculateScore(const artm::core::PhiMatrix& p_
     p_wt_local.reserve(tokens.size());
 
     for (int token_index = 0; token_index < token_size; token_index++) {
-      auto token = p_wt.token(token_index);
-      if (token.class_id != class_id)
+      const auto& token = p_wt.token(token_index);
+      if (token.class_id != class_id) {
         continue;
+      }
 
       float weight = p_wt.get(token_index, topic_ids[i]);
       p_wt_local.push_back(std::pair<float, int>(weight, p_wt_local.size()));
@@ -75,21 +78,27 @@ std::shared_ptr<Score> TopTokens::CalculateScore(const artm::core::PhiMatrix& p_
 
     int first_index = p_wt_local.size() - 1;
     int last_index = (p_wt_local.size() - config_.num_tokens());
-    if (last_index < 0) last_index = 0;
+    if (last_index < 0) {
+      last_index = 0;
+    }
 
     std::vector<core::Token> tokens_for_coherence;
     for (int token_index = first_index; token_index >= last_index; token_index--) {
       ::artm::core::Token token = tokens[p_wt_local[token_index].second];
       float weight = p_wt_local[token_index].first;
-      if (weight < config_.eps())
+      if (weight < config_.eps()) {
         continue;
+      }
+
       top_tokens_score->add_token(token.keyword);
       top_tokens_score->add_weight(weight);
       top_tokens_score->add_topic_index(topic_ids[i]);
       top_tokens_score->add_topic_name(topic_name.Get(topic_ids[i]));
-      num_entries++;
+      ++num_entries;
 
-      if (count_coherence && weight > 0.0f) tokens_for_coherence.push_back(token);
+      if (count_coherence && weight > 0.0f) {
+        tokens_for_coherence.push_back(token);
+      }
     }
 
     if (count_coherence) {

--- a/src/artm/score/top_tokens.cc
+++ b/src/artm/score/top_tokens.cc
@@ -50,8 +50,9 @@ std::shared_ptr<Score> TopTokens::CalculateScore(const artm::core::PhiMatrix& p_
   std::vector<artm::core::Token> tokens;
   for (int token_index = 0; token_index < token_size; token_index++) {
     auto token = p_wt.token(token_index);
-    if (token.class_id == class_id)
+    if (token.class_id == class_id) {
       tokens.push_back(token);
+    }
   }
 
   TopTokensScore* top_tokens_score = new TopTokensScore();

--- a/src/artm/score/top_tokens.h
+++ b/src/artm/score/top_tokens.h
@@ -15,8 +15,7 @@
 
 */
 
-#ifndef SRC_ARTM_SCORE_TOP_TOKENS_H_
-#define SRC_ARTM_SCORE_TOP_TOKENS_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -44,5 +43,3 @@ class TopTokens : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_TOP_TOKENS_H_

--- a/src/artm/score/topic_kernel.cc
+++ b/src/artm/score/topic_kernel.cc
@@ -15,24 +15,28 @@ namespace artm {
 namespace score {
 
 std::shared_ptr<Score> TopicKernel::CalculateScore(const artm::core::PhiMatrix& p_wt) {
-  int topic_size = p_wt.topic_size();
-  int token_size = p_wt.token_size();
+  const int topic_size = p_wt.topic_size();
+  const int token_size = p_wt.token_size();
 
   // parameters preparation
   std::shared_ptr<core::Dictionary> dictionary_ptr = nullptr;
-  if (config_.has_cooccurrence_dictionary_name())
+  if (config_.has_cooccurrence_dictionary_name()) {
     dictionary_ptr = dictionary(config_.cooccurrence_dictionary_name());
+  }
   bool count_coherence = dictionary_ptr != nullptr;
 
-  auto topic_name = p_wt.topic_name();
+  const auto& topic_name = p_wt.topic_name();
   std::vector<bool> topics_to_score;
-  if (config_.topic_name_size() == 0)
+  if (config_.topic_name_size() == 0) {
     topics_to_score.assign(topic_size, true);
-  else
+  } else {
     topics_to_score = core::is_member(topic_name, config_.topic_name());
+  }
+
   ::artm::core::ClassId class_id = ::artm::core::DefaultClass;
-  if (config_.has_class_id())
+  if (config_.has_class_id()) {
     class_id = config_.class_id();
+  }
 
   float probability_mass_threshold = config_.probability_mass_threshold();
   if (probability_mass_threshold < 0 || probability_mass_threshold > 1) {
@@ -67,21 +71,24 @@ std::shared_ptr<Score> TopicKernel::CalculateScore(const artm::core::PhiMatrix& 
     }
   }
 
-  auto n_wt = GetPhiMatrix(instance_->config()->nwt_name());
+  const auto& n_wt = GetPhiMatrix(instance_->config()->nwt_name());
   std::vector<float> n_t(topic_size, 0.0f);
   std::vector<std::vector<core::Token> > topic_kernel_tokens(
       topic_size, std::vector<core::Token>());
 
-  for (int topic_index = 0; topic_index < topic_size; ++topic_index)
-    for (int token_index = 0; token_index < token_size; ++token_index)
+  for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
+    for (int token_index = 0; token_index < token_size; ++token_index) {
       n_t[topic_index] += n_wt->get(token_index, topic_index);
+    }
+  }
 
   for (int token_index = 0; token_index < token_size; ++token_index) {
     if (p_wt.token(token_index).class_id == class_id) {
       float p_w = 0.0;
       for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
-        if (topics_to_score[topic_index])
+        if (topics_to_score[topic_index]) {
           p_w += p_wt.get(token_index, topic_index) * n_t[topic_index];
+	}
       }
 
       for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
@@ -130,7 +137,7 @@ std::shared_ptr<Score> TopicKernel::CalculateScore(const artm::core::PhiMatrix& 
 
   for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
     float current_kernel_size = kernel_size->Get(topic_index);
-    bool useful_topic = (current_kernel_size != -1);
+    const bool useful_topic = (current_kernel_size != -1);
     if (useful_topic) {
       useful_topics_count += 1;
       average_kernel_size += current_kernel_size;
@@ -138,8 +145,9 @@ std::shared_ptr<Score> TopicKernel::CalculateScore(const artm::core::PhiMatrix& 
       average_kernel_contrast += kernel_contrast->Get(topic_index);
 
       StringArray* tokens = kernel_tokens->Add();
-      for (unsigned token_id = 0; token_id < topic_kernel_tokens[topic_index].size(); ++token_id)
+      for (unsigned token_id = 0; token_id < topic_kernel_tokens[topic_index].size(); ++token_id) {
         tokens->add_value(topic_kernel_tokens[topic_index][token_id].keyword);
+      }
     }
   }
   average_kernel_size /= useful_topics_count;
@@ -149,8 +157,9 @@ std::shared_ptr<Score> TopicKernel::CalculateScore(const artm::core::PhiMatrix& 
   topic_kernel_score->set_average_kernel_size(average_kernel_size);
   topic_kernel_score->set_average_kernel_purity(average_kernel_purity);
   topic_kernel_score->set_average_kernel_contrast(average_kernel_contrast);
-  if (count_coherence)
+  if (count_coherence) {
     topic_kernel_score->set_average_coherence(average_kernel_coherence);
+  }
 
   return retval;
 }

--- a/src/artm/score/topic_kernel.cc
+++ b/src/artm/score/topic_kernel.cc
@@ -88,7 +88,7 @@ std::shared_ptr<Score> TopicKernel::CalculateScore(const artm::core::PhiMatrix& 
       for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
         if (topics_to_score[topic_index]) {
           p_w += p_wt.get(token_index, topic_index) * n_t[topic_index];
-	}
+        }
       }
 
       for (int topic_index = 0; topic_index < topic_size; ++topic_index) {

--- a/src/artm/score/topic_kernel.cc
+++ b/src/artm/score/topic_kernel.cc
@@ -7,6 +7,7 @@
 
 #include "artm/core/dictionary.h"
 #include "artm/core/exceptions.h"
+#include "artm/core/phi_matrix_operations.h"
 #include "artm/core/protobuf_helpers.h"
 
 #include "artm/score/topic_kernel.h"
@@ -72,15 +73,16 @@ std::shared_ptr<Score> TopicKernel::CalculateScore(const artm::core::PhiMatrix& 
   }
 
   const auto& n_wt = GetPhiMatrix(instance_->config()->nwt_name());
-  std::vector<float> n_t(topic_size, 0.0f);
+  auto normalizers = artm::core::PhiMatrixOperations::FindNormalizers(*n_wt);
+  auto norm_iter = normalizers.find(class_id);
+  if (norm_iter == normalizers.end()) {
+    BOOST_THROW_EXCEPTION(artm::core::InvalidOperation(
+        "TopicKernelScoreConfig.class_id " + class_id + " does not exists in n_wt matrix"));
+  }
+
+  const auto& n_t = norm_iter->second;
   std::vector<std::vector<core::Token> > topic_kernel_tokens(
       topic_size, std::vector<core::Token>());
-
-  for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
-    for (int token_index = 0; token_index < token_size; ++token_index) {
-      n_t[topic_index] += n_wt->get(token_index, topic_index);
-    }
-  }
 
   for (int token_index = 0; token_index < token_size; ++token_index) {
     if (p_wt.token(token_index).class_id == class_id) {

--- a/src/artm/score/topic_kernel.h
+++ b/src/artm/score/topic_kernel.h
@@ -18,8 +18,7 @@
 
 */
 
-#ifndef SRC_ARTM_SCORE_TOPIC_KERNEL_H_
-#define SRC_ARTM_SCORE_TOPIC_KERNEL_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -48,5 +47,3 @@ class TopicKernel : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_TOPIC_KERNEL_H_

--- a/src/artm/score/topic_mass_phi.cc
+++ b/src/artm/score/topic_mass_phi.cc
@@ -29,7 +29,7 @@ std::shared_ptr<Score> TopicMassPhi::CalculateScore(const artm::core::PhiMatrix&
     use_all_classes = true;
   }
 
-  std::vector<double> topic_mass;
+  std::vector<float> topic_mass;
   topic_mass.assign(topics_to_score_size, 0.0);
   double denominator = 0.0;
   double numerator = 0.0;
@@ -40,7 +40,7 @@ std::shared_ptr<Score> TopicMassPhi::CalculateScore(const artm::core::PhiMatrix&
 
     int real_topic_index = 0;
     for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
-      double value = p_wt.get(token_index, topic_index);
+      float value = p_wt.get(token_index, topic_index);
       denominator += value;
 
       if (topics_to_score[topic_index]) {
@@ -53,9 +53,9 @@ std::shared_ptr<Score> TopicMassPhi::CalculateScore(const artm::core::PhiMatrix&
   TopicMassPhiScore* topic_mass_score = new TopicMassPhiScore();
   std::shared_ptr<Score> retval(topic_mass_score);
 
-  double value = 0.0;
+  float value = 0.0;
   if (denominator > config_.eps())
-    value = static_cast<double>(numerator / denominator);
+    value = static_cast<float>(numerator / denominator);
   topic_mass_score->set_value(value);
 
   for (int i = 0; i < topic_size; ++i) {
@@ -63,10 +63,10 @@ std::shared_ptr<Score> TopicMassPhi::CalculateScore(const artm::core::PhiMatrix&
       topic_mass_score->add_topic_name(p_wt.topic_name(i));
   }
 
-  for (double elem : topic_mass) {
+  for (const auto& elem : topic_mass) {
     // don't check denominator value: if it's near zero the 'value' will show it
     topic_mass_score->add_topic_mass(elem);
-    topic_mass_score->add_topic_ratio(static_cast<double>(elem / denominator));
+    topic_mass_score->add_topic_ratio(elem / denominator);
   }
 
   return retval;

--- a/src/artm/score/topic_mass_phi.cc
+++ b/src/artm/score/topic_mass_phi.cc
@@ -11,10 +11,10 @@ namespace artm {
 namespace score {
 
 std::shared_ptr<Score> TopicMassPhi::CalculateScore(const artm::core::PhiMatrix& p_wt) {
-  int topic_size = p_wt.topic_size();
-  int token_size = p_wt.token_size();
-
   // parameters preparation
+  const int topic_size = p_wt.topic_size();
+  const int token_size = p_wt.token_size();
+
   std::vector<bool> topics_to_score;
   int topics_to_score_size = topic_size;
   if (config_.topic_name_size() == 0) {
@@ -30,13 +30,14 @@ std::shared_ptr<Score> TopicMassPhi::CalculateScore(const artm::core::PhiMatrix&
   }
 
   std::vector<float> topic_mass;
-  topic_mass.assign(topics_to_score_size, 0.0);
+  topic_mass.assign(topics_to_score_size, 0.0f);
   double denominator = 0.0;
   double numerator = 0.0;
 
   for (int token_index = 0; token_index < token_size; token_index++) {
-    if (!use_all_classes && !core::is_member(p_wt.token(token_index).class_id, config_.class_id()))
+    if (!use_all_classes && !core::is_member(p_wt.token(token_index).class_id, config_.class_id())) {
       continue;
+    }
 
     int real_topic_index = 0;
     for (int topic_index = 0; topic_index < topic_size; ++topic_index) {
@@ -53,14 +54,16 @@ std::shared_ptr<Score> TopicMassPhi::CalculateScore(const artm::core::PhiMatrix&
   TopicMassPhiScore* topic_mass_score = new TopicMassPhiScore();
   std::shared_ptr<Score> retval(topic_mass_score);
 
-  float value = 0.0;
-  if (denominator > config_.eps())
+  float value = 0.0f;
+  if (denominator > config_.eps()) {
     value = static_cast<float>(numerator / denominator);
+  }
   topic_mass_score->set_value(value);
 
   for (int i = 0; i < topic_size; ++i) {
-    if (topics_to_score[i])
+    if (topics_to_score[i]) {
       topic_mass_score->add_topic_name(p_wt.topic_name(i));
+    }
   }
 
   for (const auto& elem : topic_mass) {

--- a/src/artm/score/topic_mass_phi.h
+++ b/src/artm/score/topic_mass_phi.h
@@ -11,8 +11,7 @@
 
 */
 
-#ifndef SRC_ARTM_SCORE_TOPIC_MASS_PHI_H_
-#define SRC_ARTM_SCORE_TOPIC_MASS_PHI_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -40,5 +39,3 @@ class TopicMassPhi : public ScoreCalculatorInterface {
 
 }  // namespace score
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_TOPIC_MASS_PHI_H_

--- a/src/artm/score_calculator_interface.h
+++ b/src/artm/score_calculator_interface.h
@@ -30,9 +30,9 @@ class Instance;
 class ScoreCalculatorInterface {
  public:
   explicit ScoreCalculatorInterface(const ScoreConfig& score_config)
-    : score_config_(score_config),
-      dictionaries_(nullptr),
-      instance_(nullptr) {}
+    : score_config_(score_config)
+    , dictionaries_(nullptr)
+    , instance_(nullptr) { }
 
   virtual ~ScoreCalculatorInterface() { }
 
@@ -61,7 +61,7 @@ class ScoreCalculatorInterface {
       const Batch& batch,
       const artm::core::PhiMatrix& p_wt,
       const artm::ProcessBatchesArgs& args,
-      Score* score) {}
+      Score* score) { }
 
   std::shared_ptr< ::artm::core::Dictionary> dictionary(const std::string& dictionary_name);
   std::shared_ptr<const ::artm::core::PhiMatrix> GetPhiMatrix(const std::string& model_name);
@@ -84,12 +84,14 @@ class ScoreCalculatorInterface {
 template<typename ConfigType>
 ConfigType ScoreCalculatorInterface::ParseConfig() const {
   ConfigType config;
-  if (!score_config_.has_config())
+  if (!score_config_.has_config()) {
     return config;
+  }
 
   const std::string& config_blob = score_config_.config();
-  if (!config.ParseFromString(config_blob))
+  if (!config.ParseFromString(config_blob)) {
     BOOST_THROW_EXCEPTION(::artm::core::CorruptedMessageException("Unable to parse score config"));
+  }
   return config;
 }
 

--- a/src/artm/score_calculator_interface.h
+++ b/src/artm/score_calculator_interface.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_SCORE_CALCULATOR_INTERFACE_H_
-#define SRC_ARTM_SCORE_CALCULATOR_INTERFACE_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -95,5 +94,3 @@ ConfigType ScoreCalculatorInterface::ParseConfig() const {
 }
 
 }  // namespace artm
-
-#endif  // SRC_ARTM_SCORE_CALCULATOR_INTERFACE_H_

--- a/src/artm/score_calculator_interface.h
+++ b/src/artm/score_calculator_interface.h
@@ -30,9 +30,9 @@ class Instance;
 class ScoreCalculatorInterface {
  public:
   explicit ScoreCalculatorInterface(const ScoreConfig& score_config)
-    : score_config_(score_config)
-    , dictionaries_(nullptr)
-    , instance_(nullptr) { }
+      : score_config_(score_config)
+      , dictionaries_(nullptr)
+      , instance_(nullptr) { }
 
   virtual ~ScoreCalculatorInterface() { }
 

--- a/src/artm/utility/blas.h
+++ b/src/artm/utility/blas.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_UTILITY_BLAS_H_
-#define SRC_ARTM_UTILITY_BLAS_H_
+#pragma once
 
 #include <assert.h>
 #include <memory>
@@ -274,5 +273,3 @@ void AssignDenseMatrixByDivision(const DenseMatrix<T>& first_matrix,
 }  // namespace artm
 
 #undef CATCH_BIG_ALLOCATION
-
-#endif  // SRC_ARTM_UTILITY_BLAS_H_

--- a/src/artm/utility/ifstream_or_cin.h
+++ b/src/artm/utility/ifstream_or_cin.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_UTILITY_IFSTREAM_OR_CIN_H_
-#define SRC_ARTM_UTILITY_IFSTREAM_OR_CIN_H_
+#pragma once
 
 #include <string>
 #include <iostream>  // NOLINT
@@ -51,5 +50,3 @@ class ifstream_or_cin {
 
 }  // namespace utility
 }  // namespace artm
-
-#endif  // SRC_ARTM_UTILITY_IFSTREAM_OR_CIN_H_

--- a/src/artm/utility/memory_usage.h
+++ b/src/artm/utility/memory_usage.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_UTILITY_MEMORY_USAGE_H_
-#define SRC_ARTM_UTILITY_MEMORY_USAGE_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -31,5 +30,3 @@ inline int64_t getMemoryUsage(const std::unordered_map<K, V, H>& obj) {
 
 }  // namespace utility
 }  // namespace artm
-
-#endif  // SRC_ARTM_UTILITY_MEMORY_USAGE_H_

--- a/src/artm/utility/progress_printer.h
+++ b/src/artm/utility/progress_printer.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_UTILITY_PROGRESS_PRINTER_H_
-#define SRC_ARTM_UTILITY_PROGRESS_PRINTER_H_
+#pragma once
 
 #include <cstddef>
 
@@ -22,5 +21,3 @@ class ProgressPrinter {
 
 }  // namespace utility
 }  // namespace artm
-
-#endif  // SRC_ARTM_UTILITY_PROGRESS_PRINTER_H_

--- a/src/artm/version.h.in
+++ b/src/artm/version.h.in
@@ -1,10 +1,7 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_VERSION_H_
-#define SRC_ARTM_VERSION_H_
+#pragma once
 
 #define ARTM_VERSION_MAJOR @ARTM_VERSION_MAJOR@
 #define ARTM_VERSION_MINOR @ARTM_VERSION_MINOR@
 #define ARTM_VERSION_PATCH @ARTM_VERSION_PATCH@
-
-#endif  // SRC_ARTM_VERSION_H_

--- a/src/artm_tests/api.cc
+++ b/src/artm_tests/api.cc
@@ -58,10 +58,12 @@ TopicModel Api::AttachTopicModel(const AttachModelArgs& args, Matrix* matrix) {
   std::string args_blob;
   SerializeMessageToString(args, &args_blob);
 
-  if (retval.num_topics() == 0)
+  if (retval.num_topics() == 0) {
     throw ArgumentOutOfRangeException("Unable to attach to topic model with zero topics");
-  if (retval.token_size() == 0)
+  }
+  if (retval.token_size() == 0) {
     throw ArgumentOutOfRangeException("Unable to attach to topic model with zero tokens");
+  }
 
   matrix->resize(retval.token_size(), retval.num_topics());
   int address_length = matrix->no_columns() * matrix->no_rows() * sizeof(float);
@@ -121,15 +123,18 @@ int Api::Duplicate(const DuplicateMasterComponentArgs& args) {
                                                   ::artm::InitializeModelArgs* initialize_model_args,
                                                   const ::artm::DictionaryData* dictionary_data) {
   ImportBatchesArgs import_args;
-  for (auto& batch : batches)
+  for (auto& batch : batches) {
     import_args.add_batch()->CopyFrom(*batch);
+  }
   master_model_.ImportBatches(import_args);
-  if (import_batches_args != nullptr)
+  if (import_batches_args != nullptr) {
     import_batches_args->CopyFrom(import_args);
+  }
 
   ::artm::FitOfflineMasterModelArgs fit_offline_args;
-  for (auto& batch : import_args.batch())
+  for (auto& batch : import_args.batch()) {
     fit_offline_args.add_batch_filename(batch.id());
+  }
 
   if (dictionary_data == nullptr) {
     ::artm::GatherDictionaryArgs gather_args;
@@ -146,8 +151,9 @@ int Api::Duplicate(const DuplicateMasterComponentArgs& args) {
   init_model_args.set_model_name(master_model_.config().pwt_name());
   init_model_args.mutable_topic_name()->CopyFrom(master_model_.config().topic_name());
   master_model_.InitializeModel(init_model_args);
-  if (initialize_model_args != nullptr)
+  if (initialize_model_args != nullptr) {
     initialize_model_args->CopyFrom(init_model_args);
+  }
 
   return fit_offline_args;
 }

--- a/src/artm_tests/api.h
+++ b/src/artm_tests/api.h
@@ -15,7 +15,7 @@ namespace test {
 // Defines additional APIs, not exposed through ::artm::MasterModel interface.
 class Api {
  public:
-  explicit Api(MasterModel& master_model) : master_model_(master_model) {}
+  explicit Api(MasterModel& master_model) : master_model_(master_model) { }
 
   // Methods wrapping c_interface
   TopicModel AttachTopicModel(const AttachModelArgs& args, Matrix* matrix);

--- a/src/artm_tests/api.h
+++ b/src/artm_tests/api.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_TESTS_API_H_
-#define SRC_ARTM_TESTS_API_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -44,5 +43,3 @@ class Api {
 
 }  // namespace test
 }  // namespace artm
-
-#endif  // SRC_ARTM_TESTS_API_H_

--- a/src/artm_tests/blas_test.cc
+++ b/src/artm_tests/blas_test.cc
@@ -23,17 +23,28 @@ TEST(Blas, Basic) {
 
   EXPECT_EQ(blas_builtin->sdot(12, C, 1, CT, 1), 75188);
   blas_builtin->saxpy(6, 1.0, A, 1, A2, 1);
-  for (int i = 0; i < 6; ++i) EXPECT_EQ(A2[i], A[i]);
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_EQ(A2[i], A[i]);
+  }
+
   blas_builtin->saxpy(6, -1.0, A, 1, A2, 1);
   blas_builtin->sgemm(Blas::RowMajor, Blas::NoTrans, Blas::NoTrans,
       3, 4, 2, 1.0, A, 2, B, 4, 0, C1, 4);
-  for (int i = 0; i < 12; ++i) EXPECT_EQ(C1[i], C[i]);
+  for (int i = 0; i < 12; ++i) {
+    EXPECT_EQ(C1[i], C[i]);
+  }
+
   blas_builtin->sgemm(Blas::ColMajor, Blas::NoTrans, Blas::NoTrans,
       3, 4, 2, 1.0, AT, 3, BT, 2, 0, C1, 3);
-  for (int i = 0; i < 12; ++i) EXPECT_EQ(C1[i], CT[i]);
+  for (int i = 0; i < 12; ++i) {
+    EXPECT_EQ(C1[i], CT[i]);
+  }
+
   blas_builtin->sgemm(Blas::RowMajor, Blas::Trans, Blas::NoTrans,
       3, 4, 2, 1.0, AT, 3, B, 4, 0, C1, 4);
-  for (int i = 0; i < 12; ++i) EXPECT_EQ(C1[i], C[i]);
+  for (int i = 0; i < 12; ++i) {
+    EXPECT_EQ(C1[i], C[i]);
+  }
 }
 
 TEST(Blas, scsr2csc) {
@@ -47,13 +58,25 @@ TEST(Blas, scsr2csc) {
   Blas& blas = *Blas::builtin();
   ASSERT_TRUE(blas.is_loaded());
   blas.scsr2csc(m, n, nnz, csr_val, csr_row_ptr, csr_col_ind, csc_val, csc_row_ind, csc_col_ptr);
-  for (int i = 0; i < nnz; ++i) EXPECT_EQ(csc_val[i], csc_val_exp[i]);
-  for (int i = 0; i < nnz; ++i) EXPECT_EQ(csc_row_ind[i], csc_row_ind_exp[i]);
-  for (int i = 0; i < (n + 1); ++i) EXPECT_EQ(csc_col_ptr[i], csc_col_ptr_exp[i]);
+  for (int i = 0; i < nnz; ++i) {
+    EXPECT_EQ(csc_val[i], csc_val_exp[i]);
+  }
+  for (int i = 0; i < nnz; ++i) {
+    EXPECT_EQ(csc_row_ind[i], csc_row_ind_exp[i]);
+  }
+  for (int i = 0; i < (n + 1); ++i) {
+    EXPECT_EQ(csc_col_ptr[i], csc_col_ptr_exp[i]);
+  }
 
   // convert back
   blas.scsr2csc(n, m, nnz, csc_val, csc_col_ptr, csc_row_ind, csr_val2, csr_col_ind2, csr_row_ptr2);
-  for (int i = 0; i < nnz; ++i) EXPECT_EQ(csr_val2[i], csr_val[i]);
-  for (int i = 0; i < nnz; ++i) EXPECT_EQ(csr_col_ind2[i], csr_col_ind[i]);
-  for (int i = 0; i < (m + 1); ++i) EXPECT_EQ(csr_row_ptr2[i], csr_row_ptr[i]);
+  for (int i = 0; i < nnz; ++i) {
+    EXPECT_EQ(csr_val2[i], csr_val[i]);
+  }
+  for (int i = 0; i < nnz; ++i) {
+    EXPECT_EQ(csr_col_ind2[i], csr_col_ind[i]);
+  }
+  for (int i = 0; i < (m + 1); ++i) {
+    EXPECT_EQ(csr_row_ptr2[i], csr_row_ptr[i]);
+  }
 }

--- a/src/artm_tests/cache_manager_test.cc
+++ b/src/artm_tests/cache_manager_test.cc
@@ -65,7 +65,7 @@ void RunTest(bool disk_cache, std::string ptd_name) {
   }
 
   try { boost::filesystem::remove_all(target_path); }
-  catch (...) {}
+  catch (...) { }
 }
 
 // To run this particular test:

--- a/src/artm_tests/cache_manager_test.cc
+++ b/src/artm_tests/cache_manager_test.cc
@@ -29,7 +29,9 @@ void RunTest(bool disk_cache, std::string ptd_name) {
   ::artm::MasterModelConfig master_config = ::artm::test::TestMother::GenerateMasterModelConfig(nTopics);
   master_config.set_reuse_theta(true);
   master_config.set_ptd_name(ptd_name);
-  if (disk_cache) master_config.set_disk_cache_path(target_path);
+  if (disk_cache) {
+    master_config.set_disk_cache_path(target_path);
+  }
   ::artm::MasterModel master_component(master_config);
   ::artm::test::Api api(master_component);
   EXPECT_TRUE(master_component.info().config().cache_theta());
@@ -37,10 +39,13 @@ void RunTest(bool disk_cache, std::string ptd_name) {
   auto batches = ::artm::test::TestMother::GenerateBatches(batches_size, nTokens);
   auto fit_offline_args = api.Initialize(batches);
 
-  for (int iter = 0; iter < 3; ++iter)
+  for (int iter = 0; iter < 3; ++iter) {
     master_component.FitOfflineModel(fit_offline_args);
+  }
 
-  if (ptd_name.empty()) EXPECT_GT(master_component.info().cache_entry_size(), 0);
+  if (ptd_name.empty()) {
+    EXPECT_GT(master_component.info().cache_entry_size(), 0);
+  }
   ::artm::ThetaMatrix theta1 = master_component.GetThetaMatrix();
   EXPECT_EQ(theta1.num_topics(), nTopics);
   EXPECT_GE(theta1.item_id_size(), 1);

--- a/src/artm_tests/collection_parser_test.cc
+++ b/src/artm_tests/collection_parser_test.cc
@@ -238,10 +238,12 @@ TEST(CollectionParser, VowpalWabbit) {
       ::artm::core::Helpers::LoadMessage(it->path().string(), &batch);
       ASSERT_TRUE(batch.class_id_size() == 3 || batch.class_id_size() == 2);
       for (int i = 0; i < batch.token_size(); ++i) {
-        if (batch.token(i) == "hello" || batch.token(i) == "world")
+        if (batch.token(i) == "hello" || batch.token(i) == "world") {
           ASSERT_EQ(batch.class_id(i), "@default_class");
-        if (batch.token(i) == "noname" || batch.token(i) == "alex")
+        }
+        if (batch.token(i) == "noname" || batch.token(i) == "alex") {
           ASSERT_EQ(batch.class_id(i), "author");
+        }
       }
       ASSERT_EQ(batch.item_size(), 1);
     }

--- a/src/artm_tests/collection_parser_test.cc
+++ b/src/artm_tests/collection_parser_test.cc
@@ -90,7 +90,7 @@ TEST(CollectionParser, UciBagOfWords) {
   dictionary_checker("../../../test_data/vocab.parser_test_no_newline.txt", "no_newline_dictionary");
 
   try { fs::remove_all(target_folder); }
-  catch (...) {}
+  catch (...) { }
 }
 
 TEST(CollectionParser, ErrorHandling) {
@@ -139,7 +139,7 @@ TEST(CollectionParser, MatrixMarket) {
   ASSERT_EQ(batches_count, 1);
 
   try { fs::remove_all(target_folder); }
-  catch (...) {}
+  catch (...) { }
 }
 
 TEST(CollectionParser, Multiclass) {
@@ -212,7 +212,7 @@ TEST(CollectionParser, Multiclass) {
   ASSERT_APPROX_EQ(dictionary_ptr.token_value(2), 9.0 / 14.0);
 
   try { fs::remove_all(target_folder); }
-  catch (...) {}
+  catch (...) { }
 }
 
 // To run this particular test:
@@ -253,6 +253,6 @@ TEST(CollectionParser, VowpalWabbit) {
   ASSERT_EQ(batches_count, 2);
 
   try { fs::remove_all(target_folder); }
-  catch (...) {}
+  catch (...) { }
 }
 // vim: set ts=2 sw=2 sts=2:

--- a/src/artm_tests/cpp_interface_test.cc
+++ b/src/artm_tests/cpp_interface_test.cc
@@ -125,7 +125,7 @@ void RunBasicTest(bool serialize_as_json) {
 
   artm::TopicModel topic_model;
   double expected_normalizer = 0;
-  double previous_perplexity = 0;
+  float previous_perplexity = 0;
   for (int iter = 0; iter < 5; ++iter) {
     master_component.FitOfflineModel(offline_args);
     {

--- a/src/artm_tests/cpp_interface_test.cc
+++ b/src/artm_tests/cpp_interface_test.cc
@@ -276,13 +276,13 @@ void RunBasicTest(bool serialize_as_json) {
   ASSERT_EQ(new_topic_model3.token(2), "my_tok_3");
 
   try { boost::filesystem::remove_all(target_path); }
-  catch (...) {}
+  catch (...) { }
 }
 
 // artm_tests.exe --gtest_filter=CppInterface.BasicTest
 TEST(CppInterface, BasicTest) {
   bool wasJson = ArtmProtobufMessageFormatIsJson();
-  try { RunBasicTest(false); } catch (...) {}
+  try { RunBasicTest(false); } catch (...) { }
   wasJson ? ArtmSetProtobufMessageFormatToJson() : ArtmSetProtobufMessageFormatToBinary();
 }
 
@@ -495,7 +495,7 @@ TEST(CppInterface, ProcessBatchesApi) {
   }
 
   try { boost::filesystem::remove_all(target_folder); }
-  catch (...) {}
+  catch (...) { }
 }
 
 // artm_tests.exe --gtest_filter=CppInterface.AttachModel
@@ -563,7 +563,7 @@ TEST(CppInterface, AttachModel) {
 
 
   try { boost::filesystem::remove_all(target_folder); }
-  catch (...) {}
+  catch (...) { }
 }
 
 // artm_tests.exe --gtest_filter=CppInterface.AsyncProcessBatches
@@ -659,10 +659,10 @@ TEST(CppInterface, Dictionaries) {
   ASSERT_GT(dictionary.token_value(0), 0);
 
   try { boost::filesystem::remove_all(target_folder); }
-  catch (...) {}
+  catch (...) { }
 
   try { boost::filesystem::remove(import_args.file_name()); }
-  catch (...) {}
+  catch (...) { }
 }
 
 // artm_tests.exe --gtest_filter=ProtobufMessages.Json

--- a/src/artm_tests/cpp_interface_test.cc
+++ b/src/artm_tests/cpp_interface_test.cc
@@ -127,8 +127,8 @@ void RunBasicTest(bool serialize_as_json) {
   ::artm::FitOfflineMasterModelArgs offline_args = api.Initialize(batches);
 
   artm::TopicModel topic_model;
-  double expected_normalizer = 0;
-  float previous_perplexity = 0;
+  double expected_normalizer = 0.0;
+  float previous_perplexity = 0.0f;
   for (int iter = 0; iter < 5; ++iter) {
     master_component.FitOfflineModel(offline_args);
     {

--- a/src/artm_tests/cpp_interface_test.cc
+++ b/src/artm_tests/cpp_interface_test.cc
@@ -31,10 +31,11 @@ TEST(CppInterface, Version) {
 }
 
 void RunBasicTest(bool serialize_as_json) {
-  if (serialize_as_json)
+  if (serialize_as_json) {
     ArtmSetProtobufMessageFormatToJson();
-  else
+  } else {
     ArtmSetProtobufMessageFormatToBinary();
+  }
 
   artm::ConfigureLoggingArgs log_args;
   log_args.set_minloglevel(2);
@@ -56,10 +57,11 @@ void RunBasicTest(bool serialize_as_json) {
   const int nTopics = master_config.topic_name_size();
 
   ::artm::ScoreConfig* score_config = master_config.add_score_config();
-  if (serialize_as_json)
+  if (serialize_as_json) {
     pb::util::MessageToJsonString(::artm::PerplexityScoreConfig(), score_config->mutable_config_json());
-  else
+  } else {
     score_config->set_config(::artm::PerplexityScoreConfig().SerializeAsString());
+  }
   score_config->set_type(::artm::ScoreType_Perplexity);
   score_config->set_name("PerplexityScore");
 
@@ -73,10 +75,11 @@ void RunBasicTest(bool serialize_as_json) {
   artm::DecorrelatorPhiConfig decor_config;
   reg_decor_config->set_name("decorrelator");
   reg_decor_config->set_type(artm::RegularizerType_DecorrelatorPhi);
-  if (serialize_as_json)
+  if (serialize_as_json) {
     pb::util::MessageToJsonString(decor_config, reg_decor_config->mutable_config_json());
-  else
+  } else {
     reg_decor_config->set_config(decor_config.SerializeAsString());
+  }
   reg_decor_config->set_tau(1.0);
 
   // Create master component
@@ -143,10 +146,13 @@ void RunBasicTest(bool serialize_as_json) {
     ::artm::GetScoreValueArgs get_score_args;
     get_score_args.set_score_name("PerplexityScore");
     auto perplexity = master_component.GetScoreAs< ::artm::PerplexityScore>(get_score_args);
-    if (serialize_as_json) EXPECT_FALSE(master_component.GetScore(get_score_args).data_json().empty());
+    if (serialize_as_json) {
+      EXPECT_FALSE(master_component.GetScore(get_score_args).data_json().empty());
+    }
 
-    if (iter > 0)
+    if (iter > 0) {
       EXPECT_EQ(perplexity.value(), previous_perplexity);
+    }
 
     ::artm::TransformMasterModelArgs transform_args;
     transform_args.add_batch_filename(batch.id());

--- a/src/artm_tests/multiple_classes_test.cc
+++ b/src/artm_tests/multiple_classes_test.cc
@@ -16,11 +16,14 @@
 
 void ShowTopicModel(const ::artm::TopicModel& topic_model) {
   for (int i = 0; i < topic_model.token_size(); ++i) {
-    if (i > 10) break;
+    if (i > 10) {
+      break;
+    }
     std::cout << topic_model.token(i) << "(" << topic_model.class_id(i) << "): ";
     const ::artm::FloatArray& weights = topic_model.token_weights(i);
-    for (int j = 0; j < weights.value_size(); ++j)
+    for (int j = 0; j < weights.value_size(); ++j) {
       std::cout << std::fixed << std::setw(4) << std::setprecision(3) << weights.value(j) << " ";
+    }
     std::cout << std::endl;
   }
   std::cout << std::endl;
@@ -28,7 +31,9 @@ void ShowTopicModel(const ::artm::TopicModel& topic_model) {
 
 void ShowThetaMatrix(const ::artm::ThetaMatrix& theta_matrix) {
   for (int i = 0; i < theta_matrix.item_id_size(); ++i) {
-    if (i > 10) break;
+    if (i > 10) {
+      break;
+    }
     std::cout << theta_matrix.item_id(i) << ": ";
     const artm::FloatArray& weights = theta_matrix.item_weights(i);
     for (int j = 0; j < weights.value_size(); ++j) {
@@ -41,16 +46,27 @@ void ShowThetaMatrix(const ::artm::ThetaMatrix& theta_matrix) {
 
 bool CompareTopicModels(const ::artm::TopicModel& t1, const ::artm::TopicModel& t2, float* max_diff) {
   *max_diff = 0.0f;
-  if (t1.token_size() != t2.token_size()) return false;
+  if (t1.token_size() != t2.token_size()) {
+    return false;
+  }
+
   for (int i = 0; i < t1.token_size(); ++i) {
-    if (t1.token(i) != t2.token(i)) return false;
-    if (t1.class_id(i) != t2.class_id(i)) return false;
+    if (t1.token(i) != t2.token(i) || t1.class_id(i) != t2.class_id(i)) {
+      return false;
+    }
+
     const artm::FloatArray& w1 = t1.token_weights(i);
     const artm::FloatArray& w2 = t2.token_weights(i);
-    if (w1.value_size() != w2.value_size()) return false;
+
+    if (w1.value_size() != w2.value_size()) {
+      return false;
+    }
+
     for (int j = 0; j < w1.value_size(); ++j) {
       float diff = fabs(w1.value(j) - w2.value(j));
-      if (diff > *max_diff) *max_diff = diff;
+      if (diff > *max_diff) {
+        *max_diff = diff;
+      }
     }
   }
 
@@ -59,15 +75,27 @@ bool CompareTopicModels(const ::artm::TopicModel& t1, const ::artm::TopicModel& 
 
 bool CompareThetaMatrices(const ::artm::ThetaMatrix& t1, const ::artm::ThetaMatrix& t2, float *max_diff) {
   *max_diff = 0.0f;
-  if (t1.item_id_size() != t2.item_id_size()) return false;
+  if (t1.item_id_size() != t2.item_id_size()) {
+    return false;
+  }
+
   for (int i = 0; i < t1.item_id_size(); ++i) {
-    if (t1.item_id(i) != t2.item_id(i)) return false;
+    if (t1.item_id(i) != t2.item_id(i)) {
+      return false;
+    }
+
     const artm::FloatArray& w1 = t1.item_weights(i);
     const artm::FloatArray& w2 = t2.item_weights(i);
-    if (w1.value_size() != w2.value_size()) return false;
+
+    if (w1.value_size() != w2.value_size()) {
+      return false;
+    }
+
     for (int j = 0; j < w1.value_size(); ++j) {
       float diff = (fabs(w1.value(j) - w2.value(j)));
-      if (diff > *max_diff) *max_diff = diff;
+      if (diff > *max_diff) {
+        *max_diff = diff;
+      }
     }
   }
 
@@ -187,14 +215,18 @@ TEST(MultipleClasses, BasicTest) {
   ASSERT_EQ(matrix_phi.no_columns(), nTopics);
   ASSERT_EQ(matrix_theta.no_rows(), nDocs);
   ASSERT_EQ(matrix_theta.no_columns(), nTopics);
-  for (int token_index = 0; token_index < nTokens; ++token_index)
-    for (int topic_index = 0; topic_index < nTopics; ++topic_index)
+  for (int token_index = 0; token_index < nTokens; ++token_index) {
+    for (int topic_index = 0; topic_index < nTopics; ++topic_index) {
       ASSERT_APPROX_EQ(matrix_phi(token_index, topic_index),
                        topic_model1.token_weights(token_index).value(topic_index));
-  for (int topic_index = 0; topic_index < nTopics; ++topic_index)
-    for (int item_index = 0; item_index < nDocs; ++item_index)
+    }
+  }
+  for (int topic_index = 0; topic_index < nTopics; ++topic_index) {
+    for (int item_index = 0; item_index < nDocs; ++item_index) {
       ASSERT_APPROX_EQ(matrix_theta(item_index, topic_index),
                        theta_matrix1.item_weights(item_index).value(topic_index));
+    }
+  }
 
   // ToDo: validate matrix_phi and matrix_theta
 
@@ -284,7 +316,10 @@ void configureTopTokensScore(std::string score_name, std::string class_id, artm:
   ::artm::ScoreConfig score_config;
   ::artm::TopTokensScoreConfig top_tokens_config;
   top_tokens_config.set_num_tokens(4);
-  if (!class_id.empty()) top_tokens_config.set_class_id(class_id);
+  if (!class_id.empty()) {
+    top_tokens_config.set_class_id(class_id);
+  }
+
   score_config.set_config(top_tokens_config.SerializeAsString());
   score_config.set_type(::artm::ScoreType_TopTokens);
   score_config.set_name(score_name);
@@ -407,10 +442,12 @@ void VerifySparseVersusDenseTopicModel(const ::artm::GetTopicModelArgs& args, ::
   ASSERT_GT(tm_sparse.token_size(), 0);
 
   if (!all_topics) {
-    for (int i = 0; i < tm_dense.topic_name_size(); ++i)
+    for (int i = 0; i < tm_dense.topic_name_size(); ++i) {
       EXPECT_EQ(tm_dense.topic_name(i), args.topic_name(i));
-    for (int i = 0; i < tm_sparse.topic_name_size(); ++i)
+    }
+    for (int i = 0; i < tm_sparse.topic_name_size(); ++i) {
       EXPECT_EQ(tm_sparse.topic_name(i), args.topic_name(i));
+    }
   }
 
   ASSERT_EQ(tm_sparse.token_size(), tm_dense.token_size());
@@ -418,7 +455,9 @@ void VerifySparseVersusDenseTopicModel(const ::artm::GetTopicModelArgs& args, ::
   ASSERT_EQ(tm_sparse.class_id_size(), tm_dense.class_id_size());
   ASSERT_TRUE(tm_sparse.token_size() == tm_sparse.token_weights_size() &&
               tm_sparse.token_size() == tm_sparse.class_id_size());
-  if (!all_tokens) ASSERT_TRUE(tm_sparse.token_size() == args.token_size());
+  if (!all_tokens) {
+    ASSERT_TRUE(tm_sparse.token_size() == args.token_size());
+  }
 
   for (int i = 0; i < tm_sparse.token_size(); ++i) {
     EXPECT_EQ(tm_sparse.token(i), tm_dense.token(i));
@@ -434,9 +473,11 @@ void VerifySparseVersusDenseTopicModel(const ::artm::GetTopicModelArgs& args, ::
 
     if (some_classes) {
       bool contains = false;
-      for (int j = 0; j < args.class_id_size(); ++j)
-        if (args.class_id(j) == tm_sparse.class_id(i))
+      for (int j = 0; j < args.class_id_size(); ++j) {
+        if (args.class_id(j) == tm_sparse.class_id(i)) {
           contains = true;
+	}
+      }
       EXPECT_TRUE(contains);  // only return classes that had been requested
     }
 
@@ -477,15 +518,17 @@ void VerifySparseVersusDenseThetaMatrix(const ::artm::GetThetaMatrixArgs& args, 
 
   if (by_names) {
     ASSERT_EQ(tm_dense.num_topics(), args.topic_name_size());
-    for (int i = 0; i < tm_dense.num_topics(); ++i)
+    for (int i = 0; i < tm_dense.num_topics(); ++i) {
       EXPECT_EQ(tm_dense.topic_name(i), args.topic_name(i));
+    }
   } else {
     ASSERT_EQ(tm_dense.num_topics(), tm_all.num_topics());
   }
 
   ASSERT_EQ(tm_sparse.num_topics(), tm_all.num_topics());
-  for (int i = 0; i < tm_sparse.num_topics(); ++i)
+  for (int i = 0; i < tm_sparse.num_topics(); ++i) {
     EXPECT_EQ(tm_sparse.topic_name(i), tm_all.topic_name(i));
+  }
 
   ASSERT_EQ(tm_sparse.item_id_size(), tm_dense.item_id_size());
   ASSERT_EQ(tm_sparse.item_weights_size(), tm_dense.item_weights_size());
@@ -541,8 +584,9 @@ TEST(MultipleClasses, GetTopicModel) {
   args.set_eps(0.05f);
   VerifySparseVersusDenseTopicModel(args, &master);
 
-  for (int i = 0; i < nTopics; i += 2)
+  for (int i = 0; i < nTopics; i += 2) {
     args.add_topic_name(master_config.topic_name(i));
+  }
   VerifySparseVersusDenseTopicModel(args, &master);
 
   args.add_class_id("class_two");

--- a/src/artm_tests/multiple_classes_test.cc
+++ b/src/artm_tests/multiple_classes_test.cc
@@ -476,7 +476,7 @@ void VerifySparseVersusDenseTopicModel(const ::artm::GetTopicModelArgs& args, ::
       for (int j = 0; j < args.class_id_size(); ++j) {
         if (args.class_id(j) == tm_sparse.class_id(i)) {
           contains = true;
-	}
+        }
       }
       EXPECT_TRUE(contains);  // only return classes that had been requested
     }

--- a/src/artm_tests/multiple_classes_test.cc
+++ b/src/artm_tests/multiple_classes_test.cc
@@ -373,8 +373,8 @@ TEST(MultipleClasses, WithoutDefaultClass) {
   gs.set_score_name("tts_class_two"); EXPECT_TRUE(master2.GetScoreAs< ::artm::TopTokensScore>(gs).num_entries() > 0);
 
   gs.set_score_name("perplexity");
-  double p1 = master.GetScoreAs< ::artm::PerplexityScore>(gs).value();
-  double p2 = master2.GetScoreAs< ::artm::PerplexityScore>(gs).value();
+  float p1 = master.GetScoreAs< ::artm::PerplexityScore>(gs).value();
+  float p2 = master2.GetScoreAs< ::artm::PerplexityScore>(gs).value();
   EXPECT_TRUE((p1 > 0) && (p2 > 0) && (p1 != p2));
 
   gs.set_score_name("theta_snippet");

--- a/src/artm_tests/regularizers_test.cc
+++ b/src/artm_tests/regularizers_test.cc
@@ -108,7 +108,7 @@ TEST(Regularizers, SmoothSparseTheta) {
   ::artm::ThetaMatrix theta_matrix = master.GetThetaMatrix();
 
   // nDocs x nTopics
-  std::vector<std::vector<double> > expected_values = {
+  std::vector<std::vector<float> > expected_values = {
     { 0.0,  0.0,   0.0,   0.0 },
     { 0.265, 0.224, 0.247, 0.264 },
     { 0.0,  0.0,   0.0,   0.0 }

--- a/src/artm_tests/regularizers_test.cc
+++ b/src/artm_tests/regularizers_test.cc
@@ -27,8 +27,9 @@ TEST(Regularizers, TopicSelection) {
   regularizer_config->set_tau(0.5f);
 
   ::artm::TopicSelectionThetaConfig internal_config;
-  for (int i = 0; i < nTopics; ++i)
+  for (int i = 0; i < nTopics; ++i) {
     internal_config.add_topic_value(static_cast<float>(i) / nTopics);
+  }
 
   regularizer_config->set_config(internal_config.SerializeAsString());
   artm::MasterModel master(master_config);
@@ -37,8 +38,9 @@ TEST(Regularizers, TopicSelection) {
   // iterations
   auto batches = ::artm::test::TestMother::GenerateBatches(1, 5);
   auto offline_args = api.Initialize(batches);
-  for (int iter = 0; iter < 3; ++iter)
+  for (int iter = 0; iter < 3; ++iter) {
     master.FitOfflineModel(offline_args);
+  }
 
   // get and check theta
   artm::GetThetaMatrixArgs args;
@@ -49,8 +51,9 @@ TEST(Regularizers, TopicSelection) {
   //  std::cout << theta_matrix.item_weights(0).value(i) << std::endl;
   float expected_values[] = { 0.41836f, 0.262486f, 0.160616f, 0.0845677f, 0.032849f,
                               0.022987f, 0.0103793f, 0.0040327f, 0.00267936f, 0.00104289f };
-  for (int i = 0; i < nTopics; ++i)
+  for (int i = 0; i < nTopics; ++i) {
     ASSERT_NEAR(theta_matrix.item_weights(0).value(i), expected_values[i], 0.00001);
+  }
 }
 
 // artm_tests.exe --gtest_filter=Regularizers.SmoothSparseTheta
@@ -114,13 +117,16 @@ TEST(Regularizers, SmoothSparseTheta) {
     { 0.0,  0.0,   0.0,   0.0 }
   };
 
-  for (int i = 0; i < nDocs; ++i)
-    for (int j = 0; j < nTopics; ++j)
+  for (int i = 0; i < nDocs; ++i) {
+    for (int j = 0; j < nTopics; ++j) {
       ASSERT_NEAR(theta_matrix.item_weights(i).value(j), expected_values[i][j], 0.001);
+    }
+  }
 
   for (int i = 0; i < nDocs; ++i) {
-    for (int j = 0; j < nTopics; ++j)
+    for (int j = 0; j < nTopics; ++j) {
       std::cout << theta_matrix.item_weights(i).value(j) << " ";
+    }
     std::cout << std::endl;
   }
   std::cout << std::endl;
@@ -148,8 +154,9 @@ TEST(Regularizers, SmoothSparseTheta) {
 
   internal_config_2.add_item_title("item_2");
   values = internal_config_2.add_item_topic_multiplier();
-  for (int i = 0; i < nTopics; ++i)
-    values->add_value(-1.0);
+  for (int i = 0; i < nTopics; ++i) {
+    values->add_value(-1.0f);
+  }
 
   regularizer_config->set_config(internal_config_2.SerializeAsString());
 
@@ -164,19 +171,22 @@ TEST(Regularizers, SmoothSparseTheta) {
 
   // nDocs x nTopics
   expected_values = {
-    { 0.5,  0.0,   0.5,   0.0 },
-    { 0.265, 0.224, 0.247, 0.264 },
-    { 0.0,  0.0,   0.0,   0.0 }
+    { 0.5f,  0.0f,   0.5f,   0.0f },
+    { 0.265f, 0.224f, 0.247f, 0.264f },
+    { 0.0f,  0.0f,   0.0f,   0.0f }
   };
 
-  for (int i = 0; i < nDocs; ++i)
-    for (int j = 0; j < nTopics; ++j)
+  for (int i = 0; i < nDocs; ++i) {
+    for (int j = 0; j < nTopics; ++j) {
       ASSERT_NEAR(theta_matrix.item_weights(i).value(j), expected_values[i][j], 0.001);
+    }
+  }
 
   for (int i = 0; i < nDocs; ++i) {
-  for (int j = 0; j < nTopics; ++j)
-  std::cout << theta_matrix.item_weights(i).value(j) << " ";
-  std::cout << std::endl;
+    for (int j = 0; j < nTopics; ++j) {
+      std::cout << theta_matrix.item_weights(i).value(j) << " ";
+    }
+    std::cout << std::endl;
   }
   std::cout << std::endl;
 }

--- a/src/artm_tests/regularizers_test.cc
+++ b/src/artm_tests/regularizers_test.cc
@@ -112,9 +112,9 @@ TEST(Regularizers, SmoothSparseTheta) {
 
   // nDocs x nTopics
   std::vector<std::vector<float> > expected_values = {
-    { 0.0,  0.0,   0.0,   0.0 },
-    { 0.265, 0.224, 0.247, 0.264 },
-    { 0.0,  0.0,   0.0,   0.0 }
+    { 0.0f,  0.0f,   0.0f,   0.0f },
+    { 0.265f, 0.224f, 0.247f, 0.264f },
+    { 0.0f,  0.0f,   0.0f,   0.0f }
   };
 
   for (int i = 0; i < nDocs; ++i) {

--- a/src/artm_tests/repeatable_result_test.cc
+++ b/src/artm_tests/repeatable_result_test.cc
@@ -34,8 +34,9 @@ std::string runOfflineTest() {
   auto batches = ::artm::test::TestMother::GenerateBatches(batches_size, nTokens);
   auto offline_args = api.Initialize(batches);
 
-  for (int iter = 0; iter < 3; ++iter)
+  for (int iter = 0; iter < 3; ++iter) {
     master_component.FitOfflineModel(offline_args);
+  }
 
   ::artm::TopicModel topic_model = master_component.GetTopicModel();
   std::stringstream ss;
@@ -56,8 +57,9 @@ std::string runOfflineTest() {
 TEST(RepeatableResult, Offline) {
   std::string first_result = runOfflineTest();
   std::string second_result = runOfflineTest();
-  if (first_result != second_result)
+  if (first_result != second_result) {
     std::cout << first_result << "\n" << second_result;
+  }
   ASSERT_EQ(first_result, second_result);
 }
 
@@ -108,8 +110,9 @@ void OverwriteTopicModel_internal(::artm::MatrixLayout matrix_layout) {
   ::artm::ImportBatchesArgs import_args;
   auto offline_args = api.Initialize(batches, &import_args);
 
-  for (int iter = 0; iter < 3; ++iter)
+  for (int iter = 0; iter < 3; ++iter) {
     master_component.FitOfflineModel(offline_args);
+  }
 
   ::artm::MasterModel master2(master_config);
   master2.ImportBatches(import_args);

--- a/src/artm_tests/repeatable_result_test.cc
+++ b/src/artm_tests/repeatable_result_test.cc
@@ -128,7 +128,7 @@ void OverwriteTopicModel_internal(::artm::MatrixLayout matrix_layout) {
   api2.OverwriteModel(master_component.GetTopicModel(get_topic_model_args));
 
   std::string file_name = ::artm::test::Helpers::getUniqueString();
-  artm::core::call_on_destruction c([&]() { try { boost::filesystem::remove(file_name); } catch (...) {} });  // NOLINT
+  artm::core::call_on_destruction c([&]() { try { boost::filesystem::remove(file_name); } catch (...) { } });  // NOLINT
   ::artm::ExportModelArgs export_args;
   export_args.set_model_name(master_config.pwt_name());
   export_args.set_file_name(file_name);

--- a/src/artm_tests/scores_test.cc
+++ b/src/artm_tests/scores_test.cc
@@ -25,7 +25,7 @@ TEST(Scores, Perplexity) {
   ::artm::MasterModelConfig master_config_2 = ::artm::test::TestMother::GenerateMasterModelConfig(nTopics);
   master_config_2.add_class_id("@default_class"); master_config_2.add_class_weight(1.0f);
   master_config_2.add_class_id("@some_class"); master_config_2.add_class_weight(2.0f);
-  ::artm::test::Helpers::ConfigurePerplexityScore("perplexity_1", &master_config_2, {});
+  ::artm::test::Helpers::ConfigurePerplexityScore("perplexity_1", &master_config_2, { });
   ::artm::test::Helpers::ConfigurePerplexityScore("perplexity_2", &master_config_2, { "@default_class" });
   ::artm::test::Helpers::ConfigurePerplexityScore("perplexity_3", &master_config_2,
                                                   { "@default_class", "@some_class" });
@@ -35,7 +35,7 @@ TEST(Scores, Perplexity) {
   ::artm::test::Api api_2(master_2);
 
   ::artm::MasterModelConfig master_config_3 = ::artm::test::TestMother::GenerateMasterModelConfig(nTopics);
-  ::artm::test::Helpers::ConfigurePerplexityScore("perplexity", &master_config_3, {});
+  ::artm::test::Helpers::ConfigurePerplexityScore("perplexity", &master_config_3, { });
   ::artm::MasterModel master_3(master_config_3);
   ::artm::test::Api api_3(master_3);
 
@@ -174,5 +174,5 @@ TEST(Scores, ScoreTrackerExportImport) {
   }
 
   try { boost::filesystem::remove(target_name); }
-  catch (...) {}
+  catch (...) { }
 }

--- a/src/artm_tests/scores_test.cc
+++ b/src/artm_tests/scores_test.cc
@@ -73,7 +73,7 @@ TEST(Scores, Perplexity) {
   ASSERT_DOUBLE_EQ(score.normalizer(), 0.0);
   ASSERT_EQ(score.zero_words(), 0);
   ASSERT_EQ(score.class_id_info_size(), 2);
-  double value_1 = score.value();
+  float value_1 = score.value();
 
   gs.set_score_name("perplexity_3");
   score = master_2.GetScoreAs< ::artm::PerplexityScore>(gs);
@@ -82,7 +82,7 @@ TEST(Scores, Perplexity) {
   ASSERT_DOUBLE_EQ(score.normalizer(), 0.0);
   ASSERT_EQ(score.zero_words(), 0);
   ASSERT_EQ(score.class_id_info_size(), 2);
-  double value_2 = score.value();
+  float value_2 = score.value();
 
   ASSERT_DOUBLE_EQ(value_1, value_2);
 

--- a/src/artm_tests/supcry_test.cc
+++ b/src/artm_tests/supcry_test.cc
@@ -25,8 +25,9 @@ void GenerateBatches(std::vector< ::artm::Batch>* batches, ::artm::DictionaryDat
   for (int i = 0; i < nTokens; i++) {
     std::stringstream str;
     str << "token" << i;
-    if (dictionary != nullptr)
+    if (dictionary != nullptr) {
       dictionary->add_token(str.str());
+    }
   }
 
   // Keep batch.token empty; batch.item.field.token_id point straight to global dictionary
@@ -85,10 +86,11 @@ void describeTopTokensScore(const ::artm::TopTokensScore& top_tokens) {
   */
   for (int i = 0; i < top_tokens.num_entries(); ++i) {
     bool is_new_topic = (i == 0 || top_tokens.topic_name(i) != top_tokens.topic_name(i - 1));
-    if (is_new_topic)
+    if (is_new_topic) {
       std::cout << std::endl << top_tokens.topic_name(i) << ": ";
-    else
+    } else {
       std::cout << ", ";
+    }
     std::cout << top_tokens.token(i) << "(" << std::setprecision(3) << top_tokens.weight(i) << ")";
   }
   std::cout << std::endl;
@@ -104,7 +106,9 @@ TEST(Supcry, Fit) {
   ::artm::MasterModelConfig config;
 
   // Add topic names (this steps defines how many topics it will be in the topic model)
-  for (auto& topic_name : getTopicNames()) config.add_topic_name(topic_name);
+  for (const auto& topic_name : getTopicNames()) {
+    config.add_topic_name(topic_name);
+  }
 
   ::artm::ScoreConfig* score_config = config.add_score_config();
   score_config->set_type(::artm::ScoreType_Perplexity);
@@ -131,8 +135,9 @@ TEST(Supcry, Fit) {
 
   // Step 3. Import batches into BigARTM memory
   ::artm::ImportBatchesArgs import_batches_args;
-  for (auto& batch : batches)
+  for (auto& batch : batches) {
     import_batches_args.add_batch()->CopyFrom(batch);
+  }
   master_model.ImportBatches(import_batches_args);
 
   // Step 4. Import dictionary into BigARTM memory
@@ -163,7 +168,8 @@ TEST(Supcry, Fit) {
   ::artm::ExportModelArgs export_model_args;
   export_model_args.set_file_name("artm_model.bin");
 
-  try { boost::filesystem::remove("artm_model.bin"); } catch (...) {}  // NOLINT
+  try { boost::filesystem::remove("artm_model.bin"); }
+  catch (...) {}
   master_model.ExportModel(export_model_args);
 
   // Step 9. Memory export
@@ -178,7 +184,9 @@ TEST(Supcry, TransformAfterImport) {
   ::artm::MasterModelConfig config;
 
   // Add topic names (this steps defines how many topics it will be in the topic model)
-  for (auto& topic_name : getTopicNames()) config.add_topic_name(topic_name);
+  for (const auto& topic_name : getTopicNames()) {
+    config.add_topic_name(topic_name);
+  }
 
   ::artm::MasterModel master_model(config);
 
@@ -193,8 +201,9 @@ TEST(Supcry, TransformAfterImport) {
 
   // Step 4. Find theta matrix
   ::artm::TransformMasterModelArgs transform_args;
-  for (auto& batch : batches)
+  for (auto& batch : batches) {
     transform_args.add_batch()->CopyFrom(batch);
+  }
   ::artm::ThetaMatrix theta = master_model.Transform(transform_args);
 
   describeTheta(theta, 5);
@@ -207,7 +216,9 @@ TEST(Supcry, TransformAfterOverwrite) {
   ::artm::MasterModelConfig config;
 
   // Add topic names (this steps defines how many topics it will be in the topic model)
-  for (auto& topic_name : getTopicNames()) config.add_topic_name(topic_name);
+  for (const auto& topic_name : getTopicNames()) {
+    config.add_topic_name(topic_name);
+  }
 
   ::artm::MasterModel master_model(config);
 
@@ -218,16 +229,18 @@ TEST(Supcry, TransformAfterOverwrite) {
   // Step 3. Import topic model
   topic_model->set_name("garbage");  // to test ArtmOverwriteTopicModelNamed
   std::string blob;
-  if (ArtmProtobufMessageFormatIsJson())
+  if (ArtmProtobufMessageFormatIsJson()) {
     ::google::protobuf::util::MessageToJsonString(*topic_model, &blob);
-  else
+  } else {
     topic_model->SerializeToString(&blob);
+  }
   ArtmOverwriteTopicModelNamed(master_model.id(), blob.size(), &*(blob.begin()), /*name=*/ nullptr);
 
   // Step 4. Find theta matrix
   ::artm::TransformMasterModelArgs transform_args;
-  for (auto& batch : batches)
+  for (auto& batch : batches) {
     transform_args.add_batch()->CopyFrom(batch);
+  }
   ::artm::ThetaMatrix theta = master_model.Transform(transform_args);
 
   describeTheta(theta, 5);
@@ -238,7 +251,10 @@ TEST(Supcry, TransformAfterOverwrite) {
 TEST(Supcry, FitFromDiskFolder) {
   // Step 1. Configure and create MasterModel
   ::artm::MasterModelConfig config;
-  for (auto& topic_name : getTopicNames()) config.add_topic_name(topic_name);
+  for (const auto& topic_name : getTopicNames()) {
+    config.add_topic_name(topic_name);
+  }
+
   ::artm::ScoreConfig* score_config = config.add_score_config();
   score_config->set_type(::artm::ScoreType_Perplexity);
   score_config->set_name("Perplexity");
@@ -247,7 +263,8 @@ TEST(Supcry, FitFromDiskFolder) {
 
   // Step 2. Generate batches and save them to disk
   std::string batch_folder = "./batch_folder";
-  try { boost::filesystem::remove_all(batch_folder); } catch (...) {}  // NOLINT
+  try { boost::filesystem::remove_all(batch_folder); }
+  catch (...) {}
   boost::filesystem::create_directory(batch_folder);
 
   std::vector< ::artm::Batch> batches;

--- a/src/artm_tests/supcry_test.cc
+++ b/src/artm_tests/supcry_test.cc
@@ -169,7 +169,7 @@ TEST(Supcry, Fit) {
   export_model_args.set_file_name("artm_model.bin");
 
   try { boost::filesystem::remove("artm_model.bin"); }
-  catch (...) {}
+  catch (...) { }
   master_model.ExportModel(export_model_args);
 
   // Step 9. Memory export
@@ -264,7 +264,7 @@ TEST(Supcry, FitFromDiskFolder) {
   // Step 2. Generate batches and save them to disk
   std::string batch_folder = "./batch_folder";
   try { boost::filesystem::remove_all(batch_folder); }
-  catch (...) {}
+  catch (...) { }
   boost::filesystem::create_directory(batch_folder);
 
   std::vector< ::artm::Batch> batches;

--- a/src/artm_tests/supcry_test.cc
+++ b/src/artm_tests/supcry_test.cc
@@ -201,7 +201,7 @@ TEST(Supcry, TransformAfterImport) {
 
   // Step 4. Find theta matrix
   ::artm::TransformMasterModelArgs transform_args;
-  for (auto& batch : batches) {
+  for (const auto& batch : batches) {
     transform_args.add_batch()->CopyFrom(batch);
   }
   ::artm::ThetaMatrix theta = master_model.Transform(transform_args);
@@ -238,7 +238,7 @@ TEST(Supcry, TransformAfterOverwrite) {
 
   // Step 4. Find theta matrix
   ::artm::TransformMasterModelArgs transform_args;
-  for (auto& batch : batches) {
+  for (const auto& batch : batches) {
     transform_args.add_batch()->CopyFrom(batch);
   }
   ::artm::ThetaMatrix theta = master_model.Transform(transform_args);

--- a/src/artm_tests/test_mother.cc
+++ b/src/artm_tests/test_mother.cc
@@ -43,8 +43,9 @@ artm::DictionaryData Helpers::GenerateDictionary(int nTokens, std::string class1
     std::stringstream str;
     str << "token" << i;
     std::string class_id = (i % 2 == 0) ? class1 : class2;
-    if (class_id.empty())
+    if (class_id.empty()) {
       continue;
+    }
     dictionary_data.add_token(str.str());
     dictionary_data.add_class_id(class_id);
   }
@@ -56,7 +57,7 @@ void Helpers::ConfigurePerplexityScore(std::string score_name,
                                        std::vector<std::string> class_ids) {
   ::artm::ScoreConfig score_config;
   ::artm::PerplexityScoreConfig perplexity_config;
-  for (auto& s : class_ids) {
+  for (const auto& s : class_ids) {
     perplexity_config.add_class_id(s);
   }
   score_config.set_config(perplexity_config.SerializeAsString());
@@ -67,8 +68,9 @@ void Helpers::ConfigurePerplexityScore(std::string score_name,
 
 MasterModelConfig TestMother::GenerateMasterModelConfig(int nTopics) {
   MasterModelConfig config;
-  for (int i = 0; i < nTopics; ++i)
+  for (int i = 0; i < nTopics; ++i) {
     config.add_topic_name("Topic" + boost::lexical_cast<std::string>(i));
+  }
   ::artm::core::ModelName model_name =
     boost::lexical_cast<std::string>(boost::uuids::random_generator()());
   config.set_pwt_name(boost::lexical_cast<std::string>(model_name));
@@ -77,8 +79,9 @@ MasterModelConfig TestMother::GenerateMasterModelConfig(int nTopics) {
 
 RegularizerConfig TestMother::GenerateRegularizerConfig() const {
   ::artm::SmoothSparseThetaConfig regularizer_1_config;
-  for (int i = 0; i < 12; ++i)
+  for (int i = 0; i < 12; ++i) {
     regularizer_1_config.add_alpha_iter(0.8f);
+  }
 
   ::artm::RegularizerConfig general_regularizer_1_config;
   general_regularizer_1_config.set_name(regularizer_name);
@@ -102,8 +105,9 @@ TestMother::GenerateBatches(int batches_size, int nTokens, ::artm::DictionaryDat
       str << "token" << i;
       batch.add_token(str.str());
 
-      if (dictionary != nullptr && first_iter)
+      if (dictionary != nullptr && first_iter) {
         dictionary->add_token(str.str());
+      }
     }
 
     artm::Item* item = batch.add_item();
@@ -153,8 +157,9 @@ void Helpers::CompareTopicModels(const ::artm::TopicModel& tm1, const ::artm::To
   ASSERT_EQ(tm1.token_size(), tm2.token_size());
   ASSERT_EQ(tm1.token_weights_size(), tm2.token_weights_size());
   ASSERT_EQ(tm1.topic_indices_size(), tm2.topic_indices_size());
-  if (tm1.topic_indices_size() > 0)
+  if (tm1.topic_indices_size() > 0) {
     ASSERT_EQ(tm1.topic_indices_size(), tm1.token_size());
+  }
 
   for (int i = 0; i < tm1.token_size(); ++i) {
     ASSERT_EQ(tm1.token(i), tm2.token(i));
@@ -162,8 +167,12 @@ void Helpers::CompareTopicModels(const ::artm::TopicModel& tm1, const ::artm::To
     for (int j = 0; j < tm1.token_weights(i).value_size(); ++j) {
       float tm1_value = tm1.token_weights(i).value(j);
       float tm2_value = tm2.token_weights(i).value(j);
-      if (fabs(tm1_value) < 1e-12) tm1_value = 0.0f;
-      if (fabs(tm2_value) < 1e-12) tm2_value = 0.0f;
+      if (fabs(tm1_value) < 1e-12) {
+        tm1_value = 0.0f;
+      }
+      if (fabs(tm2_value) < 1e-12) {
+        tm2_value = 0.0f;
+      }
       ASSERT_APPROX_EQ(tm1_value, tm2_value);
     }
     if (tm1.topic_indices_size() > 0) {
@@ -181,14 +190,16 @@ void Helpers::CompareThetaMatrices(const ::artm::ThetaMatrix& tm1, const ::artm:
   ASSERT_EQ(tm1.item_id_size(), tm2.item_id_size());
   ASSERT_EQ(tm1.item_weights_size(), tm2.item_weights_size());
   ASSERT_EQ(tm1.topic_indices_size(), tm2.topic_indices_size());
-  if (tm1.topic_indices_size() > 0)
+  if (tm1.topic_indices_size() > 0) {
     ASSERT_EQ(tm1.topic_indices_size(), tm1.item_id_size());
+  }
 
   for (int i = 0; i < tm1.item_id_size(); ++i) {
     ASSERT_EQ(tm1.item_id(i), tm2.item_id(i));
     ASSERT_EQ(tm1.item_weights(i).value_size(), tm2.item_weights(i).value_size());
-    for (int j = 0; j < tm1.item_weights(i).value_size(); ++j)
+    for (int j = 0; j < tm1.item_weights(i).value_size(); ++j) {
       ASSERT_APPROX_EQ(tm1.item_weights(i).value(j), tm2.item_weights(i).value(j));
+    }
     if (tm1.topic_indices_size() > 0) {
       ASSERT_EQ(tm1.topic_indices(i).value_size(), tm2.topic_indices(i).value_size());
       for (int j = 0; j < tm1.topic_indices(i).value_size(); ++j) {
@@ -201,8 +212,9 @@ void Helpers::CompareThetaMatrices(const ::artm::ThetaMatrix& tm1, const ::artm:
 
 void TestMother::GenerateBatches(int batches_size, int nTokens, const std::string& target_folder) {
   auto batches = GenerateBatches(batches_size, nTokens);
-  for (unsigned i = 0; i < batches.size(); ++i)
+  for (unsigned i = 0; i < batches.size(); ++i) {
     artm::core::Helpers::SaveBatch(*batches[i], target_folder, batches[i]->id());
+  }
 }
 
 }  // namespace test

--- a/src/artm_tests/test_mother.h
+++ b/src/artm_tests/test_mother.h
@@ -1,7 +1,6 @@
 // Copyright 2017, Additive Regularization of Topic Models.
 
-#ifndef SRC_ARTM_TESTS_TEST_MOTHER_H_
-#define SRC_ARTM_TESTS_TEST_MOTHER_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -51,5 +50,3 @@ class TestMother {
 
 }  // namespace test
 }  // namespace artm
-
-#endif  // SRC_ARTM_TESTS_TEST_MOTHER_H_

--- a/src/artm_tests/test_mother.h
+++ b/src/artm_tests/test_mother.h
@@ -37,7 +37,7 @@ class Helpers {
 
 class TestMother {
  public:
-  TestMother() : regularizer_name("regularizer1") {}
+  TestMother() : regularizer_name("regularizer1") { }
   RegularizerConfig GenerateRegularizerConfig() const;
   static MasterModelConfig GenerateMasterModelConfig(int nTopics);
   static std::vector<std::shared_ptr< ::artm::Batch>> GenerateBatches(

--- a/src/artm_tests/thread_safe_holder_test.cc
+++ b/src/artm_tests/thread_safe_holder_test.cc
@@ -55,10 +55,12 @@ TEST(Async, MultipleTasks) {
 
   const int num_threads = 4;
   std::vector<std::shared_future<void>> tasks;
-  for (int i = 0; i < num_threads; i++)
+  for (int i = 0; i < num_threads; i++) {
     tasks.push_back(std::move(std::async(std::launch::async, func)));
-  for (int i = 0; i < num_threads; i++)
+  }
+  for (int i = 0; i < num_threads; i++) {
     tasks[i].wait();
+  }
 
   ASSERT_EQ(counter, num_threads);
 }

--- a/src/artm_tests/thread_safe_holder_test.cc
+++ b/src/artm_tests/thread_safe_holder_test.cc
@@ -16,16 +16,16 @@ using ::artm::core::ThreadSafeCollectionHolder;
 // To run this particular test:
 // artm_tests.exe --gtest_filter=ThreadSafeHolder.*
 TEST(ThreadSafeHolder, Basic) {
-  ThreadSafeHolder<double> int_holder;
-  int_holder.set(std::make_shared<double>(5.0));
-  EXPECT_EQ(*int_holder.get(), 5.0);
+  ThreadSafeHolder<float> int_holder;
+  int_holder.set(std::make_shared<float>(5.0f));
+  EXPECT_EQ(*int_holder.get(), 5.0f);
 
-  ThreadSafeCollectionHolder<int, double> collection_holder;
+  ThreadSafeCollectionHolder<int, float> collection_holder;
   int key1 = 2, key2 = 3, key3 = 4;
-  collection_holder.set(key1, std::make_shared<double>(7.0));
-  collection_holder.set(key2, std::make_shared<double>(8.0));
-  EXPECT_EQ(*collection_holder.get(key1), 7.0);
-  EXPECT_EQ(*collection_holder.get(key2), 8.0);
+  collection_holder.set(key1, std::make_shared<float>(7.0f));
+  collection_holder.set(key2, std::make_shared<float>(8.0f));
+  EXPECT_EQ(*collection_holder.get(key1), 7.0f);
+  EXPECT_EQ(*collection_holder.get(key2), 8.0f);
 
   EXPECT_TRUE(collection_holder.has_key(key1));
   EXPECT_FALSE(collection_holder.has_key(key3));

--- a/src/bigartm/cooccurrence_dictionary.h
+++ b/src/bigartm/cooccurrence_dictionary.h
@@ -44,20 +44,20 @@ struct CoocPair {
 };
 
 struct CooccurrenceInfo {
-  CooccurrenceInfo(const int doc_id) : cooc_tf(1), cooc_df(1), prev_doc_id(doc_id) {}
+  CooccurrenceInfo(const int doc_id) : cooc_tf(1), cooc_df(1), prev_doc_id(doc_id) { }
   long long cooc_tf;
   int cooc_df;
   int prev_doc_id;
 };
 
 struct FirstTokenInfo {
-  FirstTokenInfo(const int doc_id) : num_of_documents(1), prev_doc_id(doc_id) {}
+  FirstTokenInfo(const int doc_id) : num_of_documents(1), prev_doc_id(doc_id) { }
   int num_of_documents;
   int prev_doc_id;
 };
 
 struct PpmiCountersValues {
-  PpmiCountersValues() : n_u_tf(0), n_u_df(0) {}
+  PpmiCountersValues() : n_u_tf(0), n_u_df(0) { }
   long long n_u_tf;
   int n_u_df;
 };
@@ -67,7 +67,7 @@ struct PpmiCountersValues {
 // Cell consists of header (first three fields) and records.
 // You need firstly to read cell header then records
 struct Cell {
-  Cell() : first_token_id(-1), num_of_documents(0), num_of_records(0) {}
+  Cell() : first_token_id(-1), num_of_documents(0), num_of_records(0) { }
   int first_token_id;
   int num_of_documents; // when cell is read, it's necessary to know how many triples to read
   unsigned num_of_records;

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -52,8 +52,9 @@ class CuckooWatch {
 static std::string formatByteSize(long long bytes) {
   std::stringstream ss;
   int unit = 1024 * 1024;  // MB;
-  if (bytes < unit)
+  if (bytes < unit) {
     return "<1 MB";
+  }
   ss << bytes / unit << " MB";
   return ss.str();
 }
@@ -81,17 +82,22 @@ class CsvEscape {
   explicit CsvEscape(char delimiter) : delimiter_(delimiter) {}
 
   std::string apply(const std::string& in) {
-    if (delimiter_ == '\0')
+    if (delimiter_ == '\0') {
       return in;
+    }
 
-    if (in.find(delimiter_) == std::string::npos)
+    if (in.find(delimiter_) == std::string::npos) {
       return in;
+    }
 
     std::stringstream ss;
     ss << "\"";
     for (unsigned i = 0; i < in.size(); ++i) {
-      if (in[i] == '"') ss << "\"\"";
-      else ss << in[i];
+      if (in[i] == '"') {
+        ss << "\"\"";
+      } else {
+        ss << in[i];
+      }
     }
     ss << "\"";
 
@@ -117,8 +123,9 @@ class ProgressScope {
 };
 
 bool parseNumberOrPercent(std::string str, float* value, bool* fraction ) {
-  if (str.empty())
+  if (str.empty()) {
     return false;
+  }
 
   bool percent = false;
   if (str[str.size() - 1] == '%') {
@@ -130,8 +137,7 @@ bool parseNumberOrPercent(std::string str, float* value, bool* fraction ) {
   *fraction = true;
   try {
     *value = boost::lexical_cast<float>(str);
-  }
-  catch (...) {
+  } catch (...) {
     return false;
   }
 
@@ -151,8 +157,9 @@ template<typename T>
 std::vector<std::pair<std::string, T>> parseKeyValuePairs(const std::string& input) {
   std::vector<std::pair<std::string, T>> retval;
 
-  if (input.empty())
+  if (input.empty()) {
     return retval;
+  }
 
   try {
     // Handle the case when "input" simply has an instance of typename T
@@ -168,8 +175,9 @@ std::vector<std::pair<std::string, T>> parseKeyValuePairs(const std::string& inp
     std::string elem = strs[elem_index];
     T elem_size = 0;
     size_t split_index = elem.find(':');
-    if (split_index == 0 || (split_index == elem.size() - 1))
+    if (split_index == 0 || (split_index == elem.size() - 1)) {
       split_index = std::string::npos;
+    }
 
     if (split_index != std::string::npos) {
       try {
@@ -197,8 +205,9 @@ std::vector<std::pair<std::string, std::vector<std::string>>> parseTopicGroups(c
       group_list.push_back(group);
     }
     else {
-      for (int i = 0; i < group_size; ++i)
+      for (int i = 0; i < group_size; ++i) {
         group_list.push_back(group + "_" + boost::lexical_cast<std::string>(i));
+      }
     }
     result.push_back(std::make_pair(group, group_list));
   }
@@ -210,9 +219,11 @@ std::vector<std::pair<std::string, std::vector<std::string>>> parseTopicGroups(c
 std::vector<std::string> parseTopics(const std::string& topics) {
   std::vector<std::string> result;
   std::vector<std::pair<std::string, std::vector<std::string>>> pairs = parseTopicGroups(topics);
-  for (auto& pair : pairs)
-    for (auto& topic_name : pair.second)
+  for (auto& pair : pairs) {
+    for (auto& topic_name : pair.second) {
       result.push_back(topic_name);
+    }
+  }
 
   return result;
 }
@@ -228,16 +239,19 @@ std::vector<std::string> parseTopics(const std::string& topics, const std::strin
     bool found = false;
     for (auto& pair : pairs) {
       if (pair.first == topic_name) {
-        for (auto& group_topic : pair.second)
+        for (auto& group_topic : pair.second) {
           result.push_back(group_topic);
+	}
         found = true;
         break;
       }
     }
 
-    if (!found)
-      if (all_topics_set.find(topic_name) != all_topics_set.end())
+    if (!found) {
+      if (all_topics_set.find(topic_name) != all_topics_set.end()) {
         result.push_back(topic_name);
+      }
+    }
   }
 
   return result;
@@ -359,13 +373,15 @@ struct artm_options {
 };
 
 void fixOptions(artm_options* options) {
-  if (boost::to_lower_copy(options->csv_separator) == "tab")
+  if (boost::to_lower_copy(options->csv_separator) == "tab") {
     options->csv_separator = "\t";
+  }
 }
 
 bool verifyWritableFile(const std::string& file, bool force) {
-  if (file.empty())
+  if (file.empty()) {
     return true;
+  }
 
   bool exists = boost::filesystem::exists(file);
   bool is_directory = exists && boost::filesystem::is_directory(file);
@@ -431,7 +447,7 @@ void fixScoreLevel(artm_options* options) {
   std::vector<std::pair<std::string, float>> class_ids_map = parseKeyValuePairs<float>(options->use_modality);
   std::vector<std::string> class_ids;
 
-  for (auto& class_id : class_ids_map) {
+  for (const auto& class_id : class_ids_map) {
     if (!class_id.first.empty()) {
       std::stringstream ss;
       ss << " @" << class_id.first;
@@ -441,21 +457,26 @@ void fixScoreLevel(artm_options* options) {
     }
   }
 
-  if (class_ids.empty())
+  if (class_ids.empty()) {
     class_ids.push_back(std::string());
+  }
 
   if (options->score_level >= 1) {
     options->score.push_back("Perplexity");
-    for (auto& class_id : class_ids)
+    for (const auto& class_id : class_ids) {
       options->score.push_back(std::string("SparsityPhi") + class_id);
+    }
+
     options->score.push_back("SparsityTheta");
-    if (!options->predict_class.empty())
+    if (!options->predict_class.empty()) {
       options->score.push_back("ClassPrecision");
+    }
   }
 
   if (options->score_level >= 2) {
-    for (auto& class_id : class_ids)
+    for (const auto& class_id : class_ids) {
       options->final_score.push_back(std::string("TopTokens") + class_id);
+    }
     options->final_score.push_back("ThetaSnippet");
   }
 
@@ -465,8 +486,9 @@ void fixScoreLevel(artm_options* options) {
 }
 
 std::string addToDictionaryMap(std::map<std::string, std::string>* dictionary_map, std::string dictionary_path) {
-  if (dictionary_path.empty())
+  if (dictionary_path.empty()) {
     return std::string();
+  }
 
   auto mapped_name = dictionary_map->find(dictionary_path);
   if (mapped_name == dictionary_map->end()) {
@@ -484,8 +506,9 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
                           MasterModelConfig* master_config) {
   std::vector<std::string> strs;
   boost::split(strs, regularizer, boost::is_any_of("\t "));
-  if (strs.size() < 2)
+  if (strs.size() < 2) {
     throw std::invalid_argument(std::string("Invalid regularizer: " + regularizer));
+  }
   float tau;
   try {
     tau = boost::lexical_cast<float>(strs[0]);
@@ -498,17 +521,24 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
   std::string dictionary_path;
   for (unsigned i = 2; i < strs.size(); ++i) {
     std::string elem = strs[i];
-    if (elem.empty())
+    if (elem.empty()) {
       continue;
+    }
     if (elem[0] == '#') {
       topic_names = parseTopics(elem.substr(1, elem.size() - 1), topics);
-      if (topic_names.empty()) throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + regularizer + "'");
+      if (topic_names.empty()) {
+        throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + regularizer + "'");
+      }
     }  else if (elem[0] == '@') {
       class_ids = parseKeyValuePairs<float>(elem.substr(1, elem.size() - 1));
-      if (class_ids.empty()) throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + regularizer + "'");
+      if (class_ids.empty()) {
+        throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + regularizer + "'");
+      }
     } else if (elem[0] == '!') {
       dictionary_path = elem.substr(1, elem.size() - 1);
-      if (dictionary_path.empty()) throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + regularizer + "'");
+      if (dictionary_path.empty()) {
+        throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + regularizer + "'");
+      }
     } else {
       throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + regularizer + "'");
     }
@@ -518,14 +548,18 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
 
   RegularizerConfig* config = master_config->add_regularizer_config();
 
-  // SmoothPhi, SparsePhi, SmoothTheta, SparseTheta, Decorrelation, TopicSelection, LabelRegularization, ImproveCoherence, Biterms
+  // SmoothPhi, SparsePhi, SmoothTheta, SparseTheta, Decorrelation,
+  // TopicSelection, LabelRegularization, ImproveCoherence, Biterms
   std::string regularizer_type = boost::to_lower_copy(strs[1]);
   if (regularizer_type == "smooththeta" || regularizer_type == "sparsetheta") {
     ::artm::SmoothSparseThetaConfig specific_config;
-    for (auto& topic_name : topic_names)
+    for (const auto& topic_name : topic_names) {
       specific_config.add_topic_name(topic_name);
+    }
 
-    if (regularizer_type == "sparsetheta") tau = -tau;
+    if (regularizer_type == "sparsetheta") {
+      tau = -tau;
+    }
 
     config->set_name(regularizer);
     config->set_type(::artm::RegularizerType_SmoothSparseTheta);
@@ -534,14 +568,21 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
   }
   else if (regularizer_type == "smoothphi" || regularizer_type == "sparsephi") {
     ::artm::SmoothSparsePhiConfig specific_config;
-    for (auto& topic_name : topic_names)
+    for (const auto& topic_name : topic_names) {
       specific_config.add_topic_name(topic_name);
-    for (auto& class_id : class_ids)
-      specific_config.add_class_id(class_id.first);
-    if (!dictionary_name.empty())
-      specific_config.set_dictionary_name(dictionary_name);
+    }
 
-    if (regularizer_type == "sparsephi") tau = -tau;
+    for (const auto& class_id : class_ids) {
+      specific_config.add_class_id(class_id.first);
+    }
+
+    if (!dictionary_name.empty()) {
+      specific_config.set_dictionary_name(dictionary_name);
+    }
+
+    if (regularizer_type == "sparsephi") {
+      tau = -tau;
+    }
 
     config->set_name(regularizer);
     config->set_type(::artm::RegularizerType_SmoothSparsePhi);
@@ -550,10 +591,13 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
   }
   else if (regularizer_type == "decorrelation") {
     ::artm::DecorrelatorPhiConfig specific_config;
-    for (auto& topic_name : topic_names)
+    for (const auto& topic_name : topic_names) {
       specific_config.add_topic_name(topic_name);
-    for (auto& class_id : class_ids)
+    }
+
+    for (const auto& class_id : class_ids) {
       specific_config.add_class_id(class_id.first);
+    }
 
     config->set_name(regularizer);
     config->set_type(::artm::RegularizerType_DecorrelatorPhi);
@@ -562,8 +606,9 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
   }
   else if (regularizer_type == "topicselection") {
     ::artm::TopicSelectionThetaConfig specific_config;
-    for (auto& topic_name : topic_names)
+    for (const auto& topic_name : topic_names) {
       specific_config.add_topic_name(topic_name);
+    }
 
     config->set_name(regularizer);
     config->set_type(::artm::RegularizerType_TopicSelectionTheta);
@@ -575,12 +620,17 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
   }
   else if (regularizer_type == "labelregularization") {
     ::artm::LabelRegularizationPhiConfig specific_config;
-    for (auto& topic_name : topic_names)
+    for (const auto& topic_name : topic_names) {
       specific_config.add_topic_name(topic_name);
-    for (auto& class_id : class_ids)
+    }
+
+    for (const auto& class_id : class_ids) {
       specific_config.add_class_id(class_id.first);
-    if (!dictionary_name.empty())
+    }
+
+    if (!dictionary_name.empty()) {
       specific_config.set_dictionary_name(dictionary_name);
+    }
 
     config->set_name(regularizer);
     config->set_type(::artm::RegularizerType_LabelRegularizationPhi);
@@ -589,12 +639,17 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
   }
   else if (regularizer_type == "improvecoherence") {
     ::artm::ImproveCoherencePhiConfig specific_config;
-    for (auto& topic_name : topic_names)
+    for (const auto& topic_name : topic_names) {
       specific_config.add_topic_name(topic_name);
-    for (auto& class_id : class_ids)
+    }
+
+    for (const auto& class_id : class_ids) {
       specific_config.add_class_id(class_id.first);
-    if (!dictionary_name.empty())
+    }
+
+    if (!dictionary_name.empty()) {
       specific_config.set_dictionary_name(dictionary_name);
+    }
 
     config->set_name(regularizer);
     config->set_type(::artm::RegularizerType_ImproveCoherencePhi);
@@ -603,12 +658,17 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
   }
   else if (regularizer_type == "biterms") {
     ::artm::BitermsPhiConfig specific_config;
-    for (auto& topic_name : topic_names)
+    for (const auto& topic_name : topic_names) {
       specific_config.add_topic_name(topic_name);
-    for (auto& class_id : class_ids)
+    }
+
+    for (const auto& class_id : class_ids) {
       specific_config.add_class_id(class_id.first);
-    if (!dictionary_name.empty())
+    }
+
+    if (!dictionary_name.empty()) {
       specific_config.set_dictionary_name(dictionary_name);
+    }
 
     config->set_name(regularizer);
     config->set_type(::artm::RegularizerType_BitermsPhi);
@@ -621,13 +681,24 @@ void configureRegularizer(const std::string& regularizer, const std::string& top
 
 void output_profile_information(const MasterModel& master) {
   auto info = master.info();
-  for (auto& model : info.model())
-    std::cerr << "\tModel " << model.name() << ": " << formatByteSize(model.byte_size()) << ", |T|=" << model.num_topics() << ", |W| = " << model.num_tokens() << ";\n";
-  for (auto& dict : info.dictionary())
-    std::cerr << "\tDictionary " << dict.name() << ": " << formatByteSize(dict.byte_size()) << ", |W|=" << dict.num_entries() << ";\n";
+  for (const auto& model : info.model()) {
+    std::cerr << "\tModel " << model.name()
+              << ": " << formatByteSize(model.byte_size())
+              << ", |T|=" << model.num_topics()
+              << ", |W| = " << model.num_tokens() << ";\n";
+  }
+
+  for (const auto& dict : info.dictionary()) {
+    std::cerr << "\tDictionary " << dict.name()
+              << ": " << formatByteSize(dict.byte_size())
+              << ", |W|=" << dict.num_entries() << ";\n";
+  }
   int64_t cache_size = 0;
-  for (auto& cache_entity : info.cache_entry()) cache_size += cache_entity.byte_size();
-  std::cerr << "\tCache size: " << formatByteSize(cache_size) << " in total across " << info.cache_entry_size() << " entries;\n";
+  for (const auto& cache_entity : info.cache_entry()) {
+    cache_size += cache_entity.byte_size();
+  }
+  std::cerr << "\tCache size: " << formatByteSize(cache_size)
+            << " in total across " << info.cache_entry_size() << " entries;\n";
 }
 
 class ScoreHelper {
@@ -646,8 +717,9 @@ class ScoreHelper {
          master_(nullptr),
          config_(config),
          dictionary_map_(dictionary_map) {
-     if (!artm_options_.write_scores.empty())
+     if (!artm_options_.write_scores.empty()) {
        output_.open(artm_options_.write_scores, std::ofstream::app);
+     }
    }
 
    void setMasterModel(::artm::MasterModel* master) { master_ = master; }
@@ -655,25 +727,34 @@ class ScoreHelper {
    void addScore(const std::string& score, const std::string& topics) {
      std::vector<std::string> strs;
      boost::split(strs, score, boost::is_any_of("\t "));
-     if (strs.size() < 1)
+     if (strs.size() < 1) {
        throw std::invalid_argument(std::string("Invalid score: " + score));
+     }
 
      std::vector<std::pair<std::string, float>> class_ids;
      std::vector<std::string> topic_names;
      std::string dictionary_path;
      for (unsigned i = 1; i < strs.size(); ++i) {
        std::string elem = strs[i];
-       if (elem.empty())
+       if (elem.empty()) {
          continue;
+       }
+
        if (elem[0] == '#') {
          topic_names = parseTopics(elem.substr(1, elem.size() - 1), topics);
-         if (topic_names.empty()) throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + score + "'");
+         if (topic_names.empty()) {
+           throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + score + "'");
+         }
        } else if (elem[0] == '@') {
          class_ids = parseKeyValuePairs<float>(elem.substr(1, elem.size() - 1));
-         if (class_ids.empty()) throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + score + "'");
+         if (class_ids.empty()) {
+           throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + score + "'");
+         }
        } else if (elem[0] == '!') {
          dictionary_path = elem.substr(1, elem.size() - 1);
-         if (dictionary_path.empty()) throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + score + "'");
+         if (dictionary_path.empty()) {
+           throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + score + "'");
+         }
        } else {
          throw std::invalid_argument(std::string("Error in '") + elem + "' from '" + score + "'");
        }
@@ -699,7 +780,9 @@ class ScoreHelper {
      score_config.set_name(score);
      if (score_type == "perplexity") {
        PerplexityScoreConfig specific_config;
-       for (auto& class_id : class_ids) specific_config.add_class_id(class_id.first);
+       for (const auto& class_id : class_ids) {
+         specific_config.add_class_id(class_id.first);
+       }
        if (dictionary_name.empty()) {
          specific_config.set_model_type(PerplexityScoreConfig_Type_UnigramDocumentModel);
        } else {
@@ -711,38 +794,73 @@ class ScoreHelper {
      }
      else if (score_type == "sparsitytheta") {
        SparsityThetaScoreConfig specific_config;
-       for (auto& topic_name : topic_names) specific_config.add_topic_name(topic_name);
+       for (const auto& topic_name : topic_names) {
+         specific_config.add_topic_name(topic_name);
+       }
+
        score_config.set_type(::artm::ScoreType_SparsityTheta);
        score_config.set_config(specific_config.SerializeAsString());
      }
      else if (score_type == "sparsityphi") {
        SparsityPhiScoreConfig specific_config;
-       for (auto& topic_name : topic_names) specific_config.add_topic_name(topic_name);
-       for (auto& class_id : class_ids) specific_config.set_class_id(class_id.first);
+       for (const auto& topic_name : topic_names) {
+         specific_config.add_topic_name(topic_name);
+       }
+
+       for (const auto& class_id : class_ids) {
+         specific_config.set_class_id(class_id.first);
+       }
+
        score_config.set_type(::artm::ScoreType_SparsityPhi);
        score_config.set_config(specific_config.SerializeAsString());
      }
      else if (score_type == "toptokens") {
        TopTokensScoreConfig specific_config;
-       if (score_arg != 0) specific_config.set_num_tokens(static_cast<int>(score_arg));
-       for (auto& topic_name : topic_names) specific_config.add_topic_name(topic_name);
-       for (auto& class_id : class_ids) specific_config.set_class_id(class_id.first);
-       if (!dictionary_name.empty()) specific_config.set_cooccurrence_dictionary_name(dictionary_name);
+       if (score_arg != 0) {
+         specific_config.set_num_tokens(static_cast<int>(score_arg));
+       }
+
+       for (const auto& topic_name : topic_names) {
+         specific_config.add_topic_name(topic_name);
+       }
+
+       for (const auto& class_id : class_ids) {
+         specific_config.set_class_id(class_id.first);
+       }
+
+       if (!dictionary_name.empty()) {
+         specific_config.set_cooccurrence_dictionary_name(dictionary_name);
+       }
+
        score_config.set_type(::artm::ScoreType_TopTokens);
        score_config.set_config(specific_config.SerializeAsString());
      }
      else if (score_type == "thetasnippet") {
        ThetaSnippetScoreConfig specific_config;
-       if (score_arg != 0) specific_config.set_num_items(score_arg);
+       if (score_arg != 0) {
+         specific_config.set_num_items(score_arg);
+       }
        score_config.set_type(::artm::ScoreType_ThetaSnippet);
        score_config.set_config(specific_config.SerializeAsString());
      }
      else if (score_type == "topickernel") {
        TopicKernelScoreConfig specific_config;
-       if (score_arg != 0) specific_config.set_probability_mass_threshold(score_arg);
-       for (auto& topic_name : topic_names) specific_config.add_topic_name(topic_name);
-       for (auto& class_id : class_ids) specific_config.set_class_id(class_id.first);
-       if (!dictionary_name.empty()) specific_config.set_cooccurrence_dictionary_name(dictionary_name);
+       if (score_arg != 0) {
+         specific_config.set_probability_mass_threshold(score_arg);
+       }
+
+       for (const auto& topic_name : topic_names) {
+         specific_config.add_topic_name(topic_name);
+       }
+
+       for (const auto& class_id : class_ids) {
+         specific_config.set_class_id(class_id.first);
+       }
+
+       if (!dictionary_name.empty()) {
+         specific_config.set_cooccurrence_dictionary_name(dictionary_name);
+       }
+
        score_config.set_type(::artm::ScoreType_TopicKernel);
        score_config.set_config(specific_config.SerializeAsString());
      }
@@ -770,21 +888,27 @@ class ScoreHelper {
      if (type == ::artm::ScoreType_Perplexity) {
        auto score_data = master_->GetScoreAs< ::artm::PerplexityScore>(get_score_args);
        std::cerr << "Perplexity      = " << score_data.value();
-       if (boost::to_lower_copy(score_name) != "perplexity") std::cerr << "\t(" << score_name << ")";
+       if (boost::to_lower_copy(score_name) != "perplexity") {
+         std::cerr << "\t(" << score_name << ")";
+       }
        std::cerr << "\n";
        retval = boost::lexical_cast<std::string>(score_data.value());
      }
      else if (type == ::artm::ScoreType_SparsityTheta) {
        auto score_data = master_->GetScoreAs< ::artm::SparsityThetaScore>(get_score_args);
        std::cerr << "SparsityTheta   = " << score_data.value();
-       if (boost::to_lower_copy(score_name) != "sparsitytheta") std::cerr << "\t(" << score_name << ")";
+       if (boost::to_lower_copy(score_name) != "sparsitytheta") {
+         std::cerr << "\t(" << score_name << ")";
+       }
        std::cerr << "\n";
        retval = boost::lexical_cast<std::string>(score_data.value());
      }
      else if (type == ::artm::ScoreType_SparsityPhi) {
        auto score_data = master_->GetScoreAs< ::artm::SparsityPhiScore>(get_score_args);
        std::cerr << "SparsityPhi     = " << score_data.value();
-       if (boost::to_lower_copy(score_name) != "sparsityphi") std::cerr << "\t(" << score_name << ")";
+       if (boost::to_lower_copy(score_name) != "sparsityphi") {
+         std::cerr << "\t(" << score_name << ")";
+       }
        std::cerr << "\n";
        retval = boost::lexical_cast<std::string>(score_data.value());
      }
@@ -819,25 +943,32 @@ class ScoreHelper {
      else if (type == ::artm::ScoreType_TopicKernel) {
        auto score_data = master_->GetScoreAs< ::artm::TopicKernelScore>(get_score_args);
        std::stringstream suffix;
-       if (boost::to_lower_copy(score_name) != "topickernel") suffix << "\t(" << score_name << ")";
+       if (boost::to_lower_copy(score_name) != "topickernel") {
+         suffix << "\t(" << score_name << ")";
+       }
 
        std::cerr << "KernelSize      = " << score_data.average_kernel_size() << suffix.str() << "\n";
        std::cerr << "KernelPurity    = " << score_data.average_kernel_purity() << suffix.str() << "\n";
        std::cerr << "KernelContrast  = " << score_data.average_kernel_contrast() << suffix.str() << "\n";
-       if (score_data.has_average_coherence())
+       if (score_data.has_average_coherence()) {
          std::cerr << "KernelCoherence = " << score_data.average_coherence() << suffix.str() << "\n";
+       }
      }
      else if (type == ::artm::ScoreType_ClassPrecision) {
        auto score_data = master_->GetScoreAs< ::artm::ClassPrecisionScore>(get_score_args);
        std::stringstream suffix;
-       if (boost::to_lower_copy(score_name) != "classprecision") suffix << "\t(" << score_name << ")";
+       if (boost::to_lower_copy(score_name) != "classprecision") {
+         suffix << "\t(" << score_name << ")";
+       }
        std::cerr << "ClassPrecision  = " << score_data.value() << suffix.str() << "\n";
        retval = boost::lexical_cast<std::string>(score_data.value());
      }
      else if (type == ::artm::ScoreType_PeakMemory) {
        auto score_data = master_->GetScoreAs< ::artm::PeakMemoryScore>(get_score_args);
        std::cerr << "PeakMemory      = " << formatByteSize(score_data.value());
-       if (boost::to_lower_copy(score_name) != "peakmemory") std::cerr << "\t(" << score_name << ")";
+       if (boost::to_lower_copy(score_name) != "peakmemory") {
+         std::cerr << "\t(" << score_name << ")";
+       }
        std::cerr << "\n";
        retval = boost::lexical_cast<std::string>(score_data.value());
        output_profile_information(*master_);
@@ -849,15 +980,25 @@ class ScoreHelper {
    }
 
    void showScoresHeader(int argc, char* argv[]) {
-     if (!output_.is_open())
+     if (!output_.is_open()) {
        return;
+     }
      for (int i = 0; i < argc; ++i) {
        bool has_space = (std::string(argv[i]).find(' ') != std::string::npos);
-       if (has_space) output_ << "\"";
+       if (has_space) {
+         output_ << "\"";
+       }
+
        output_ << argv[i];
-       if (has_space) output_ << "\"";
-       if ((i + 1) != argc) output_ << " ";
-       else output_ << std::endl;
+       if (has_space) {
+         output_ << "\"";
+       }
+
+       if ((i + 1) != argc) {
+         output_ << " ";
+       } else {
+         output_ << std::endl;
+       }
      }
 
      CsvEscape escape(artm_options_.csv_separator.size() == 1 ? artm_options_.csv_separator[0] : '\0');
@@ -872,19 +1013,27 @@ class ScoreHelper {
    void showScores(int iter, long long elapsed_ms) {
      CsvEscape escape(artm_options_.csv_separator.size() == 1 ? artm_options_.csv_separator[0] : '\0');
      const std::string sep = artm_options_.csv_separator;
-     if (output_.is_open()) output_ << iter << sep << elapsed_ms;
+     if (output_.is_open()) {
+       output_ << iter << sep << elapsed_ms;
+     }
      for (const auto& score_name: score_name_) {
        std::string score_value = showScore(score_name.first, score_name.second);
-       if (output_.is_open()) output_ << sep << score_value;
+       if (output_.is_open()) {
+         output_ << sep << score_value;
+       }
      }
-     if (output_.is_open()) output_ << std::endl;
-     if (iter > 0)
+     if (output_.is_open()) {
+       output_ << std::endl;
+     }
+     if (iter > 0) {
       std::cerr << "================= Iteration " << iter << " took " << formatMilliseconds(elapsed_ms) << std::endl;
+     }
    }
 
    void showScores() {
-     for (const auto& score_name : score_name_)
+     for (const auto& score_name : score_name_) {
        showScore(score_name.first, score_name.second);
+     }
    }
 
    static std::string formatMilliseconds(long long elapsed) {
@@ -922,10 +1071,13 @@ class BatchVectorizer {
     const bool parse_uci_format = !options_.read_uci_docword.empty();
     const bool use_batches = !options_.use_batches.empty();
 
-    if (((int)parse_vw_format + (int)parse_uci_format + (int)use_batches) >= 2)
+    if (((int)parse_vw_format + (int)parse_uci_format + (int)use_batches) >= 2) {
       throw std::invalid_argument("--read_vw_format, --read-uci-docword, --use-batches must not be used together");
-    if (parse_uci_format && options_.read_uci_vocab.empty())
+    }
+
+    if (parse_uci_format && options_.read_uci_vocab.empty()) {
       throw std::invalid_argument("--read-uci-vocab option must be specified together with --read-uci-docword\n");
+    }
 
     if (parse_vw_format || parse_uci_format) {
       if (options_.save_batches.empty()) {
@@ -936,34 +1088,43 @@ class BatchVectorizer {
         batch_folder_ = options_.save_batches;
       }
 
-      if (fs::exists(fs::path(batch_folder_)) && !fs::is_empty(fs::path(batch_folder_)))
+      if (fs::exists(fs::path(batch_folder_)) && !fs::is_empty(fs::path(batch_folder_))) {
         std::cerr << "Warning: --save-batches folder already exists, new batches will be added into " << batch_folder_ << "\n";
+      }
 
       boost::system::error_code error;
       fs::create_directories(batch_folder_, error);
-      if (error)
+      if (error) {
         throw std::runtime_error(std::string("Unable to create batch folder: ") + batch_folder_);
+      }
 
       ::artm::CollectionParserInfo parser_info;
       {
         ProgressScope scope("Parsing text collection");
         ::artm::CollectionParserConfig collection_parser_config;
-        if (parse_uci_format) collection_parser_config.set_format(CollectionParserConfig_CollectionFormat_BagOfWordsUci);
-        else if (parse_vw_format) collection_parser_config.set_format(CollectionParserConfig_CollectionFormat_VowpalWabbit);
-        else throw std::runtime_error("Internal error in bigartm.exe - unable to determine CollectionParserConfig_CollectionFormat");
+        if (parse_uci_format) {
+          collection_parser_config.set_format(CollectionParserConfig_CollectionFormat_BagOfWordsUci);
+        } else if (parse_vw_format) {
+          collection_parser_config.set_format(CollectionParserConfig_CollectionFormat_VowpalWabbit);
+        } else {
+          throw std::runtime_error("Internal error in bigartm.exe - unable to determine CollectionParserConfig_CollectionFormat");
+        }
 
         collection_parser_config.set_docword_file_path(parse_vw_format ? options_.read_vw_corpus : options_.read_uci_docword);
-        if (!options_.read_uci_vocab.empty())
+        if (!options_.read_uci_vocab.empty()) {
           collection_parser_config.set_vocab_file_path(options_.read_uci_vocab);
+        }
         collection_parser_config.set_target_folder(batch_folder_);
         collection_parser_config.set_num_items_per_batch(options_.batch_size);
         collection_parser_config.set_name_type(options_.b_guid_batch_name ? CollectionParserConfig_BatchNameType_Guid : CollectionParserConfig_BatchNameType_Code);
 
         // If user specifies specific modalities "use_modality", pass it to collection parser to limit set of modalities available in batches
         std::vector<std::pair<std::string, float>> class_ids = parseKeyValuePairs<float>(options_.use_modality);
-        for (auto& class_id : class_ids)
-          if (!class_id.first.empty())
+        for (auto& class_id : class_ids) {
+          if (!class_id.first.empty()) {
             collection_parser_config.add_class_id(class_id.first);
+          }
+        }
 
         parser_info = ::artm::ParseCollection(collection_parser_config);
       }
@@ -974,12 +1135,14 @@ class BatchVectorizer {
     }
     else if (!options_.use_batches.empty()) {
       batch_folder_ = options_.use_batches;
-      if (!fs::exists(fs::path(batch_folder_)))
+      if (!fs::exists(fs::path(batch_folder_))) {
         throw std::runtime_error(std::string("Unable to find batch folder: ") + batch_folder_);
+      }
 
       int batch_files_count = findFilesInDirectory(batch_folder_, ".batch").size();
-      if (batch_files_count == 0)
+      if (batch_files_count == 0) {
         throw std::runtime_error(std::string("No batches found in batch folder: ") + batch_folder_);
+      }
 
       std::cerr << "Using " << batch_files_count << " batches from '" << batch_folder_ << "'\n";
     }
@@ -1007,16 +1170,18 @@ void WritePredictions(const artm_options& options,
   // header
   output << "id" << sep << "title";
   for (int j = 0; j < theta_metadata.num_topics(); ++j) {
-    if (theta_metadata.topic_name_size() > 0)
+    if (theta_metadata.topic_name_size() > 0) {
       output << sep << escape.apply(theta_metadata.topic_name(j));
-    else
+    } else {
       output << sep << "topic" << j;
+    }
   }
   output << std::endl;
 
   std::vector<std::pair<int, int>> id_to_index;
-  for (int i = 0; i < theta_metadata.item_id_size(); ++i)
+  for (int i = 0; i < theta_metadata.item_id_size(); ++i) {
     id_to_index.push_back(std::make_pair(theta_metadata.item_id(i), i));
+  }
   std::sort(id_to_index.begin(), id_to_index.end());
 
   // bulk
@@ -1044,8 +1209,9 @@ void WriteClassPredictions(const artm_options& options,
   output << "id" << sep << "title" << sep << options.predict_class << std::endl;
 
   std::vector<std::pair<int, int>> id_to_index;
-  for (int i = 0; i < theta_metadata.item_id_size(); ++i)
+  for (int i = 0; i < theta_metadata.item_id_size(); ++i) {
     id_to_index.push_back(std::make_pair(theta_metadata.item_id(i), i));
+  }
   std::sort(id_to_index.begin(), id_to_index.end());
 
   // bulk
@@ -1071,8 +1237,9 @@ void WriteClassPredictions(const artm_options& options,
 void WriteVwCorpus(const artm_options& options, const std::string& batch_folder) {
   ProgressScope scope(std::string("Saving batches as Vowpal Wabbit corpus ") + options.write_vw_corpus);
   auto batch_file_names = findFilesInDirectory(batch_folder, ".batch");
-  if (batch_file_names.empty())
+  if (batch_file_names.empty()) {
     throw std::string("No batches found in ") + batch_folder + ", unabel to  active_class_id = defaultwrite VW corpus";
+  }
 
   auto remove_spaces = [](const std::string& input) {
     std::string retval = input;
@@ -1082,27 +1249,33 @@ void WriteVwCorpus(const artm_options& options, const std::string& batch_folder)
 
   std::ofstream output(options.write_vw_corpus);
   const std::string default_class_id = "@default_class";
-  for (auto batch_file_name : batch_file_names) {
+  for (const auto& batch_file_name : batch_file_names) {
     Batch batch = artm::LoadBatch(batch_file_name.string());
     std::string active_class_id = default_class_id;
 
-    for (auto& item : batch.item()) {
-      if (item.title().empty())
+    for (const auto& item : batch.item()) {
+      if (item.title().empty()) {
         output << item.id();
-      else
+      } else {
         output << remove_spaces(item.title());
+      }
       for (int i = 0; i < item.token_id_size(); ++i) {
         int token_id = item.token_id(i);
         float token_weight = (item.token_weight_size() > 0) ? item.token_weight(i) : 1.0f;
         std::string class_id = (batch.class_id_size() > 0) ? batch.class_id(token_id) : std::string();
-        if (class_id.empty()) class_id = default_class_id;
+        if (class_id.empty()) {
+          class_id = default_class_id;
+        }
+
         if (class_id != active_class_id) {
           output << " |" << class_id;
           active_class_id = class_id;
         }
         output << " " << remove_spaces(batch.token(token_id));
-        if (token_weight != 1.0f)
+    
+        if (token_weight != 1.0f) {
           output << ":" << std::setprecision(2) << token_weight;
+        }
       }
       output << std::endl;
     }
@@ -1111,9 +1284,11 @@ void WriteVwCorpus(const artm_options& options, const std::string& batch_folder)
 
 int get_dictionary_size(const MasterModel& master, std::string dictionary_name) {
   auto info = master.info();
-  for (int i = 0; i < info.dictionary_size(); ++i)
-    if (info.dictionary(i).name() == dictionary_name)
+  for (int i = 0; i < info.dictionary_size(); ++i) {
+    if (info.dictionary(i).name() == dictionary_name) {
       return info.dictionary(i).num_entries();
+    }
+  }
   return -1;
 }
 
@@ -1129,33 +1304,49 @@ int execute(const artm_options& options, int argc, char* argv[]) {
   master_config.set_pwt_name(options.pwt_model_name);
   master_config.set_nwt_name(options.nwt_model_name);
 
-  for (auto& topic_name : topic_names)
+  for (const auto& topic_name : topic_names) {
     master_config.add_topic_name(topic_name);
+  }
 
   std::vector<std::pair<std::string, float>> class_ids = parseKeyValuePairs<float>(options.use_modality);
-  for (auto& class_id : class_ids) {
-    if (class_id.first.empty())
+  for (const auto& class_id : class_ids) {
+    if (class_id.first.empty()) {
       continue;
+    }
+
     master_config.add_class_id(class_id.first);
     master_config.add_class_weight(class_id.second == 0.0f ? 1.0f : class_id.second);
   }
 
   master_config.set_opt_for_avx(!options.b_disable_avx_opt);
-  if (options.b_reuse_theta) master_config.set_reuse_theta(true);
-  if (!options.disk_cache_folder.empty()) master_config.set_disk_cache_path(options.disk_cache_folder);
+  if (options.b_reuse_theta) {
+    master_config.set_reuse_theta(true);
+  }
+
+  if (!options.disk_cache_folder.empty()) {
+    master_config.set_disk_cache_path(options.disk_cache_folder);
+  }
 
   // Step 1.1. Configure regularizers.
   std::map<std::string, std::string> dictionary_map;
-  if (!options.use_dictionary.empty())
+  if (!options.use_dictionary.empty()) {
     dictionary_map.insert(std::make_pair(options.use_dictionary, options.main_dictionary_name));
-  for (auto& regularizer : options.regularizer)
+  }
+
+  for (const auto& regularizer : options.regularizer) {
     configureRegularizer(regularizer, options.topics, &dictionary_map, &master_config);
+  }
 
   // Step 1.2. Configure scores.
   ScoreHelper score_helper(options, &master_config, &dictionary_map);
   ScoreHelper final_score_helper(options, &master_config, &dictionary_map);
-  for (auto& score : options.score) score_helper.addScore(score, options.topics);
-  for (auto& score : options.final_score) final_score_helper.addScore(score, options.topics);
+  for (const auto& score : options.score) {
+    score_helper.addScore(score, options.topics);
+  }
+
+  for (const auto& score : options.final_score) {
+    final_score_helper.addScore(score, options.topics);
+  }
 
   score_helper.showScoresHeader(argc, argv);
 
@@ -1183,13 +1374,20 @@ int execute(const artm_options& options, int argc, char* argv[]) {
     ::artm::GatherDictionaryArgs gather_dictionary_args;
     gather_dictionary_args.set_dictionary_target_name(options.main_dictionary_name);
     gather_dictionary_args.set_data_path(batch_vectorizer.batch_folder());
-    if (!options.read_cooc.empty()) gather_dictionary_args.set_cooc_file_path(options.read_cooc);
-    if (!options.read_uci_vocab.empty()) gather_dictionary_args.set_vocab_file_path(options.read_uci_vocab);
+
+    if (!options.read_cooc.empty()) {
+      gather_dictionary_args.set_cooc_file_path(options.read_cooc);
+    }
+
+    if (!options.read_uci_vocab.empty()) {
+      gather_dictionary_args.set_vocab_file_path(options.read_uci_vocab);
+    }
     master_component->GatherDictionary(gather_dictionary_args);
     has_dictionary = true;
   }
-  if (has_dictionary)
+  if (has_dictionary) {
     std::cerr << "Dictionary size: " << get_dictionary_size(*master_component, options.main_dictionary_name) << "\n";
+  }
 
   // Step 3.2. Filter dictionary
   if (!options.dictionary_max_df.empty() || !options.dictionary_min_df.empty() || (options.dictionary_size > 0)) {
@@ -1201,22 +1399,31 @@ int execute(const artm_options& options, int argc, char* argv[]) {
       bool fraction;
       float value;
       if (parseNumberOrPercent(options.dictionary_min_df, &value, &fraction))  {
-        if (fraction) filter_dictionary_args.set_min_df_rate(value);
-        else filter_dictionary_args.set_min_df(value);
+        if (fraction) {
+          filter_dictionary_args.set_min_df_rate(value);
+        } else {
+          filter_dictionary_args.set_min_df(value);
+	}
       } else {
-        if (!options.dictionary_min_df.empty())
+        if (!options.dictionary_min_df.empty()) {
           std::cerr << "Error in parameter 'dictionary_min_df', the option will be ignored (" << options.dictionary_min_df << ")\n";
+        }
       }
       if (parseNumberOrPercent(options.dictionary_max_df, &value, &fraction))  {
-        if (fraction) filter_dictionary_args.set_max_df_rate(value);
-        else filter_dictionary_args.set_max_df(value);
+        if (fraction) {
+          filter_dictionary_args.set_max_df_rate(value);
+        } else {
+          filter_dictionary_args.set_max_df(value);
+        }
       } else {
-        if (!options.dictionary_max_df.empty())
+        if (!options.dictionary_max_df.empty()) {
           std::cerr << "Error in parameter 'dictionary_max_df', the option will be ignored (" << options.dictionary_max_df << ")\n";
+        }
       }
 
-      if (options.dictionary_size > 0)
+      if (options.dictionary_size > 0) {
         filter_dictionary_args.set_max_dictionary_size(options.dictionary_size);
+      }
 
       master_component->FilterDictionary(filter_dictionary_args);
     }
@@ -1228,14 +1435,18 @@ int execute(const artm_options& options, int argc, char* argv[]) {
     ExportDictionaryArgs export_dictionary_args;
     export_dictionary_args.set_dictionary_name(options.main_dictionary_name);
     export_dictionary_args.set_file_name(options.save_dictionary);
-    if (options.force) boost::filesystem::remove(options.save_dictionary + ".dict");
+    if (options.force) {
+      boost::filesystem::remove(options.save_dictionary + ".dict");
+    }
     master_component->ExportDictionary(export_dictionary_args);
   }
 
   // Step 4.2. Loading remaining dictionaries.
-  for (auto iter : dictionary_map) {
-    if (iter.second == options.main_dictionary_name)
+  for (const auto iter : dictionary_map) {
+    if (iter.second == options.main_dictionary_name) {
       continue;  // already loaded at step 3.1
+    }
+
     ProgressScope scope(std::string("Importing dictionary ") + iter.first + " with ID=" + iter.second);
     ImportDictionaryArgs import_dictionary_args;
     import_dictionary_args.set_file_name(iter.first);
@@ -1262,8 +1473,14 @@ int execute(const artm_options& options, int argc, char* argv[]) {
     ::artm::TopicModel imported_model = master_component->GetTopicModel(get_topic_model_args);
 
     std::set<std::string> remaining_topics;
-    for (auto& topic_name : master_config.topic_name()) remaining_topics.insert(topic_name);
-    for (auto& topic_name : imported_model.topic_name()) remaining_topics.erase(topic_name);
+    for (const auto& topic_name : master_config.topic_name()) {
+      remaining_topics.insert(topic_name);
+    }
+
+    for (const auto& topic_name : imported_model.topic_name()) {
+      remaining_topics.erase(topic_name);
+    }
+
     if (!remaining_topics.empty()) {
       DictionaryData tmp_dictionary;
       tmp_dictionary.set_name("cd85d76c-5869-41d9-93ca-f96f5f118fb8-temporary-dictionary");
@@ -1275,10 +1492,13 @@ int execute(const artm_options& options, int argc, char* argv[]) {
 
       InitializeModelArgs tmp_model;
       tmp_model.set_model_name("cd85d76c-5869-41d9-93ca-f96f5f118fb8-temporary-model");
-      for (auto& topic_name : remaining_topics) tmp_model.add_topic_name(topic_name);
+      for (const auto& topic_name : remaining_topics) {
+        tmp_model.add_topic_name(topic_name);
+      }
       tmp_model.set_dictionary_name(tmp_dictionary.name());
-      if (options.rand_seed != -1)
+      if (options.rand_seed != -1) {
         tmp_model.set_seed(static_cast< int >(options.rand_seed));
+      }
       master_component->InitializeModel(tmp_model);
 
       MergeModelArgs merge_model_args;
@@ -1298,8 +1518,9 @@ int execute(const artm_options& options, int argc, char* argv[]) {
     initialize_model_args.mutable_topic_name()->CopyFrom(master_config.topic_name());
     initialize_model_args.set_dictionary_name(options.main_dictionary_name);
     // specify random seed
-    if (options.rand_seed != -1)
+    if (options.rand_seed != -1) {
       initialize_model_args.set_seed(static_cast< int >(options.rand_seed));
+    }
     master_component->InitializeModel(initialize_model_args);
 
     if (options.update_every > 0) {
@@ -1321,8 +1542,14 @@ int execute(const artm_options& options, int argc, char* argv[]) {
   int update_count = 0;
   CuckooWatch total_timer;
   for (int iter = 0;; ++iter) {
-    if ((options.num_collection_passes <= 0) && (options.time_limit <= 0)) break;
-    if ((options.num_collection_passes > 0) && (iter >= options.num_collection_passes)) break;
+    if ((options.num_collection_passes <= 0) && (options.time_limit <= 0)) {
+      break;
+    }
+
+    if ((options.num_collection_passes > 0) && (iter >= options.num_collection_passes)) {
+      break;
+    }
+
     if ((options.time_limit > 0) && (total_timer.elapsed_ms() >= options.time_limit)) {
       std::cerr << "Stopping iterations, time limit is reached." << std::endl;
       break;
@@ -1347,8 +1574,9 @@ int execute(const artm_options& options, int argc, char* argv[]) {
         fit_online_args.add_apply_weight(pow(options.tau0 + update_count, -options.kappa));
       } while (update_after < (int) batch_file_names.size());
 
-      for (auto& batch_file_name : batch_file_names)
+      for (const auto& batch_file_name : batch_file_names) {
         fit_online_args.add_batch_filename(batch_file_name.string());
+      }
 
       std::future<void> future = std::async(std::launch::async, [master_component, fit_online_args]() {
         master_component->FitOnlineModel(fit_online_args);
@@ -1356,12 +1584,15 @@ int execute(const artm_options& options, int argc, char* argv[]) {
 
       const int timeout_sec = options.profile > 0 ? options.profile : 60;
       while (future.wait_for(std::chrono::seconds(timeout_sec)) != std::future_status::ready) {
-        if (options.profile > 0) { output_profile_information(*master_component); std::cerr << "===========================================\n"; }
+        if (options.profile > 0) {
+          output_profile_information(*master_component); std::cerr << "===========================================\n";
+        }
       }
     } else {
       FitOfflineMasterModelArgs fit_offline_args;
-      for (auto& batch_file_name : batch_file_names)
+      for (const auto& batch_file_name : batch_file_names) {
         fit_offline_args.add_batch_filename(batch_file_name.string());
+      }
 
       std::future<void> future = std::async(std::launch::async, [master_component, fit_offline_args]() {
         master_component->FitOfflineModel(fit_offline_args);
@@ -1369,22 +1600,29 @@ int execute(const artm_options& options, int argc, char* argv[]) {
 
       const int timeout_sec = options.profile > 0 ? options.profile : 60;
       while (future.wait_for(std::chrono::seconds(timeout_sec)) != std::future_status::ready) {
-        if (options.profile > 0) { output_profile_information(*master_component); std::cerr << "===========================================\n"; }
+        if (options.profile > 0) {
+          output_profile_information(*master_component); std::cerr << "===========================================\n";
+        }
       }
     }
 
     score_helper.showScores(iter + 1, timer.elapsed_ms());
   }  // iter
 
-  if ((options.num_collection_passes > 0) || (options.time_limit > 0) || (options.score_level == 0 && !options.final_score.empty()))
+  if ((options.num_collection_passes > 0) ||
+      (options.time_limit > 0) ||
+      (options.score_level == 0 && !options.final_score.empty())) {
     final_score_helper.showScores();
+  }
 
   if (!options.save_model.empty()) {
     ProgressScope scope(std::string("Saving model to ") + options.save_model);
     ExportModelArgs export_model_args;
     export_model_args.set_model_name(pwt_model_name);
     export_model_args.set_file_name(options.save_model);
-    if (options.force) boost::filesystem::remove(options.save_model);
+    if (options.force) {
+      boost::filesystem::remove(options.save_model);
+    }
     master_component->ExportModel(export_model_args);
   }
 
@@ -1393,8 +1631,10 @@ int execute(const artm_options& options, int argc, char* argv[]) {
     GetDictionaryArgs get_dictionary_args;
     get_dictionary_args.set_dictionary_name(options.main_dictionary_name);
     DictionaryData dict = master_component->GetDictionary(get_dictionary_args);
-    if (dict.token_size() != dict.class_id_size())
+    if (dict.token_size() != dict.class_id_size()) {
       throw "internal error (DictionaryData.token_size() != DictionaryData->class_id_size())";
+    }
+
     CsvEscape escape(options.csv_separator.size() == 1 ? options.csv_separator[0] : '\0');
     std::ofstream output(options.write_dictionary_readable);
     const std::string sep = options.csv_separator;
@@ -1416,8 +1656,9 @@ int execute(const artm_options& options, int argc, char* argv[]) {
     CsvEscape escape(options.csv_separator.size() == 1 ? options.csv_separator[0] : '\0');
     ::artm::Matrix matrix;
     ::artm::TopicModel model = master_component->GetTopicModel(get_topic_model_args, &matrix);
-    if (matrix.no_columns() != model.num_topics())
+    if (matrix.no_columns() != model.num_topics()) {
       throw "internal error (matrix.no_columns() != theta->num_topics())";
+    }
 
     std::ofstream output(options.write_model_readable);
     const std::string sep = options.csv_separator;
@@ -1425,10 +1666,11 @@ int execute(const artm_options& options, int argc, char* argv[]) {
     // header
     output << "token" << sep << "class_id";
     for (int j = 0; j < model.num_topics(); ++j) {
-      if (model.topic_name_size() > 0)
+      if (model.topic_name_size() > 0) {
         output << sep << escape.apply(model.topic_name(j));
-      else
+      } else {
         output << sep << "topic" << j;
+      }
     }
     output << std::endl;
 
@@ -1448,24 +1690,29 @@ int execute(const artm_options& options, int argc, char* argv[]) {
 
     TransformMasterModelArgs transform_args;
     transform_args.set_theta_matrix_type(::artm::ThetaMatrixType_Dense);
-    if (!options.predict_class.empty())
+    if (!options.predict_class.empty()) {
       transform_args.set_predict_class_id(options.predict_class);
-    for (auto& batch_filename : batch_file_names)
+    }
+    for (const auto& batch_filename : batch_file_names) {
       transform_args.add_batch_filename(batch_filename.string());
+    }
 
     ::artm::Matrix theta_matrix;
     ThetaMatrix theta_metadata = master_component->Transform(transform_args, &theta_matrix);
     score_helper.showScores();
 
-    if (!options.write_predictions.empty())
+    if (!options.write_predictions.empty()) {
       WritePredictions(options, theta_metadata, theta_matrix);
+    }
 
-    if (!options.write_class_predictions.empty())
+    if (!options.write_class_predictions.empty()) {
       WriteClassPredictions(options, theta_metadata, theta_matrix);
+    }
   }
 
-  if (!options.write_vw_corpus.empty())
+  if (!options.write_vw_corpus.empty()) {
     WriteVwCorpus(options, batch_vectorizer.batch_folder());
+  }
 
   return 0;
 }
@@ -1574,8 +1821,9 @@ int main(int argc, char * argv[]) {
       getchar();
     }
 
-    if (options.num_collection_passes_depr > 0 && options.num_collection_passes == 0)
+    if (options.num_collection_passes_depr > 0 && options.num_collection_passes == 0) {
       options.num_collection_passes = options.num_collection_passes_depr;
+    }
 
     if (vm.count("response-file") && !options.response_file.empty()) {
       // Load the file and tokenize it
@@ -1618,8 +1866,9 @@ int main(int argc, char * argv[]) {
         options.read_uci_docword.empty() &&
         options.use_batches.empty() &&
         options.load_model.empty() &&
-        options.use_dictionary.empty())
+        options.use_dictionary.empty()) {
       show_help = true;
+    }
 
     if (show_help_regularizer) {
       std::cerr << "List of regularizers available in BigARTM CLI:\n\n";
@@ -1724,13 +1973,19 @@ int main(int argc, char * argv[]) {
 
     fixScoreLevel(&options);
     fixOptions(&options);
-    if (!verifyOptions(options))
+    if (!verifyOptions(options)) {
       return 1;  // verifyOptions should log an error upon failures
+    }
 
     if (vm.count("log-dir") || vm.count("log-level")) {
       ::artm::ConfigureLoggingArgs args;
-      if (vm.count("log-dir")) args.set_log_dir(options.log_dir);
-      if (vm.count("log-level")) args.set_minloglevel(options.log_level);
+      if (vm.count("log-dir")) {
+        args.set_log_dir(options.log_dir);
+      }
+
+      if (vm.count("log-level")) {
+        args.set_minloglevel(options.log_level);
+      }
       ::artm::ConfigureLogging(args);
     }
 
@@ -1740,12 +1995,15 @@ int main(int argc, char * argv[]) {
         throw std::invalid_argument("input file in VowpalWabbit format not specified");
         throw "input file in VowpalWabbit format not specified";
       }
-      if (options.read_uci_vocab.empty())
+      if (options.read_uci_vocab.empty()) {
         throw std::invalid_argument("input file in UCI vocab format not specified");
-      if (options.write_cooc_tf.empty() && !options.write_tf_ppmi.empty())
+      }
+      if (options.write_cooc_tf.empty() && !options.write_tf_ppmi.empty()) {
         throw std::invalid_argument("please specify name of cooc_tf file");
-      if (options.write_cooc_df.empty() && !options.write_df_ppmi.empty())
+      }
+      if (options.write_cooc_df.empty() && !options.write_df_ppmi.empty()) {
         throw std::invalid_argument("please specify name of cooc_df file");
+      }
 
       CooccurrenceDictionary cooc_dictionary(options.cooc_window,
           options.cooc_min_tf, options.cooc_min_df, options.read_uci_vocab,
@@ -1755,8 +2013,9 @@ int main(int argc, char * argv[]) {
       cooc_dictionary.FetchVocab();
       if (cooc_dictionary.VocabDictionarySize() > 1) {
         cooc_dictionary.ReadVowpalWabbit();
-        if (cooc_dictionary.CooccurrenceBatchQuantity() != 0)
+        if (cooc_dictionary.CooccurrenceBatchQuantity() != 0) {
           cooc_dictionary.ReadAndMergeCooccurrenceBatches();
+        }
       }
     }
 

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -37,7 +37,7 @@ using namespace artm;
 
 class CuckooWatch {
  public:
-  explicit CuckooWatch() : start_(std::chrono::system_clock::now()) {}
+  explicit CuckooWatch() : start_(std::chrono::system_clock::now()) { }
 
   long long elapsed_ms() const {
     auto delta = (std::chrono::system_clock::now() - start_);
@@ -79,7 +79,7 @@ class CsvEscape {
   char delimiter_;
 
  public:
-  explicit CsvEscape(char delimiter) : delimiter_(delimiter) {}
+  explicit CsvEscape(char delimiter) : delimiter_(delimiter) { }
 
   std::string apply(const std::string& in) {
     if (delimiter_ == '\0') {
@@ -166,7 +166,7 @@ std::vector<std::pair<std::string, T>> parseKeyValuePairs(const std::string& inp
     T single_value = boost::lexical_cast<T>(input);
     retval.push_back(std::make_pair(std::string(), single_value));
     return retval;
-  } catch (...) {}
+  } catch (...) { }
 
   // Handle the case when "input" is a set of "group:value" pairs, separated by ; or ,
   std::vector<std::string> strs;
@@ -772,7 +772,7 @@ class ScoreHelper {
          score_arg = boost::lexical_cast<float>(score_type.substr(langle + 1, rangle - langle - 1));
          score_type = score_type.substr(0, langle);
        }
-       catch (...) {}
+       catch (...) { }
      }
 
      ::artm::ScoreConfig& score_config = *config_->add_score_config();
@@ -1048,7 +1048,7 @@ class ScoreHelper {
      elapsed /= 60;
      int h = elapsed % 24;
      int days = elapsed / 24;
-     char buffer[128] = {};
+     char buffer[128] = { };
      sprintf(buffer, "%02d:%02d:%02d.%03d", h, m, s, ms);
      if (days > 0) {
        return std::to_string(days) + " days " + buffer;
@@ -1064,7 +1064,7 @@ class BatchVectorizer {
   std::string cleanup_folder_;
 
  public:
-  BatchVectorizer(const artm_options& options) : batch_folder_(), options_(options), cleanup_folder_() {}
+  BatchVectorizer(const artm_options& options) : batch_folder_(), options_(options), cleanup_folder_() { }
 
   void Vectorize() {
     const bool parse_vw_format = !options_.read_vw_corpus.empty();
@@ -1151,7 +1151,7 @@ class BatchVectorizer {
   ~BatchVectorizer() {
     if (options_.save_batches.empty() && !cleanup_folder_.empty()) {
       try { boost::filesystem::remove_all(cleanup_folder_); }
-      catch (...) {}
+      catch (...) { }
     }
   }
 

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -116,7 +116,7 @@ class ProgressScope {
   std::string newline_;
 };
 
-bool parseNumberOrPercent(std::string str, double* value, bool* fraction ) {
+bool parseNumberOrPercent(std::string str, float* value, bool* fraction ) {
   if (str.empty())
     return false;
 
@@ -129,7 +129,7 @@ bool parseNumberOrPercent(std::string str, double* value, bool* fraction ) {
   *value = 0;
   *fraction = true;
   try {
-    *value = boost::lexical_cast<double>(str);
+    *value = boost::lexical_cast<float>(str);
   }
   catch (...) {
     return false;
@@ -1199,7 +1199,7 @@ int execute(const artm_options& options, int argc, char* argv[]) {
       filter_dictionary_args.set_dictionary_name(options.main_dictionary_name);
       filter_dictionary_args.set_dictionary_target_name(options.main_dictionary_name);
       bool fraction;
-      double value;
+      float value;
       if (parseNumberOrPercent(options.dictionary_min_df, &value, &fraction))  {
         if (fraction) filter_dictionary_args.set_min_df_rate(value);
         else filter_dictionary_args.set_min_df(value);

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -219,8 +219,8 @@ std::vector<std::pair<std::string, std::vector<std::string>>> parseTopicGroups(c
 std::vector<std::string> parseTopics(const std::string& topics) {
   std::vector<std::string> result;
   std::vector<std::pair<std::string, std::vector<std::string>>> pairs = parseTopicGroups(topics);
-  for (auto& pair : pairs) {
-    for (auto& topic_name : pair.second) {
+  for (const auto& pair : pairs) {
+    for (const auto& topic_name : pair.second) {
       result.push_back(topic_name);
     }
   }
@@ -235,11 +235,11 @@ std::vector<std::string> parseTopics(const std::string& topics, const std::strin
   auto all_topics_set = std::set<std::string>(all_topics.begin(), all_topics.end());
   std::vector<std::pair<std::string, std::vector<std::string>>> pairs = parseTopicGroups(topic_groups);
   std::vector<std::string> topic_names = parseTopics(topics);
-  for (auto& topic_name : topic_names) {
+  for (const auto& topic_name : topic_names) {
     bool found = false;
-    for (auto& pair : pairs) {
+    for (const auto& pair : pairs) {
       if (pair.first == topic_name) {
-        for (auto& group_topic : pair.second) {
+        for (const auto& group_topic : pair.second) {
           result.push_back(group_topic);
 	}
         found = true;

--- a/utils/cpplint.py
+++ b/utils/cpplint.py
@@ -1707,6 +1707,10 @@ def CheckForHeaderGuard(filename, clean_lines, error):
   for linenum, line in enumerate(raw_lines):
     linesplit = line.split()
     if len(linesplit) >= 2:
+      # MelLain (great-mel@yandex.ru) fix to find #pragma once
+      if len(linesplit) == 2 and linesplit[0] == '#pragma' and linesplit[1] == "once":
+        return
+
       # find the first occurrence of #ifndef and #define, save arg
       if not ifndef and linesplit[0] == '#ifndef':
         # set ifndef to the header guard presented on the #ifndef line.
@@ -1721,7 +1725,7 @@ def CheckForHeaderGuard(filename, clean_lines, error):
 
   if not ifndef or not define or ifndef != define:
     error(filename, 0, 'build/header_guard', 5,
-          'No #ifndef header guard found, suggested CPP variable is: %s' %
+          'No #pragma once or #ifndef header guard found, suggested CPP variable is: %s' %
           cppvar)
     return
 


### PR DESCRIPTION
List of changes:

- all unnecessary doubles were replaced with floats
- everywhere if and for statements are using with brackets
- use const qualifiers for references in range based for
- replace guard headers with \#pragma once (update cpplint)
- some code decoration in regularizers and scores

According to these changes let's fix some codestyle rules:

1) use float as floating point type everywhere, where you can do it. Each usage of double type should have reasons (we don't use long instead of int everywhere, yes?)

2) each new header should have \#pragma once in the begining

3) Use const qualifier where it is possible, especially in range-based for

4) body of every if-for-while statement should be bordered with brackets { }, no matter the body contains one line or more.

5) Empty {} should be written with space (e.g. { })

6) we use Constructor() : param_(param) only in case of single parameter or short list of parameters with empty initialisation (: a_(), b_()). In other cases type

Constructor()
    : param_(param)
    , param2_(param2_)

the indention is 4 spaces before ":" and ","

7) Try to write 'f' suffix when using float numbers (e.g. 1.0f)
