### PR TITLE
rename 'async' to 'asynchronous' in order to support python 3.7

### DIFF
--- a/python/artm/artm_model.py
+++ b/python/artm/artm_model.py
@@ -92,8 +92,8 @@ def _topic_selection_regularizer_func(self, regularizers):
 
 
 class ArtmThreadPool(object):
-    def __init__(self, async=True):
-        self._pool = ThreadPool(processes=1) if async else None
+    def __init__(self, asynchronous=True):
+        self._pool = ThreadPool(processes=1) if asynchronous else None
 
     def apply_async(self, func, args):
         return self._pool.apply_async(func, args) if self._pool else func(*args)
@@ -193,7 +193,7 @@ class ARTM(object):
         self._theta_columns_naming = 'id'
         self._seed = -1
         self._show_progress_bars = show_progress_bars
-        self._pool = ArtmThreadPool(async=show_progress_bars)
+        self._pool = ArtmThreadPool(asynchronous=show_progress_bars)
 
         if topic_names is not None:
             self._topic_names = topic_names
@@ -588,7 +588,7 @@ class ARTM(object):
         self._phi_cached = None
 
     def fit_online(self, batch_vectorizer=None, tau0=1024.0, kappa=0.7, update_every=1,
-                   apply_weight=None, decay_weight=None, update_after=None, async=False):
+                   apply_weight=None, decay_weight=None, update_after=None, asynchronous=False):
         """
         :Description: proceeds the learning of topic model in online mode
 
@@ -602,10 +602,10 @@ class ARTM(object):
         :type apply_weight: list of float
         :param decay_weight: weight of applying old counters
         :type decay_weight: list of float
-        :param bool async: use or not the async implementation of the EM-algorithm
+        :param bool asynchronous: use or not the asynchronous implementation of the EM-algorithm
 
         :Note:
-          async=True leads to impossibility of score extraction via score_tracker.\
+          asynchronous=True leads to impossibility of score extraction via score_tracker.\
           Use get_score() instead.
 
         :Update formulas:
@@ -648,7 +648,7 @@ class ARTM(object):
             self._pool.apply_async(func=self.master.fit_online,
                                    args=(batch_vectorizer.batches_ids, batch_vectorizer.weights,
                                          update_after_final, apply_weight_final,
-                                         decay_weight_final, async)),
+                                         decay_weight_final, asynchronous)),
             batch_vectorizer.num_batches)
 
         for name in self.scores.data.keys():

--- a/python/artm/master_component.py
+++ b/python/artm/master_component.py
@@ -866,7 +866,7 @@ class MasterComponent(object):
         self._lib.ArtmFitOfflineMasterModel(self.master_id, args)
 
     def fit_online(self, batch_filenames=None, batch_weights=None, update_after=None,
-                   apply_weight=None, decay_weight=None, async=None):
+                   apply_weight=None, decay_weight=None, asynchronous=None):
         """
         :param batch_filenames: name of batches to process
         :type batch_filenames: list of str
@@ -880,7 +880,7 @@ class MasterComponent(object):
         :param decay_weight: weight of applying old counters\
                 (len == len of update_after)
         :type decay_weight: list of float
-        :param bool async: whether to use the async implementation\
+        :param bool asynchronous: whether to use the asynchronous implementation\
                 of the EM-algorithm or not
         """
         args = messages.FitOnlineMasterModelArgs()
@@ -914,8 +914,8 @@ class MasterComponent(object):
             for value in decay_weight:
                 args.decay_weight.append(value)
 
-        if async is not None:
-            args.async = async
+        if asynchronous is not None:
+            args.asynchronous = asynchronous
 
         self._lib.ArtmFitOnlineMasterModel(self.master_id, args)
 

--- a/src/artm/c_interface.cc
+++ b/src/artm/c_interface.cc
@@ -289,7 +289,7 @@ int64_t ArtmAsyncProcessBatches(int master_id, int64_t length, const char* proce
     master->AsyncRequestProcessBatches(args, batch_manager.get());
     int retval = AsyncProcessBatchesManager::singleton().Store(batch_manager);
 
-    LOG(INFO) << "Creating async operation (id=" << retval << ")...";
+    LOG(INFO) << "Creating asynchronous operation (id=" << retval << ")...";
     return retval;
   } CATCH_EXCEPTIONS;
 }

--- a/src/artm/core/check_messages.h
+++ b/src/artm/core/check_messages.h
@@ -1044,7 +1044,7 @@ inline std::string DescribeMessage(const ::artm::FitOnlineMasterModelArgs& messa
     ss << message.decay_weight(i);
   }
   ss << ")";
-  ss << ", async=" << (message.async() ? "yes" : "no");
+  ss << ", asynchronous=" << (message.asynchronous() ? "yes" : "no");
   return ss.str();
 }
 

--- a/src/artm/core/master_component.cc
+++ b/src/artm/core/master_component.cc
@@ -727,7 +727,7 @@ void MasterComponent::Request(const GetMasterComponentInfoArgs& /*args*/, Master
 
 void MasterComponent::Request(const ProcessBatchesArgs& args, ProcessBatchesResult* result) {
   BatchManager batch_manager;
-  RequestProcessBatchesImpl(args, &batch_manager, /* async =*/ false, nullptr, result->mutable_theta_matrix());
+  RequestProcessBatchesImpl(args, &batch_manager, /* asynchronous =*/ false, nullptr, result->mutable_theta_matrix());
   instance_->score_manager()->RequestAllScores(result->mutable_score_data());
 }
 
@@ -750,12 +750,12 @@ void MasterComponent::Request(const ProcessBatchesArgs& args, ProcessBatchesResu
 
 void MasterComponent::AsyncRequestProcessBatches(const ProcessBatchesArgs& process_batches_args,
                                                  BatchManager *batch_manager) {
-  RequestProcessBatchesImpl(process_batches_args, batch_manager, /* async =*/ true,
+  RequestProcessBatchesImpl(process_batches_args, batch_manager, /* asynchronous =*/ true,
                             /*score_manager=*/ nullptr, /* theta_matrix=*/ nullptr);
 }
 
 void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& process_batches_args,
-                                                BatchManager* batch_manager, bool async,
+                                                BatchManager* batch_manager, bool asynchronous,
                                                 ScoreManager* score_manager,
                                                 ::artm::ThetaMatrix* theta_matrix) {
   const ProcessBatchesArgs& args = process_batches_args;  // short notation
@@ -789,12 +789,12 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
     }
   }
 
-  if (async && args.theta_matrix_type() != ThetaMatrixType_None) {
+  if (asynchronous && args.theta_matrix_type() != ThetaMatrixType_None) {
     BOOST_THROW_EXCEPTION(InvalidOperation(
         "ArtmAsyncProcessBatches require ProcessBatchesArgs.theta_matrix_type to be set to None"));
   }
 
-  // The code below must not use cache_manger in async mode.
+  // The code below must not use cache_manger in asynchronous mode.
   // Since cache_manager lives on stack it will be destroyed once we return from this function.
   // Therefore, no pointers to cache_manager should exist upon return from RequestProcessBatchesImpl.
   CacheManager cache_manager("", nullptr);
@@ -868,7 +868,7 @@ void MasterComponent::RequestProcessBatchesImpl(const ProcessBatchesArgs& proces
     instance_->processor_queue()->push(pi);
   }
 
-  if (async) {
+  if (asynchronous) {
     return;
   }
 
@@ -1131,7 +1131,7 @@ void MasterComponent::Request(const TransformMasterModelArgs& args, ::artm::Thet
 
   BatchManager batch_manager;
   RequestProcessBatchesImpl(process_batches_args, &batch_manager,
-                            /* async =*/ false, /*score_manager =*/ nullptr, result);
+                            /* asynchronous =*/ false, /*score_manager =*/ nullptr, result);
   ValidateProcessedItems("Transform", this);
 }
 
@@ -1393,7 +1393,7 @@ class ArtmExecutor {
   MasterComponent* master_component_;
   ProcessBatchesArgs process_batches_args_;
   RegularizeModelArgs regularize_model_args_;
-  std::vector<std::shared_ptr<BatchManager>> async_;
+  std::vector<std::shared_ptr<BatchManager>> asynchronous_;
 
   void ProcessBatches(std::string pwt, std::string nwt, BatchesIterator* iter, ScoreManager* score_manager) {
     process_batches_args_.set_pwt_source_name(pwt);
@@ -1404,7 +1404,7 @@ class ArtmExecutor {
     LOG(INFO) << DescribeMessage(process_batches_args_);
     master_component_->RequestProcessBatchesImpl(process_batches_args_,
                                                  &batch_manager,
-                                                 /* async =*/ false,
+                                                 /* asynchronous =*/ false,
                                                  /* score_manager =*/ score_manager,
                                                  /* theta_matrix*/ nullptr);
     process_batches_args_.clear_batch_filename();
@@ -1416,12 +1416,12 @@ class ArtmExecutor {
     process_batches_args_.set_theta_matrix_type(ThetaMatrixType_None);
     iter->move(&process_batches_args_);
 
-    int operation_id = static_cast<int>(async_.size());
-    async_.push_back(std::make_shared<BatchManager>());
+    int operation_id = static_cast<int>(asynchronous_.size());
+    asynchronous_.push_back(std::make_shared<BatchManager>());
     LOG(INFO) << DescribeMessage(process_batches_args_);
     master_component_->RequestProcessBatchesImpl(process_batches_args_,
-                                                 async_.back().get(),
-                                                 /* async =*/ true,
+                                                 asynchronous_.back().get(),
+                                                 /* asynchronous =*/ true,
                                                  /* score_manager =*/ nullptr,
                                                  /* theta_matrix*/ nullptr);
     process_batches_args_.clear_batch_filename();
@@ -1429,7 +1429,7 @@ class ArtmExecutor {
   }
 
   void Await(int operation_id) {
-    while (!async_[operation_id]->IsEverythingProcessed()) {
+    while (!asynchronous_[operation_id]->IsEverythingProcessed()) {
       boost::this_thread::sleep(boost::posix_time::milliseconds(kIdleLoopFrequency));
     }
   }
@@ -1506,7 +1506,7 @@ void MasterComponent::FitOnline(const FitOnlineMasterModelArgs& args) {
   ArtmExecutor artm_executor(*config, this);
   OnlineBatchesIterator iter(args.batch_filename(), args.batch_weight(), args.update_after(),
                              args.apply_weight(), args.decay_weight());
-  if (args.async()) {
+  if (args.asynchronous()) {
     artm_executor.ExecuteAsyncOnlineAlgorithm(&iter);
   } else {
     artm_executor.ExecuteOnlineAlgorithm(&iter);

--- a/src/artm/core/master_component.h
+++ b/src/artm/core/master_component.h
@@ -107,7 +107,7 @@ class MasterComponent : boost::noncopyable {
   MasterComponent& operator=(const MasterComponent&);
 
   void RequestProcessBatchesImpl(const ProcessBatchesArgs& process_batches_args,
-                                 BatchManager* batch_manager, bool async,
+                                 BatchManager* batch_manager, bool asynchronous,
                                  ScoreManager* score_manager,
                                  ::artm::ThetaMatrix* theta_matrix);
 

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -809,7 +809,7 @@ message FitOnlineMasterModelArgs {
   repeated int32 update_after = 3;
   repeated float apply_weight = 4;
   repeated float decay_weight = 5;
-  optional bool async = 6 [default = false];
+  optional bool asynchronous = 6 [default = false];
 }
 
 message TransformMasterModelArgs {

--- a/src/artm/score/top_tokens.cc
+++ b/src/artm/score/top_tokens.cc
@@ -47,11 +47,6 @@ std::shared_ptr<Score> TopTokens::CalculateScore(const artm::core::PhiMatrix& p_
     class_id = config_.class_id();
   }
 
-  /*if (count_coherence) {
-    LOG(ERROR) << "Coherence computation in TopTokens score does not support transactions!";
-    return nullptr;
-  }*/
-
   std::vector<artm::core::Token> tokens;
   for (int token_index = 0; token_index < token_size; token_index++) {
     auto token = p_wt.token(token_index);

--- a/src/artm/score/top_tokens.cc
+++ b/src/artm/score/top_tokens.cc
@@ -47,10 +47,10 @@ std::shared_ptr<Score> TopTokens::CalculateScore(const artm::core::PhiMatrix& p_
     class_id = config_.class_id();
   }
 
-  if (count_coherence) {
+  /*if (count_coherence) {
     LOG(ERROR) << "Coherence computation in TopTokens score does not support transactions!";
     return nullptr;
-  }
+  }*/
 
   std::vector<artm::core::Token> tokens;
   for (int token_index = 0; token_index < token_size; token_index++) {

--- a/src/artm_tests/master_model_test.cc
+++ b/src/artm_tests/master_model_test.cc
@@ -115,7 +115,7 @@ TEST(MasterModel, Basic) {
     for (int pass = 0; pass < 4; pass++) {
       ::artm::FitOnlineMasterModelArgs fit_online_args;
       fit_online_args.mutable_batch_filename()->CopyFrom(fit_offline_args.batch_filename());
-      fit_online_args.set_async(is_async == 1);
+      fit_online_args.set_asynchronous(is_async == 1);
 
       // Populate update_after and apply_weight fields
       int update_after = 0;
@@ -130,7 +130,7 @@ TEST(MasterModel, Basic) {
       artm::PerplexityScore perplexity_score = master_model.GetScoreAs< ::artm::PerplexityScore>(get_score_args);
       ASSERT_APPROX_EQ(perplexity_score.value(), expected[pass]);
 
-      if (!fit_online_args.async()) {
+      if (!fit_online_args.asynchronous()) {
         auto perplexity_scores = master_model.GetScoreArrayAs< ::artm::PerplexityScore>(get_score_array_args);
         ASSERT_EQ(perplexity_scores.size(), (pass + 1) * nBatches / update_every);
 

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -290,7 +290,7 @@ struct artm_options {
   std::vector<std::string> regularizer;
   bool b_reuse_theta;
   int threads;
-  bool async;
+  bool asynchronous;
 
   // Output
   bool force;
@@ -1587,7 +1587,7 @@ int execute(const artm_options& options, int argc, char* argv[]) {
 
     if (options.update_every > 0) {  // online algorithm
       FitOnlineMasterModelArgs fit_online_args;
-      fit_online_args.set_async(options.async);
+      fit_online_args.set_asynchronous(options.asynchronous);
 
       int update_after = 0;
       do {
@@ -1789,7 +1789,7 @@ int main(int argc, char * argv[]) {
       ("reuse-theta", po::bool_switch(&options.b_reuse_theta)->default_value(false), "reuse theta between iterations")
       ("regularizer", po::value< std::vector<std::string> >(&options.regularizer)->multitoken()->zero_tokens(), "regularizers (SmoothPhi,SparsePhi,SmoothTheta,SparseTheta,Decorrelation)")
       ("threads", po::value(&options.threads)->default_value(-1), "number of concurrent processors (default: auto-detect)")
-      ("async", po::bool_switch(&options.async)->default_value(false), "invoke asynchronous version of the online algorithm")
+      ("asynchronous", po::bool_switch(&options.asynchronous)->default_value(false), "invoke asynchronous version of the online algorithm")
     ;
 
     po::options_description output_options("Output");


### PR DESCRIPTION
This is the solution to this issue https://github.com/bigartm/bigartm/issues/922

* Now the code can be compiled and models can be built with python 3.7;
* Also there was a bug with coherence computation in the file src/artm/score/top_tokens.cc, it's fixed.

@ofrei, I think we should squash commits in master rather then merge all commits from PR.