### PR TITLE
Build standalone Python wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
 before_install:
   # we need latest pip to work with only-binary option
   - pip install -U pip
-  - pip install -U pytest pep8
+  - pip install -U pytest pep8 wheel
   - pip install -U numpy pandas tqdm --only-binary numpy pandas
   - pip install protobuf==3.0.0
   # configure ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,7 @@ option(BUILD_TESTS "Indicates whether to build artm_tests" ON)
 option(BUILD_BIGARTM_CLI "Indicates whether to build bigartm-CLI executable" ON)
 option(BUILD_INTERNAL_PYTHON_API "Indicates whether to build Python API" ON)
 
-if (MSVC OR APPLE)
 set(PYTHON python CACHE INTERNAL "Python command")
-else (MSVC OR APPLE)
-set(PYTHON python2 CACHE INTERNAL "Python command")
-endif (MSVC OR APPLE)
 
 if (BUILD_BIGARTM_CLI AND UNIX AND NOT APPLE)
   option(BUILD_BIGARTM_CLI_STATIC "Request build of static executable bigartm (for Linux only)" ON)

--- a/docs/installation/linux.txt
+++ b/docs/installation/linux.txt
@@ -27,19 +27,13 @@ Scroll further below for more OS-specific insructinos.
 
     # Step 1. Update and install dependencies
     apt-get --yes update
-    apt-get --yes install git
-    apt-get --yes install make
-    apt-get --yes install cmake
-    apt-get --yes install build-essential
-    apt-get --yes install libboost-all-dev
+    apt-get --yes install git make cmake build-essential libboost-all-dev
 
     # Step 2. Insall python packages
-    apt-get --yes install python-numpy
-    apt-get --yes install python-pandas
+    apt-get --yes install python-numpy python-pandas
     wget https://bootstrap.pypa.io/get-pip.py
     python get-pip.py
-    pip install protobuf
-    pip install tqdm
+    pip install protobuf tqdm wheel
 
     # Step 3. Clone repository and build
     git clone --branch=stable https://github.com/bigartm/bigartm.git
@@ -51,6 +45,9 @@ Scroll further below for more OS-specific insructinos.
     # Step 4. Install BigARTM
     make install
     export ARTM_SHARED_LIBRARY=/usr/local/lib/libartm.so
+    
+    # Alternative step 4 - installing only the Python package
+    pip install python/bigartm*.whl
 
 Now you should be able to use BigARTM command line utility (try ``bigartm --help``),
 or run BigARTM from python, like this: ``import artm; print(artm.version()); print(artm.ARTM(num_topics=10).info)``.
@@ -132,8 +129,8 @@ Then install required python packages:
 
 .. code-block:: bash
 
-   sudo pip2 install -U numpy pandas protobuf==3.0.0 tqdm # Python 2
-   sudo pip3 install -U numpy pandas protobuf==3.0.0 tqdm # Python 3
+   sudo pip2 install -U numpy pandas protobuf==3.0.0 tqdm wheel # Python 2
+   sudo pip3 install -U numpy pandas protobuf==3.0.0 tqdm wheel # Python 3
 
 Step 3. Build and install BigARTM library
 -----------------------------------------

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -13,6 +13,11 @@ if (BUILD_INTERNAL_PYTHON_API)
     COMMENT "Building python package bigartm"
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
   add_dependencies(python_bigartm_build protoc)
+  add_custom_target(python_bigartm_wheel ALL
+    ${CMAKE_COMMAND} -E env ARTM_SHARED_LIBRARY=$<TARGET_FILE:artm> ${PYTHON} setup.py bdist_wheel -d ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Building wheel bigartm"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+  add_dependencies(python_bigartm_wheel python_bigartm_build artm)
 
   if (MSVC)
     FILE(GLOB PYTHON_ARTM artm/*.py)
@@ -25,7 +30,7 @@ if (BUILD_INTERNAL_PYTHON_API)
   elseif (UNIX)
     install(CODE "message(\"Installing python package bigartm\")")
     install(CODE "execute_process(COMMAND ${PYTHON} setup.py install
-      WORKING_DIRECTORY \"${CMAKE_CURRENT_LIST_DIR}\")")
+                                  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})")
   endif (MSVC)
 endif (BUILD_INTERNAL_PYTHON_API)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Distribution
+from setuptools.command.build_py import build_py
 from distutils.spawn import find_executable
 
 # parse arguments
@@ -91,7 +92,47 @@ class build(_build):
         _build.run(self)
 
 
-setup(
+class AddLibraryBuild(build_py):
+    """
+    This hacky inheritor adds the shared library into the binary distribution.
+    We pretend that we generated our library and place it into the temporary
+    build directory.
+    """
+    def run(self):
+        if not self.dry_run:
+            self.copy_library()
+        build_py.run(self)
+
+    def get_outputs(self, *args, **kwargs):
+        outputs = build_py.get_outputs(*args, **kwargs)
+        outputs.extend(self._library_paths)
+        return outputs
+
+    def copy_library(self, builddir=None):
+        self._library_paths = []
+        library = os.getenv("ARTM_SHARED_LIBRARY", None)
+        if library is None:
+            return
+        destdir = os.path.join(self.build_lib, 'artm')
+        self.mkpath(destdir)
+        dest = os.path.join(destdir, os.path.basename(library))
+        shutil.copy(library, dest)
+        self._library_paths = [dest]
+
+
+class BinaryDistribution(Distribution):
+    """
+    This inheritor forces setuptools to include the "built" shared library into
+    the binary distribution.
+    """
+    def has_ext_modules(self):
+        return True
+        
+    def is_pure(self):
+        return False
+
+
+setup_kwargs = dict(
     name='bigartm',
     version='0.8.3',
     packages=find_packages(),
@@ -109,3 +150,11 @@ setup(
     ],
     cmdclass={'build': build},
 )
+
+if sys.argv[1] == "bdist_wheel":
+    # we only mess up with those hacks if we are building a wheel
+    setup_kwargs['distclass'] = BinaryDistribution
+    setup_kwargs['cmdclass']['build_py'] = AddLibraryBuild
+
+setup(**setup_kwargs)
+


### PR DESCRIPTION
I call "a standalone wheel" a package which does not require the libartm installation - aka "tensorflow style". Those wheels can be safely pushed on PyPi and will just work.

I had to change:

* `python/CMakeLists.txt`: add another custom target to execute ` setup.py bdist_wheel`
* `python/setup.py`: hack setuptools to include the needed shared library
* `python/artm/wrapper/api.py`: refactor `_load_cdll()` to load the library from several places - the common practice. The env variable is the most important, then the default relative path and finally the absolute path in the package root.
* docs - as far as I could

Besides, there seems to be a bug in TravisCI configuration regarding python command detection. There is no explicit `-DPYTHON` in the build script, and by default cmake chooses `python2` which prevents from testing py3.x:

```
if (MSVC OR APPLE)
set(PYTHON python CACHE INTERNAL "Python command")
else (MSVC OR APPLE)
set(PYTHON python2 CACHE INTERNAL "Python command")
endif (MSVC OR APPLE)
```

`bdist_wheel` command helped to find this bug: there is no `wheel` package installed in py2 env in Travis.
I dared to remove `python2` branch completely.