### PR TITLE
Fix _run_from_ipython() to differentiate consoles and notebooks

### DIFF
--- a/python/artm/artm_model.py
+++ b/python/artm/artm_model.py
@@ -51,10 +51,10 @@ PARAMETERS_FILENAME_JSON = 'parameters.json'
 PARAMETERS_FILENAME_BIN = 'parameters.bin'
 
 
-def _run_from_ipython():
+def _run_from_notebook():
     try:
-        get_ipython().config
-        return True
+        shell = get_ipython().__class__.__name__
+        return shell == 'ZMQInteractiveShell'
     except:  # noqa
         return False
 
@@ -534,7 +534,7 @@ class ARTM(object):
         import warnings
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
-            progress = tqdm.tqdm_notebook if _run_from_ipython() else tqdm.tqdm
+            progress = tqdm.tqdm_notebook if _run_from_notebook() else tqdm.tqdm
             with progress(total=num_batches, desc='Batch', leave=False,
                           disable=not self._show_progress_bars) as batch_tqdm:
                 previous_num_batches = 0
@@ -567,7 +567,7 @@ class ARTM(object):
         import warnings
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
-            progress = tqdm.tnrange if _run_from_ipython() else tqdm.trange
+            progress = tqdm.tnrange if _run_from_notebook() else tqdm.trange
             for _ in progress(num_collection_passes, desc='Pass',
                               disable=not self._show_progress_bars):
                 # temp code for easy using of TopicSelectionThetaRegularizer from Python


### PR DESCRIPTION
Currently, `_run_from_ipython` function in artm_model.py is used to choose between graphical or console version of tqdm progress bars. It makes an erroneous assumption that all IPython interpreters are IPython **notebook** interpreters, however an IPython can be run in non-notebook mode with console CLI, which is **unable** to display graphical progress bars.

This PR aims to fix that. The difference in behavior of new `_run_from_notebook` function is highlighted in the following screenshots.

**CPython:**
<img width="779" alt="screenshot 2018-10-17 at 17 57 35" src="https://user-images.githubusercontent.com/274365/47096631-46a4b100-d238-11e8-88ec-0670a15bde4f.png">

**IPython console** (previously returned `True`)**:**
<img width="746" alt="screenshot 2018-10-17 at 17 58 01" src="https://user-images.githubusercontent.com/274365/47096630-46a4b100-d238-11e8-9a10-8298c96785f2.png">

**IPython notebook:**
<img width="375" alt="screenshot 2018-10-17 at 17 56 47" src="https://user-images.githubusercontent.com/274365/47096632-46a4b100-d238-11e8-8dba-d5c68d2d0160.png">
