### PR TITLE
Use BIGARTM_UNITTEST_DATA env in cpp tests

### DIFF
--- a/src/artm_tests/collection_parser_test.cc
+++ b/src/artm_tests/collection_parser_test.cc
@@ -177,7 +177,8 @@ TEST(CollectionParser, Multiclass) {
   artm::GatherDictionaryArgs gather_args;
   gather_args.set_data_path(target_folder);
   gather_args.set_dictionary_target_name(dictionary_name);
-  gather_args.set_vocab_file_path((::artm::test::Helpers::getTestDataDir() / "vocab.parser_test_multiclass.txt").string());
+  gather_args.set_vocab_file_path((::artm::test::Helpers::getTestDataDir() /
+                                   "vocab.parser_test_multiclass.txt").string());
 
   ::artm::MasterModelConfig master_config;
   artm::MasterModel master(master_config);

--- a/src/artm_tests/collection_parser_test.cc
+++ b/src/artm_tests/collection_parser_test.cc
@@ -22,8 +22,8 @@ TEST(CollectionParser, UciBagOfWords) {
   config.set_format(::artm::CollectionParserConfig_CollectionFormat_BagOfWordsUci);
   config.set_target_folder(target_folder);
   config.set_num_items_per_batch(1);
-  config.set_vocab_file_path("../../../test_data/vocab.parser_test.txt");
-  config.set_docword_file_path("../../../test_data/docword.parser_test.txt");
+  config.set_vocab_file_path((::artm::test::Helpers::getTestDataDir() / "vocab.parser_test.txt").string());
+  config.set_docword_file_path((::artm::test::Helpers::getTestDataDir() / "docword.parser_test.txt").string());
 
   ::artm::ParseCollection(config);
 
@@ -87,7 +87,8 @@ TEST(CollectionParser, UciBagOfWords) {
   };
 
   dictionary_checker(config.vocab_file_path(), "default_dictionary");
-  dictionary_checker("../../../test_data/vocab.parser_test_no_newline.txt", "no_newline_dictionary");
+  dictionary_checker((::artm::test::Helpers::getTestDataDir() / "vocab.parser_test_no_newline.txt").string(),
+                     "no_newline_dictionary");
 
   try { fs::remove_all(target_folder); }
   catch (...) { }
@@ -97,16 +98,16 @@ TEST(CollectionParser, ErrorHandling) {
   ::artm::CollectionParserConfig config;
   config.set_format(::artm::CollectionParserConfig_CollectionFormat_BagOfWordsUci);
 
-  config.set_vocab_file_path("../../../test_data/vocab.parser_test_non_unique.txt");
-  config.set_docword_file_path("../../../test_data/docword.parser_test.txt");
+  config.set_vocab_file_path((::artm::test::Helpers::getTestDataDir() / "vocab.parser_test_non_unique.txt").string());
+  config.set_docword_file_path((::artm::test::Helpers::getTestDataDir() / "docword.parser_test.txt").string());
   ASSERT_THROW(::artm::ParseCollection(config), artm::InvalidOperationException);
 
-  config.set_vocab_file_path("../../../test_data/vocab.parser_test_empty_line.txt");
-  config.set_docword_file_path("../../../test_data/docword.parser_test.txt");
+  config.set_vocab_file_path((::artm::test::Helpers::getTestDataDir() / "vocab.parser_test_empty_line.txt").string());
+  config.set_docword_file_path((::artm::test::Helpers::getTestDataDir() / "docword.parser_test.txt").string());
   ASSERT_THROW(::artm::ParseCollection(config), artm::InvalidOperationException);
 
   config.set_vocab_file_path("no_such_file.txt");
-  config.set_docword_file_path("../../../test_data/docword.parser_test.txt");
+  config.set_docword_file_path((::artm::test::Helpers::getTestDataDir() / "docword.parser_test.txt").string());
   ASSERT_THROW(::artm::ParseCollection(config), artm::DiskReadException);
 }
 
@@ -117,8 +118,8 @@ TEST(CollectionParser, MatrixMarket) {
   config.set_format(::artm::CollectionParserConfig_CollectionFormat_MatrixMarket);
   config.set_target_folder(target_folder);
   config.set_num_items_per_batch(10000);
-  config.set_vocab_file_path("../../../test_data/deerwestere.txt");
-  config.set_docword_file_path("../../../test_data/deerwestere.mm");
+  config.set_vocab_file_path((::artm::test::Helpers::getTestDataDir() / "deerwestere.txt").string());
+  config.set_docword_file_path((::artm::test::Helpers::getTestDataDir() / "deerwestere.mm").string());
 
   ::artm::ParseCollection(config);
 
@@ -148,8 +149,8 @@ TEST(CollectionParser, Multiclass) {
   ::artm::CollectionParserConfig config;
   config.set_format(::artm::CollectionParserConfig_CollectionFormat_BagOfWordsUci);
   config.set_target_folder(target_folder);
-  config.set_vocab_file_path("../../../test_data/vocab.parser_test_multiclass.txt");
-  config.set_docword_file_path("../../../test_data/docword.parser_test.txt");
+  config.set_vocab_file_path((::artm::test::Helpers::getTestDataDir() / "vocab.parser_test_multiclass.txt").string());
+  config.set_docword_file_path((::artm::test::Helpers::getTestDataDir() / "docword.parser_test.txt").string());
 
   ::artm::ParseCollection(config);
 
@@ -176,7 +177,7 @@ TEST(CollectionParser, Multiclass) {
   artm::GatherDictionaryArgs gather_args;
   gather_args.set_data_path(target_folder);
   gather_args.set_dictionary_target_name(dictionary_name);
-  gather_args.set_vocab_file_path("../../../test_data/vocab.parser_test_multiclass.txt");
+  gather_args.set_vocab_file_path((::artm::test::Helpers::getTestDataDir() / "vocab.parser_test_multiclass.txt").string());
 
   ::artm::MasterModelConfig master_config;
   artm::MasterModel master(master_config);
@@ -223,7 +224,7 @@ TEST(CollectionParser, VowpalWabbit) {
   ::artm::CollectionParserConfig config;
   config.set_format(::artm::CollectionParserConfig_CollectionFormat_VowpalWabbit);
   config.set_target_folder(target_folder);
-  config.set_docword_file_path("../../../test_data/vw_data.txt");
+  config.set_docword_file_path((::artm::test::Helpers::getTestDataDir() / "vw_data.txt").string());
   config.set_num_items_per_batch(1);
 
   ::artm::ParseCollection(config);
@@ -264,7 +265,7 @@ TEST(CollectionParser, TransactionVowpalWabbit) {
   ::artm::CollectionParserConfig config;
   config.set_format(::artm::CollectionParserConfig_CollectionFormat_VowpalWabbit);
   config.set_target_folder(target_folder);
-  config.set_docword_file_path("../../../test_data/vw_transaction_data.txt");
+  config.set_docword_file_path((::artm::test::Helpers::getTestDataDir() / "vw_transaction_data.txt").string());
   config.set_num_items_per_batch(2);
 
   ::artm::ParseCollection(config);

--- a/src/artm_tests/cpp_interface_test.cc
+++ b/src/artm_tests/cpp_interface_test.cc
@@ -838,7 +838,7 @@ TEST(CppInterface, TransactionDictionaries) {
   ::artm::CollectionParserConfig config;
   config.set_format(::artm::CollectionParserConfig_CollectionFormat_VowpalWabbit);
   config.set_target_folder(target_folder);
-  config.set_docword_file_path("../../../test_data/vw_transaction_data_extended.txt");
+  config.set_docword_file_path((::artm::test::Helpers ::getTestDataDir() / "vw_transaction_data_extended.txt").string());
   config.set_num_items_per_batch(2);
 
   ::artm::ParseCollection(config);

--- a/src/artm_tests/cpp_interface_test.cc
+++ b/src/artm_tests/cpp_interface_test.cc
@@ -838,7 +838,8 @@ TEST(CppInterface, TransactionDictionaries) {
   ::artm::CollectionParserConfig config;
   config.set_format(::artm::CollectionParserConfig_CollectionFormat_VowpalWabbit);
   config.set_target_folder(target_folder);
-  config.set_docword_file_path((::artm::test::Helpers ::getTestDataDir() / "vw_transaction_data_extended.txt").string());
+  config.set_docword_file_path((::artm::test::Helpers ::getTestDataDir() /
+                                "vw_transaction_data_extended.txt").string());
   config.set_num_items_per_batch(2);
 
   ::artm::ParseCollection(config);

--- a/src/artm_tests/test_mother.cc
+++ b/src/artm_tests/test_mother.cc
@@ -2,6 +2,7 @@
 
 #include "artm_tests/test_mother.h"
 
+#include <cstdlib>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -11,6 +12,8 @@
 
 namespace artm {
 namespace test {
+
+namespace fs = boost::filesystem;
 
 artm::Batch Helpers::GenerateBatch(int nTokens, int nDocs, std::string class1, std::string class2) {
   artm::Batch batch;
@@ -210,6 +213,14 @@ void Helpers::CompareThetaMatrices(const ::artm::ThetaMatrix& tm1, const ::artm:
     }
   }
   *ok = true;
+}
+
+fs::path Helpers::getTestDataDir() {
+  auto dir = std::getenv("BIGARTM_UNITTEST_DATA");
+  // Construct path object only once.
+  // Since C++11 local static variable initialization is thread-safe.
+  static const fs::path testDataDir = dir != nullptr ? fs::path(dir) : fs::path("../../../test_data");
+  return testDataDir;
 }
 
 void TestMother::GenerateBatches(int batches_size, int nTokens, const std::string& target_folder) {

--- a/src/artm_tests/test_mother.h
+++ b/src/artm_tests/test_mother.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "boost/filesystem/path.hpp"
 #include "boost/lexical_cast.hpp"
 #include "boost/uuid/uuid.hpp"
 #include "boost/uuid/uuid_generators.hpp"
@@ -33,6 +34,7 @@ class Helpers {
   static void ConfigurePerplexityScore(std::string score_name,
                                        artm::MasterModelConfig* master_config,
                                        std::vector<std::string> class_ids = { });
+  static boost::filesystem::path getTestDataDir();
 };
 
 class TestMother {

--- a/src/artm_tests/transactions_test.cc
+++ b/src/artm_tests/transactions_test.cc
@@ -35,7 +35,7 @@ TEST(Transactions, BasicTest) {
   ::artm::CollectionParserConfig config;
   config.set_format(::artm::CollectionParserConfig_CollectionFormat_VowpalWabbit);
   config.set_target_folder(target_folder);
-  config.set_docword_file_path("../../../test_data/vw_transaction_data_extended.txt");
+  config.set_docword_file_path((::artm::test::Helpers ::getTestDataDir() / "vw_transaction_data_extended.txt").string());
   config.set_num_items_per_batch(10);
 
   ::artm::ParseCollection(config);

--- a/src/artm_tests/transactions_test.cc
+++ b/src/artm_tests/transactions_test.cc
@@ -35,7 +35,8 @@ TEST(Transactions, BasicTest) {
   ::artm::CollectionParserConfig config;
   config.set_format(::artm::CollectionParserConfig_CollectionFormat_VowpalWabbit);
   config.set_target_folder(target_folder);
-  config.set_docword_file_path((::artm::test::Helpers ::getTestDataDir() / "vw_transaction_data_extended.txt").string());
+  config.set_docword_file_path((::artm::test::Helpers ::getTestDataDir() /
+                                "vw_transaction_data_extended.txt").string());
   config.set_num_items_per_batch(10);
 
   ::artm::ParseCollection(config);


### PR DESCRIPTION
Currently cpp tests use hardcoded (*nix-like) paths to files with test data.
This PR proposes consideration of BIGARTM_UNITTEST_DATA env variable in  thread-safe and cross-platform manner.