### PR TITLE
Fix bulding issues for static CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
 before_install:
   # we need latest pip to work with only-binary option
   - pip install -U pip
-  - pip install -U pytest pep8 wheel
+  - pip install -U pytest pep8 wheel pytest-forked
   - pip install -U numpy scipy pandas tqdm --only-binary numpy,scipy,pandas
   - pip install -U protobuf
   # configure ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,18 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.3)
+
+# CMake Policy 0060 (CMP0060) controls how CMake
+# adds library dependencies to linker
+# When this policy is disabled (turned to OLD),
+# CMake uses weird linker options (e.g. -Wl,-Bstatic -lfoo -Wl,-dynamic),
+# which can mess up linkage types of libraries
+# When this policy is enabled (turned to NEW),
+# CMake uses full path when linking libraries,
+# and this helps to avoid aforementioned linker options
+# The complete description of this policy can be found here:
+# https://cmake.org/cmake/help/latest/policy/CMP0060.html
+IF (POLICY CMP0060)
+  cmake_policy(SET CMP0060 NEW)
+endif (POLICY CMP0060)
 
 project(BigARTM)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,47 @@ option(BUILD_INTERNAL_PYTHON_API "Indicates whether to build Python API" ON)
 
 set(PYTHON python CACHE INTERNAL "Python command")
 
-if (BUILD_BIGARTM_CLI AND UNIX AND NOT APPLE)
-  option(BUILD_BIGARTM_CLI_STATIC "Request build of static executable bigartm (for Linux only)" ON)
-endif (BUILD_BIGARTM_CLI AND UNIX AND NOT APPLE)
+# Describe necessary options for static version of `bigartm` executable
+
+include(CMakeDependentOption)
+CMAKE_DEPENDENT_OPTION(
+  BUILD_BIGARTM_CLI_STATIC "[EXPERIMENTAL] Requests static version of executable `bigartm`" OFF
+  "BUILD_BIGARTM_CLI;UNIX;NOT APPLE" OFF)
+
+CMAKE_DEPENDENT_OPTION(
+  HAS_STATIC_LIBUNWIND "[EXPERIMENTAL] Indicates presence if static version of libunwind" OFF
+  "BUILD_BIGARTM_CLI_STATIC" OFF)
+
+if (BUILD_BIGARTM_CLI_STATIC AND NOT HAS_STATIC_LIBUNWIND)
+  message(WARNING
+    "You're requesting static version of CLI `bigartm`. "
+    "Some 3rdparty of library (namely, `glog`) uses `libunwind` library, which "
+    "provides convenient way of maniulating with call frames. "
+    "Here `glog` uses this library mostly for stacktrace generation. "
+    "Unfortunatley, not all Linux distributives provide static version of it "
+    "in official repositories, that's why we disable usage of this library by default.\n"
+
+    "If you certainly have static version of `libunwind` on your system "
+    "and want to use it in BigARTM project, just set option "
+    "'HAS_STATIC_LIBUNWIND' to 'ON'. For example, if you use CMake "
+    "as a command-line utility, you can add option '-DHAS_STATIC_LIBUNWIND=ON' "
+    "to argument list.")
+
+  # There is problem with some Linux distributions (e.g. Fedora),
+  # which currently doesn't provide convenient way to obtain
+  # static version of `libunwind` library (either via official or custom repos)
+  # This library is autodetected by 3rdparty `glog` module.
+  # That's why there may be some problems when user wants to build
+  # static CLI `bigartm` on system with only shared version of `libunwind`.
+  #
+  # It sounds reasonable to disable autodetection of `libunwind` library
+  # by `glog` while building static CLI executable.
+  # One possible way to do this is to "forge" `glog` module that
+  # there is no libunwind library (via CMake CACHE vairables).
+  # A nice candidate to do is variable "UNWIND_LIBRARY" which is directly
+  # related to autodetection in file 3rdparty/glog/CMakeLists.txt
+  set(UNWIND_LIBRARY CACHE INTERNAL "")
+endif (BUILD_BIGARTM_CLI_STATIC AND NOT HAS_STATIC_LIBUNWIND)
 
 if (APPLE)
   set(CMAKE_MACOSX_RPATH 1)

--- a/docs/installation/linux.txt
+++ b/docs/installation/linux.txt
@@ -145,7 +145,7 @@ Next step is to run ``cmake``. The following options are available.
 * ``-DPYTHON=python3`` - to use Python 3 instead of Python 2;
 * ``-DCMAKE_INSTALL_PREFIX=xxx`` - for custom install location instead of default ``/usr/local``;
 * ``-DBoost_USE_STATIC_LIBS=ON`` -- required on openSUSE;
-* ``-DBUILD_BIGARTM_CLI_STATIC=OFF`` -- to use shared versions of Boost, C and C++ libraries for ``bigartm`` executable.
+* ``-DBUILD_BIGARTM_CLI_STATIC=ON`` -- to use static versions of Boost, C and C++ libraries for ``bigartm`` executable.
 
 
 Example:

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -46,15 +46,11 @@ and Fedora.
 
 **Open source**.
 BigARTM is released under the `New BSD License`_.
-If you plan to use our library commercially, please beware that
-BigARTM depends on ZeroMQ. Please, make sure to review
-`ZeroMQ license`_.
 
 .. _Additive Regularization of Topic Models: http://www.machinelearning.ru/wiki/images/1/1f/Voron14aist.pdf
 .. _topic models: http://en.wikipedia.org/wiki/Topic_model
 .. _Google Protocol Buffers: https://code.google.com/p/protobuf/
 .. _New BSD license: http://opensource.org/licenses/BSD-3-Clause
-.. _ZeroMQ license: http://zeromq.org/area:licensing
 
 =========================================
 

--- a/python/tests/artm/CMakeLists.txt
+++ b/python/tests/artm/CMakeLists.txt
@@ -1,6 +1,12 @@
-add_test(NAME python_artm_tests
+if (WIN32)
+  add_test(NAME python_artm_tests
+    COMMAND py.test --junit-xml=${CMAKE_CURRENT_BINARY_DIR}/junit.xml
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+else (WIN32)
+  add_test(NAME python_artm_tests
     COMMAND py.test --forked --junit-xml=${CMAKE_CURRENT_BINARY_DIR}/junit.xml
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif (WIN32)
 
 set_tests_properties(python_artm_tests PROPERTIES
-    ENVIRONMENT "ARTM_SHARED_LIBRARY=$<TARGET_FILE:artm>")
+  ENVIRONMENT "ARTM_SHARED_LIBRARY=$<TARGET_FILE:artm>")

--- a/python/tests/artm/CMakeLists.txt
+++ b/python/tests/artm/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_test(NAME python_artm_tests
-    COMMAND py.test --junit-xml=${CMAKE_CURRENT_BINARY_DIR}/junit.xml
+    COMMAND py.test --forked --junit-xml=${CMAKE_CURRENT_BINARY_DIR}/junit.xml
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 set_tests_properties(python_artm_tests PROPERTIES

--- a/python/tests/wrapper/CMakeLists.txt
+++ b/python/tests/wrapper/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_test(NAME python_wrapper_tests
-    COMMAND py.test --junit-xml=${CMAKE_CURRENT_BINARY_DIR}/junit.xml
+    COMMAND py.test --forked --junit-xml=${CMAKE_CURRENT_BINARY_DIR}/junit.xml
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 set_tests_properties(python_wrapper_tests PROPERTIES

--- a/python/tests/wrapper/CMakeLists.txt
+++ b/python/tests/wrapper/CMakeLists.txt
@@ -1,6 +1,12 @@
-add_test(NAME python_wrapper_tests
+if (WIN32)
+  add_test(NAME python_wrapper_tests
+    COMMAND py.test --junit-xml=${CMAKE_CURRENT_BINARY_DIR}/junit.xml
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+else (WIN32)
+  add_test(NAME python_wrapper_tests
     COMMAND py.test --forked --junit-xml=${CMAKE_CURRENT_BINARY_DIR}/junit.xml
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif (WIN32)
 
 set_tests_properties(python_wrapper_tests PROPERTIES
-    ENVIRONMENT "ARTM_SHARED_LIBRARY=$<TARGET_FILE:artm>")
+  ENVIRONMENT "ARTM_SHARED_LIBRARY=$<TARGET_FILE:artm>")

--- a/src/artm/CMakeLists.txt
+++ b/src/artm/CMakeLists.txt
@@ -226,8 +226,7 @@ source_group(""                    FILES ${SRC_LIST_OTHER}               )
 
 add_library(artm-static STATIC ${SRC_LIST})
 target_link_libraries(artm-static
-    PUBLIC messages_proto internals_proto glog
-    PRIVATE ${BOOST_IMPORTED_TARGETS})
+    PUBLIC messages_proto internals_proto glog)
 add_dependencies(artm-static messages_proto internals_proto)
 target_compile_definitions(artm-static PRIVATE ARTM_STATIC_DEFINE)
 
@@ -236,6 +235,7 @@ if (WIN32)
     target_link_libraries(artm-static PUBLIC psapi)
 endif (WIN32)
 
+target_include_directories(artm-static PRIVATE ${Boost_INCLUDE_DIRS})
 target_include_directories(artm-static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
 
 # Shared 'artm' library


### PR DESCRIPTION
This PR is supposed to solve several problems related to building static CLI on Linux:
* Remove autodetection of `libunwind`, because currently there is no static version of this library in official Fedora repositories.
* Enable CMake Policy 0060 (CMP0060) to solve issues with links to  BOOST_IMPORTED_TARGETS
* Move to building shared version of CLI by default.

@ofrei Right now I have little expertise in building it on Windows (e.g. some dll exports, external symbols etc.), and our Appveyor setup can miss some corner cases. Could you help me to ensure that there is no problem with this PR on Windows?
@MichaelSolotky I will be grateful you to check whether this PR works on your Linux machine