### PR TITLE
Update version of cmake in docs to 3.1, minor fixes

### DIFF
--- a/docs/devguide/dev_build_linux.txt
+++ b/docs/devguide/dev_build_linux.txt
@@ -10,7 +10,7 @@ System dependencies
 Building BigARTM requires the following components:
 
     * `git <https://git-scm.org>`_ (any recent version) -- for obtaining source code;
-    * `cmake <https://cmake.org>`_ (at least of version 2.8), *make*,
+    * `cmake <https://cmake.org>`_ (at least version 3.1), *make*,
       *g++* or *clang* compiler with c++11 support,
       `boost <boost.org>`_ (at least of version 1.40) --
       for building library and binary executable;

--- a/docs/devguide/dev_build_windows.txt
+++ b/docs/devguide/dev_build_windows.txt
@@ -13,7 +13,7 @@ The following steps describe the procedure to build BigARTM's C++ code on Window
   at `www.visualstudio.com <http://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx>`_).
 
 * Install `CMake <http://www.cmake.org/cmake/resources/software.html>`_
-  (tested with cmake-3.0.1, Win32 Installer).
+  (at least version 3.1, Win32 Installer).
 
   Make sure that CMake executable is added to the ``PATH`` environmental variable.
   To achieve this either select the option *"Add CMake to the system PATH for all users"*

--- a/docs/devguide/downloads.txt
+++ b/docs/devguide/downloads.txt
@@ -8,8 +8,8 @@ Download and install the following tools:
 * Github for Windows from https://windows.github.com/
     * https://github-windows.s3.amazonaws.com/GitHubSetup.exe
 * Visual Studio 2013 Express for Windows Desktop from https://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx
-* CMake from http://www.cmake.org/download/ 
-    * http://www.cmake.org/files/v3.0/cmake-3.0.2-win32-x86.exe
+* CMake from http://www.cmake.org/download/
+    * https://cmake.org/files/v3.10/cmake-3.10.0-win32-x86.msi
 * Prebuilt Boost binaries from http://sourceforge.net/projects/boost/files/boost-binaries/, for example these two:
     * http://sourceforge.net/projects/boost/files/boost-binaries/1.57.0/boost_1_57_0-msvc-12.0-32.exe/download
     * http://sourceforge.net/projects/boost/files/boost-binaries/1.57.0/boost_1_57_0-msvc-12.0-64.exe/download

--- a/docs/installation/linux.txt
+++ b/docs/installation/linux.txt
@@ -144,7 +144,9 @@ Next step is to run ``cmake``. The following options are available.
 
 * ``-DPYTHON=python3`` - to use Python 3 instead of Python 2;
 * ``-DCMAKE_INSTALL_PREFIX=xxx`` - for custom install location instead of default ``/usr/local``;
-* ``-DBoost_USE_STATIC_LIBS=ON`` — required on openSUSE.
+* ``-DBoost_USE_STATIC_LIBS=ON`` -- required on openSUSE;
+* ``-DBUILD_BIGARTM_CLI_STATIC=OFF`` -- to use shared versions of Boost, C and C++ libraries for ``bigartm`` executable.
+
 
 Example:
 


### PR DESCRIPTION
CMake config for python wheel (`python/CMakeLists.txt`) uses `cmake -E env` command which was implemented only in CMake 3.1 (https://github.com/Kitware/CMake/commit/7abd574798f9900abfe502f3941cffaa774062b1). So some distributives (at least Centos 7), which still use CMake 2.8 as default, produce a quite ambiguous error message. PR contains two updates for docs: an update version of CMake to 3.1 and a copy note about shared versions of libraries to the linux installation page also (shared libraries are installed by default in Centos 7 and Gentoo).