### PR TITLE
Tool to automatically convert plaintext into UCI Bag-of-words

### DIFF
--- a/utils/text_to_bow.py
+++ b/utils/text_to_bow.py
@@ -6,8 +6,10 @@ from __future__ import print_function
 
 import argparse
 import os
+import re
+from collections import Counter
 
-from sklearn.feature_extraction.text import CountVectorizer
+from six import iteritems
 
 
 def main(args):
@@ -19,22 +21,17 @@ def main(args):
   with open(args.fname, 'r')as file:
     rawdata = file.read().replace('\n', '')
 
-  # instantiate the parser and feed it some HTML
-  vectorizer = CountVectorizer()
-
-  x = vectorizer.fit_transform([rawdata])
-
-  vocabulary = vectorizer.get_feature_names()
-  count_vector = x.toarray()
+  bagofwords = Counter(re.findall(r'\w+', rawdata.lower()))
+  vocabulary = sorted(bagofwords.keys())
 
   # Initialize Bag-of-words data
   bow = [
     str(1),  # D - Number of documents
-    str(len(vocabulary)),  # W - Number of words in vocabulary
-    str(count_vector.sum()),  # NNZ - Number of words in documents
+    str(len(bagofwords)),  # W - Number of words in vocabulary
+    str(sum(bagofwords.values())),  # NNZ - Number of words in documents
     ]
 
-  for word, count in zip(vocabulary, count_vector.squeeze()):
+  for word, count in iteritems(bagofwords):
     bow.append('{} {} {}'.format(1, 1 + vocabulary.index(word), count))
 
   # Save docfile and vocabulary

--- a/utils/text_to_bow.py
+++ b/utils/text_to_bow.py
@@ -1,0 +1,60 @@
+# Convert plaintext into UCI Bag-of-words
+#
+# Created by Albert Aparicio <aaparicio@posteo.net>
+
+from __future__ import print_function
+
+import argparse
+import os
+
+from sklearn.feature_extraction.text import CountVectorizer
+
+
+def main(args):
+  file_dir = os.path.dirname(args.fname)
+
+  basename, ext = os.path.splitext(os.path.basename(args.fname))
+
+  # Read text file
+  with open(args.fname, 'r')as file:
+    rawdata = file.read().replace('\n', '')
+
+  # instantiate the parser and feed it some HTML
+  vectorizer = CountVectorizer()
+
+  x = vectorizer.fit_transform([rawdata])
+
+  vocabulary = vectorizer.get_feature_names()
+  count_vector = x.toarray()
+
+  # Initialize Bag-of-words data
+  bow = [
+    str(1),  # D - Number of documents
+    str(len(vocabulary)),  # W - Number of words in vocabulary
+    str(count_vector.sum()),  # NNZ - Number of words in documents
+    ]
+
+  for word, count in zip(vocabulary, count_vector.squeeze()):
+    bow.append('{} {} {}'.format(1, 1 + vocabulary.index(word), count))
+
+  # Save docfile and vocabulary
+  with open(os.path.join(file_dir, 'docword.{}.txt'.format(basename)), 'w') as docf:
+    docf.writelines('\n'.join(bow))
+
+  with open(os.path.join(file_dir, 'vocab.{}.txt'.format(basename)), 'w') as vocabf:
+    vocabf.writelines('\n'.join(vocabulary))
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(
+      description='Convert plaintext to UCI Bag-of-words')
+  parser.add_argument('-f', '--fname', type=str, required=True,
+                      help='Filename of the data to convert')
+
+  opts = parser.parse_args()
+
+  print('Arguments parsed')
+
+  main(opts)
+
+  exit()


### PR DESCRIPTION
I have been using BigARTM for a couple of days now, and one of the greatest dificulties I have had with it is that there is no easy way to convert a piece of plain text into Bag-of-words or Vowpal Wabbit.

Since I needed it, I made this little tool, which converts any plaintext into BOW. I am sharing it with the community hoping that someone will find it useful.

It can be run from the command-line. It requires a filename of a file with plaintext in it, and it outputs the `docfile.*` and `vocab.*` files right next to the input file.

Cheers!