### PR TITLE
added clarification in docs and some preferences in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ datasets/docword.*.txt
 */ipch/*
 *.vcxproj.user
 
+# CLion garbage
+.idea/
+
 # Auto-generated files (by pdflatex)
 collateral/*.aux
 collateral/*.log
@@ -130,6 +133,7 @@ src/Win32/*
 docs/_build/*
 
 build*
+cmake-build-debug*
 
 # protobuf generated files
 /python/artm/wrapper/messages_pb2.py

--- a/docs/installation/linux.txt
+++ b/docs/installation/linux.txt
@@ -152,6 +152,12 @@ Example:
 
    cmake -DPYTHON=python3 -DCMAKE_INSTALL_PREFIX=/opt/bigartm ..
 
+By default you may run just:
+
+.. code-block:: bash
+
+   cmake ..
+
 Now build and install the library:
 
 .. code-block:: bash


### PR DESCRIPTION
The clarification's been done in order to help new users to install bigartm from sources easier (some people don't read documentation and just copy and paste commands from examples).