### PR TITLE
add ability to build on Apple Clang with c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,8 +151,11 @@ endforeach(boost_component)
 
 add_subdirectory(3rdparty)  # gflags must be compiled without -std=c++11
 
+message("123456 ${CMAKE_CXX_COMPILER_ID}")
+
 if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
-    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))
+    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") OR
+    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang"))
   include(CheckCXXCompilerFlag)
   CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
   CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
@@ -164,7 +167,8 @@ if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
     message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
   endif (COMPILER_SUPPORTS_CXX11)
 endif (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR
-       ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))
+       ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") OR
+       ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang"))
 
 add_subdirectory(src)
 add_subdirectory(python)


### PR DESCRIPTION
Now the library can't be compiled not with Apple Clang, because for it flag c++11 isn't added.