### PR TITLE
Support MinGW on appveyor

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -23,6 +23,13 @@ set(gflags_NAMESPACE "gflags")
 set(gflags_FOUND "ON")
 get_target_property(gflags_INCLUDE_DIR gflags INTERFACE_INCLUDE_DIRECTORIES)
 get_target_property(gflags_LIBRARIES gflags INTERFACE_LINK_LIBRARIES)
+if (NOT gflags_LIBRARIES)
+    # INTERFACE_LINK_LIBRARIES can legitimately be empty, but cmake sets them
+    # as NOTFOUND
+    # This happens e.g. on Alpine Linux
+    set(gflags_LIBRARIES "")
+endif ()
+
 set(gflags_LIBRARIES $<TARGET_FILE:gflags> ${gflags_LIBRARIES})
 
 add_subdirectory(glog EXCLUDE_FROM_ALL)

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -35,3 +35,9 @@ set(CMAKE_SKIP_INSTALL_RULES FALSE)
 set(CMAKE_INSTALL_INCLUDEDIR include/artm)
 add_subdirectory(protobuf-3.0.0/cmake EXCLUDE_FROM_ALL)
 set(PROTOBUF_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/protobuf-3.0.0/cmake CACHE "" INTERNAL)
+
+# This is a hack. We build libprotobuf (a STATIC library) with __dllexport
+# so that when we later link it into SHARED library artm.dll all protobuf
+# symbols would get exported and cause no linking errors when using the
+# library
+target_compile_definitions(libprotobuf PRIVATE PROTOBUF_USE_DLLS LIBPROTOBUF_EXPORTS)

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -8,35 +8,29 @@ else (MSVC)
   add_definitions("-w")
 endif (MSVC)
 
+# Disable tests and install rules for glog
+# Enabled install rules will cause configuration failure
 set(BUILD_TESTING "OFF" CACHE "" INTERNAL)
+set(CMAKE_SKIP_INSTALL_RULES TRUE)
 
 add_subdirectory(gflags EXCLUDE_FROM_ALL)
 
-# Do not call find_package for gflags and fill all relevant info manually
-# We cannot make glog link to gflags __target__, because cmake would try to
-# pull it into glog's export set and will get confused and fail
-# Instead we manually specify location and include path for gflags, this way
-# cmake does not create inter-target dependency and export set does not fail
+# Do not call find_package for gflags and pretend it exists
 set(WITH_GFLAGS "OFF" CACHE "" INTERNAL)
 set(HAVE_LIB_GFLAGS "ON")
 set(gflags_NAMESPACE "gflags")
 set(gflags_FOUND "ON")
-get_target_property(gflags_INCLUDE_DIR gflags INTERFACE_INCLUDE_DIRECTORIES)
-get_target_property(gflags_LIBRARIES gflags INTERFACE_LINK_LIBRARIES)
-if (NOT gflags_LIBRARIES)
-    # INTERFACE_LINK_LIBRARIES can legitimately be empty, but cmake sets them
-    # as NOTFOUND
-    # This happens e.g. on Alpine Linux
-    set(gflags_LIBRARIES "")
-endif ()
 
-set(gflags_LIBRARIES $<TARGET_FILE:gflags> ${gflags_LIBRARIES})
+# Make glog link to gflags target directly, cmake will handle the rest
+set(gflags_LIBRARIES gflags)
 
 add_subdirectory(glog EXCLUDE_FROM_ALL)
 
 # We need to ask CMake to compile gflags before compiling glog, so that
 # ${gflags_LIBRARIES} actually exists
 add_dependencies(glog gflags)
+
+set(CMAKE_SKIP_INSTALL_RULES FALSE)
 
 set(CMAKE_INSTALL_INCLUDEDIR include/artm)
 add_subdirectory(protobuf-3.0.0/cmake EXCLUDE_FROM_ALL)

--- a/3rdparty/protobuf-3.0.0/cmake/CMakeLists.txt
+++ b/3rdparty/protobuf-3.0.0/cmake/CMakeLists.txt
@@ -155,9 +155,9 @@ if (protobuf_BUILD_TESTS)
   include(tests.cmake)
 endif (protobuf_BUILD_TESTS)
 
-if (NOT MSVC)
+#if (NOT MSVC)
   include(install.cmake)
-endif()
+#endif()
 
 if (protobuf_BUILD_EXAMPLES)
   include(examples.cmake)

--- a/3rdparty/protobuf-3.0.0/src/google/protobuf/stubs/port.h
+++ b/3rdparty/protobuf-3.0.0/src/google/protobuf/stubs/port.h
@@ -66,7 +66,7 @@
     #define PROTOBUF_LITTLE_ENDIAN 1
   #endif
 #endif
-#if defined(_MSC_VER) && defined(PROTOBUF_USE_DLLS)
+#if defined(WIN32) && defined(PROTOBUF_USE_DLLS)
   #ifdef LIBPROTOBUF_EXPORTS
     #define LIBPROTOBUF_EXPORT __declspec(dllexport)
   #else

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,12 @@ find_package(Boost COMPONENTS REQUIRED ${BIGARTM_BOOST_COMPONENTS})
 if (NOT Boost_FOUND)
   message(SEND_ERROR "Failed to find required boost libraries.")
   return()
-else (NOT Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
 endif (NOT Boost_FOUND)
+
+set(BOOST_IMPORTED_TARGETS Boost::boost)
+foreach(boost_component ${BIGARTM_BOOST_COMPONENTS})
+    list(APPEND BOOST_IMPORTED_TARGETS Boost::${boost_component})
+endforeach(boost_component)
 
 add_subdirectory(3rdparty)  # gflags must be compiled without -std=c++11
 

--- a/appveyor-mingw.yml
+++ b/appveyor-mingw.yml
@@ -1,0 +1,73 @@
+version: "{build}"
+
+image: Visual Studio 2017
+
+platform:
+    - x64
+
+environment:
+    global:
+        BIGARTM_UNITTEST_DATA: C:\projects\bigartm\test_data
+        INSTALL_FOLDER: '"C:\Program Files\BigARTM"'
+        PROTOC: C:\projects\bigartm\build\bin\protoc.exe
+        ARTM_SHARED_LIBRARY: C:\projects\bigartm\build\bin\artm.dll
+
+    matrix:
+        - PYTHON_VERSION: 3.6
+          MINICONDA: C:\Miniconda36-x64
+
+        - PYTHON_VERSION: 2.7
+          MINICONDA: C:\Miniconda-x64
+
+cache:
+    # Cache MSYS2 packages to speed up builds. If version in repo changes, pacman will update it
+    - c:\msys64\mingw64
+    - c:\msys64\var\lib\pacman
+    - C:\Miniconda36-x64\Lib\site-packages
+    - C:\Miniconda-x64\Lib\site-packages
+
+install:
+    - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;C:\\msys64\\mingw64\\bin;%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\
+"
+    - c:\msys64\usr\bin\pacman -S --noconfirm --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-make
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q -c conda-forge conda
+    - conda info -a
+    - conda install -c conda-forge numpy scipy pandas pytest
+    - conda install -c conda-forge tqdm
+
+before_build:
+    - cmd: cd C:\projects\bigartm
+    - cmd: md build
+    - cmd: cd build
+    - cmd: cmake -DPYTHON="%MINICONDA%\\python.exe" -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=%configuration% ..
+    - cmd: cd %BIGARTM_UNITTEST_DATA%
+    - ps: Start-FileDownload 'https://s3-eu-west-1.amazonaws.com/artm/docword.kos.txt'
+    - ps: Start-FileDownload 'https://s3-eu-west-1.amazonaws.com/artm/vocab.kos.txt'
+
+build_script:
+    - cmd: cd C:\projects\bigartm\build
+    - cmd: mingw32-make VERBOSE=1 -j4
+    - cmd: mingw32-make VERBOSE=1 install
+
+after_build:
+    - cmd: cd C:\projects\bigartm\3rdparty\protobuf-3.0.0\python
+    - cmd: python setup.py install
+    - cmd: cd C:\projects\bigartm\python
+    - cmd: python setup.py install
+    #- cmd: call C:\projects\bigartm\utils\create_windows_package.bat
+
+test_script:
+    - cmd: cd C:\projects\bigartm\build\
+    - ps: |
+        & mingw32-make VERBOSE=1 ARGS=-V test
+        $testCode = $lastExitCode
+
+        $wc = New-Object 'System.Net.WebClient'
+        $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\src\artm_tests\junit.xml))
+        $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\python\tests\artm\junit.xml))
+        $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\python\tests\wrapper\junit.xml))
+
+        if ($testCode -ne 0) {
+            exit $testCode
+        }

--- a/appveyor-mingw.yml
+++ b/appveyor-mingw.yml
@@ -2,6 +2,9 @@ version: "{build}"
 
 image: Visual Studio 2017
 
+configuration:
+    - Release
+
 platform:
     - x64
 
@@ -27,9 +30,11 @@ cache:
     - C:\Miniconda-x64\Lib\site-packages
 
 install:
-    - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;C:\\msys64\\mingw64\\bin;%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\
+    - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;C:\\msys64\\mingw64\\bin;C:\\Program Files\\7-Zip;%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\
 "
-    - c:\msys64\usr\bin\pacman -S --noconfirm --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-make
+    - c:\msys64\usr\bin\pacman -Sy --noconfirm
+    - c:\msys64\usr\bin\pacman -S --noconfirm --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-make
+    - c:\msys64\usr\bin\pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-boost-1.64.0-3-any.pkg.tar.xz
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q -c conda-forge conda
     - conda info -a
@@ -55,7 +60,7 @@ after_build:
     - cmd: python setup.py install
     - cmd: cd C:\projects\bigartm\python
     - cmd: python setup.py install
-    #- cmd: call C:\projects\bigartm\utils\create_windows_package.bat
+    - cmd: 7z.exe a C:\projects\bigartm\BigARTM-MinGW.7z "C:\\Program Files (x86)\\BigARTM"
 
 test_script:
     - cmd: cd C:\projects\bigartm\build\
@@ -71,3 +76,10 @@ test_script:
         if ($testCode -ne 0) {
             exit $testCode
         }
+
+#on_finish:
+    #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+artifacts:
+    - path: BigARTM-MinGW.7z
+      name: BigARTM-MinGW

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,10 +74,6 @@ after_build:
   - cmd: call C:\projects\bigartm\utils\create_windows_package.bat
 
 test_script:
-  - cmd: cd C:\projects\bigartm\build\bin\Release
-  - cmd: artm_tests.exe
-  - cmd: cd C:\projects\bigartm\python\tests
-  - cmd: py.test
   - ps: |
         cd C:\projects\bigartm\build
         & msbuild .\RUN_TESTS.vcxproj

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,6 +78,19 @@ test_script:
   - cmd: artm_tests.exe
   - cmd: cd C:\projects\bigartm\python\tests
   - cmd: py.test
+  - ps: |
+        cd C:\projects\bigartm\build
+        & msbuild .\RUN_TESTS.vcxproj
+        $testCode = $lastExitCode
+
+        $wc = New-Object 'System.Net.WebClient'
+        $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\src\artm_tests\junit.xml))
+        $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\python\tests\artm\junit.xml))
+        $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\python\tests\wrapper\junit.xml))
+
+        if ($testCode -ne 0) {
+            exit $testCode
+        }
 
 artifacts:
   - path: BigARTM.7z

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -26,6 +26,8 @@ if (BUILD_INTERNAL_PYTHON_API)
     install(FILES ${PYTHON_ARTM} DESTINATION python/artm)
     FILE(GLOB PYTHON_ARTM artm/wrapper/*.py)
     install(FILES ${PYTHON_ARTM} DESTINATION python/artm/wrapper)
+    # This file is generated, therefore needs to be specified without *
+    install(FILES artm/wrapper/messages_pb2.py DESTINATION python/artm/wrapper)
     FILE(GLOB PYTHON_EXAMPLES tests/wrapper/*.py)
     install(FILES ${PYTHON_EXAMPLES} DESTINATION python/tests/wrapper)
     install(FILES setup.py DESTINATION python)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -21,7 +21,7 @@ if (BUILD_INTERNAL_PYTHON_API)
 
   option(INSTALL_PYTHON_PACKAGE "Install python package as well during make install stage" OFF)
 
-  if (MSVC)
+  if (WIN32)
     FILE(GLOB PYTHON_ARTM artm/*.py)
     install(FILES ${PYTHON_ARTM} DESTINATION python/artm)
     FILE(GLOB PYTHON_ARTM artm/wrapper/*.py)
@@ -35,6 +35,6 @@ if (BUILD_INTERNAL_PYTHON_API)
       install(CODE "execute_process(COMMAND ${PYTHON} setup.py install
                                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})")
     endif (INSTALL_PYTHON_PACKAGE)
-  endif (MSVC)
+  endif (WIN32)
 endif (BUILD_INTERNAL_PYTHON_API)
 

--- a/python/tests/artm/CMakeLists.txt
+++ b/python/tests/artm/CMakeLists.txt
@@ -1,1 +1,6 @@
-add_test(NAME python_artm_tests COMMAND py.test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME python_artm_tests
+    COMMAND py.test --junit-xml=${CMAKE_CURRENT_BINARY_DIR}/junit.xml
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_tests_properties(python_artm_tests PROPERTIES
+    ENVIRONMENT "ARTM_SHARED_LIBRARY=$<TARGET_FILE:artm>")

--- a/python/tests/wrapper/CMakeLists.txt
+++ b/python/tests/wrapper/CMakeLists.txt
@@ -1,1 +1,6 @@
-add_test(NAME python_wrapper_tests COMMAND py.test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME python_wrapper_tests
+    COMMAND py.test --junit-xml=${CMAKE_CURRENT_BINARY_DIR}/junit.xml
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_tests_properties(python_wrapper_tests PROPERTIES
+    ENVIRONMENT "ARTM_SHARED_LIBRARY=$<TARGET_FILE:artm>")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,8 +5,6 @@ find_package(ProtobufPlugin REQUIRED)
 if (NOT PROTOBUF_FOUND)
   message(SEND_ERROR "Failed to find protobuf.")
   return()
-else (NOT PROTOBUF_FOUND)
-  include_directories(${PROTOBUF_INCLUDE_DIRS})
 endif (NOT PROTOBUF_FOUND)
 
 add_subdirectory(artm)

--- a/src/artm/CMakeLists.txt
+++ b/src/artm/CMakeLists.txt
@@ -252,6 +252,11 @@ source_group("" FILES ${SRC_LIST})
 add_library(artm SHARED ${SRC_LIST}
     ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 
+# Make protobuf export symbols from our shared library
+target_compile_definitions(artm
+    PUBLIC PROTOBUF_USE_DLLS
+    PRIVATE LIBPROTOBUF_EXPORTS)
+
 if (WIN32)
     set_target_properties(artm PROPERTIES PREFIX "")
 endif (WIN32)

--- a/src/artm/CMakeLists.txt
+++ b/src/artm/CMakeLists.txt
@@ -72,8 +72,8 @@ add_library(internals_proto STATIC EXCLUDE_FROM_ALL
     core/internals.pb.h)
 add_dependencies(internals_proto proto_generation)
 
-target_link_libraries(internals_proto ${PROTOBUF_LIBRARIES})
-target_link_libraries(messages_proto ${PROTOBUF_LIBRARIES})
+target_link_libraries(internals_proto libprotobuf)
+target_link_libraries(messages_proto libprotobuf)
 target_compile_definitions(messages_proto PRIVATE ARTM_STATIC_DEFINE)
 if (MSVC)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/messages.pb.cc
@@ -225,7 +225,10 @@ source_group("utility"             FILES ${SRC_LIST_UTILITY}             )
 source_group(""                    FILES ${SRC_LIST_OTHER}               )
 
 add_library(artm-static STATIC ${SRC_LIST})
-target_link_libraries(artm-static messages_proto internals_proto glog ${Boost_LIBRARIES})
+target_link_libraries(artm-static
+    messages_proto internals_proto
+    glog ${BOOST_IMPORTED_TARGETS}
+    )
 add_dependencies(artm-static messages_proto internals_proto)
 target_compile_definitions(artm-static PRIVATE ARTM_STATIC_DEFINE)
 
@@ -259,11 +262,8 @@ endif (WIN32)
 target_link_libraries(artm PRIVATE artm-static)
 target_include_directories(artm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
 target_include_directories(artm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
-# Support compiling with bundled protobuf headers from build-tree and from
-# installed package
-target_include_directories(artm PUBLIC
-    $<BUILD_INTERFACE:${PROTOBUF_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:include/artm>)
+# Support compiling with bundled protobuf headers from build-tree
+target_include_directories(artm PUBLIC $<BUILD_INTERFACE:${PROTOBUF_INCLUDE_DIR}>)
 
 include(GenerateExportHeader)
 generate_export_header(artm
@@ -272,7 +272,7 @@ generate_export_header(artm
 install(TARGETS artm EXPORT artm
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
-    INCLUDES DESTINATION include
+    INCLUDES DESTINATION include/artm
     )
 install(FILES
     c_interface.h

--- a/src/artm/CMakeLists.txt
+++ b/src/artm/CMakeLists.txt
@@ -249,6 +249,10 @@ source_group("" FILES ${SRC_LIST})
 add_library(artm SHARED ${SRC_LIST}
     ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 
+if (WIN32)
+    set_target_properties(artm PROPERTIES PREFIX "")
+endif (WIN32)
+
 # Using PRIVATE here so that consumers of the library do not link explicitly
 # to boost, etc. This should be handled by the linker via DT_NEEDED or similar
 # But we have to repeat include dir here for artm_export.h

--- a/src/artm/CMakeLists.txt
+++ b/src/artm/CMakeLists.txt
@@ -226,15 +226,14 @@ source_group(""                    FILES ${SRC_LIST_OTHER}               )
 
 add_library(artm-static STATIC ${SRC_LIST})
 target_link_libraries(artm-static
-    messages_proto internals_proto
-    glog ${BOOST_IMPORTED_TARGETS}
-    )
+    PUBLIC messages_proto internals_proto glog
+    PRIVATE ${BOOST_IMPORTED_TARGETS})
 add_dependencies(artm-static messages_proto internals_proto)
 target_compile_definitions(artm-static PRIVATE ARTM_STATIC_DEFINE)
 
 if (WIN32)
     # This library is needed for GetProcessMemoryInfo and is not linked by default on MinGW
-    target_link_libraries(artm-static psapi)
+    target_link_libraries(artm-static PUBLIC psapi)
 endif (WIN32)
 
 target_include_directories(artm-static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
@@ -264,7 +263,7 @@ endif (WIN32)
 # Using PRIVATE here so that consumers of the library do not link explicitly
 # to boost, etc. This should be handled by the linker via DT_NEEDED or similar
 # But we have to repeat include dir here for artm_export.h
-target_link_libraries(artm PRIVATE artm-static)
+target_link_libraries(artm PRIVATE artm-static ${BOOST_IMPORTED_TARGETS})
 target_include_directories(artm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
 target_include_directories(artm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 # Support compiling with bundled protobuf headers from build-tree
@@ -315,6 +314,12 @@ install(CODE
     set(COMPONENT_BACKUP \${CMAKE_INSTALL_COMPONENT})
     set(CMAKE_INSTALL_COMPONENT \"protobuf-headers\")
     include(${PROTOBUF_BINARY_DIR}/cmake_install.cmake)
+    set(CMAKE_INSTALL_COMPONENT \"protobuf-protos\")
+    include(${PROTOBUF_BINARY_DIR}/cmake_install.cmake)
+    if (WIN32)
+        set(CMAKE_INSTALL_COMPONENT \"protoc\")
+        include(${PROTOBUF_BINARY_DIR}/cmake_install.cmake)
+    endif (WIN32)
     set(CMAKE_INSTALL_COMPONENT \${COMPONENT_BACKUP})
     "
     )

--- a/src/artm/CMakeLists.txt
+++ b/src/artm/CMakeLists.txt
@@ -277,6 +277,7 @@ generate_export_header(artm
 install(TARGETS artm EXPORT artm
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
     INCLUDES DESTINATION include/artm
     )
 install(FILES

--- a/src/artm_tests/CMakeLists.txt
+++ b/src/artm_tests/CMakeLists.txt
@@ -1,8 +1,5 @@
 project(artm_tests)
 
-include_directories(${3RD_PARTY_DIR}/gtest/fused-src/)
-include_directories(${CMAKE_CURRENT_LIST_DIR}/../)
-
 set(SRC_LIST
 	api.cc
 	batch_manager_test.cc
@@ -29,7 +26,11 @@ set(SRC_LIST
 add_definitions("-Dartm_EXPORTS")
 add_executable(artm_tests ${SRC_LIST})
 add_dependencies(artm_tests messages_proto)
-target_link_libraries(artm_tests artm-static)
+target_link_libraries(artm_tests artm-static ${BOOST_IMPORTED_TARGETS})
+target_include_directories(artm_tests PRIVATE
+    ${3RD_PARTY_DIR}/gtest/fused-src/
+    ${CMAKE_CURRENT_LIST_DIR}/../
+    )
 
 # add target for testing
 add_test(NAME core_tests

--- a/src/artm_tests/CMakeLists.txt
+++ b/src/artm_tests/CMakeLists.txt
@@ -32,4 +32,6 @@ add_dependencies(artm_tests messages_proto)
 target_link_libraries(artm_tests artm-static)
 
 # add target for testing
-add_test(NAME core_tests COMMAND artm_tests)
+add_test(NAME core_tests
+    COMMAND artm_tests --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/junit.xml
+    )

--- a/src/bigartm/CMakeLists.txt
+++ b/src/bigartm/CMakeLists.txt
@@ -6,12 +6,7 @@ set(SRC_LIST
 	srcmain.cc
 )
 
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC ON)
-find_package(Boost COMPONENTS REQUIRED ${BIGARTM_BOOST_COMPONENTS})
-
 add_executable(bigartm ${SRC_LIST})
-add_dependencies(bigartm messages_proto)
 
 if (BUILD_BIGARTM_CLI_STATIC)
   set(CMAKE_EXE_LINKER_FLAGS "-static")
@@ -21,9 +16,11 @@ target_include_directories(bigartm PRIVATE $<TARGET_PROPERTY:glog,INTERFACE_INCL
 
 if (WIN32)
   # FIXME find a way to export all needed symbols from protobuf without needing to link to it here
-  target_link_libraries(bigartm artm ${Boost_LIBRARIES} ${PROTOBUF_LIBRARIES})
+  target_link_libraries(bigartm artm)
 else (WIN32)
   target_link_libraries(bigartm artm-static)
 endif (WIN32)
+
+target_link_libraries(bigartm ${BOOST_IMPORTED_TARGETS})
 
 install(TARGETS bigartm DESTINATION bin)

--- a/src/bigartm/CMakeLists.txt
+++ b/src/bigartm/CMakeLists.txt
@@ -20,6 +20,17 @@ else (WIN32)
   target_link_libraries(bigartm artm-static)
 endif (WIN32)
 
-target_link_libraries(bigartm ${BOOST_IMPORTED_TARGETS})
+if (NOT WIN32 AND BUILD_BIGARTM_CLI_STATIC)
+  # To use static boost libraries, we need to re-find them
+  unset(Boost_LIBRARIES)
+  set(Boost_USE_STATIC_LIBS ON)
+  find_package(Boost REQUIRED COMPONENTS ${BIGARTM_BOOST_COMPONENTS})
+  target_include_directories(bigartm PRIVATE ${Boost_INCLUDE_DIRS})
+  target_link_libraries(bigartm ${Boost_LIBRARIES})
+else (NOT WIN32 AND BUILD_BIGARTM_CLI_STATIC)
+  # If we don't want static linkage, we can just use new approach with
+  # imported targets like everywhere else in the project
+  target_link_libraries(bigartm ${BOOST_IMPORTED_TARGETS})
+endif (NOT WIN32 AND BUILD_BIGARTM_CLI_STATIC)
 
 install(TARGETS bigartm DESTINATION bin)

--- a/src/bigartm/CMakeLists.txt
+++ b/src/bigartm/CMakeLists.txt
@@ -15,7 +15,6 @@ endif (BUILD_BIGARTM_CLI_STATIC)
 target_include_directories(bigartm PRIVATE $<TARGET_PROPERTY:glog,INTERFACE_INCLUDE_DIRECTORIES>)
 
 if (WIN32)
-  # FIXME find a way to export all needed symbols from protobuf without needing to link to it here
   target_link_libraries(bigartm artm)
 else (WIN32)
   target_link_libraries(bigartm artm-static)

--- a/utils/create_windows_package.bat
+++ b/utils/create_windows_package.bat
@@ -1,15 +1,7 @@
 REM This script is part of appveyor build. It copies some ARTM files into the installation folder and packs everytying with 7z.
 
-if not exist %INSTALL_FOLDER%\lib mkdir %INSTALL_FOLDER%\lib
 if not exist %INSTALL_FOLDER%\python\examples mkdir %INSTALL_FOLDER%\python\examples
 cd C:\projects\bigartm
-xcopy C:\projects\bigartm\3rdparty\protobuf-3.0.0\python %INSTALL_FOLDER%\protobuf\Python\ /s /e
-xcopy C:\projects\bigartm\3rdparty\protobuf-3.0.0\src\google\protobuf\*.proto %INSTALL_FOLDER%\protobuf\src\google\protobuf\ /s
-xcopy C:\projects\bigartm\python\artm\wrapper\messages_pb2.py %INSTALL_FOLDER%\python\artm\wrapper\
-cp %PROTOC% %INSTALL_FOLDER%\bin\protoc.exe
-cp %PROTOC% %INSTALL_FOLDER%\protobuf\src\protoc.exe
-cp build\lib\release\artm.lib %INSTALL_FOLDER%\lib\artm.lib
-cp build\lib\release\libprotobuf.lib %INSTALL_FOLDER%\lib\libprotobuf.lib
 cp test_data\docword.kos.txt %INSTALL_FOLDER%\python\examples\docword.kos.txt
 cp test_data\vocab.kos.txt %INSTALL_FOLDER%\python\examples\vocab.kos.txt
 7z.exe a BigARTM.7z %INSTALL_FOLDER%\*


### PR DESCRIPTION
Hi. I finally managed to do this. Here's the summary of changes:

- Upload test results in jUnit xml format to appveyor
- Export all protobuf symbols directly from `artm.dll`, so that we don't need to package `libprotobuf.lib` for linking
- Add import lib to installation

Please review, test and merge. AppVeyour results for MinGW can be seen here: https://ci.appveyor.com/project/maksbotan/bigartm