### PR TITLE
Correction of mistakes associated with co-occurrence gathering and collection parsing

### DIFF
--- a/appveyor-mingw.yml
+++ b/appveyor-mingw.yml
@@ -36,7 +36,7 @@ install:
 "
     - c:\msys64\usr\bin\pacman -Syu --noconfirm
     - c:\msys64\usr\bin\pacman -Syyu --noconfirm --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-make
-    - c:\msys64\usr\bin\pacman -Syu --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-boost-1.64.0-3-any.pkg.tar.xz
+    - c:\msys64\usr\bin\pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-boost-1.64.0-3-any.pkg.tar.xz
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q -c conda-forge conda
     - conda info -a

--- a/appveyor-mingw.yml
+++ b/appveyor-mingw.yml
@@ -36,7 +36,7 @@ install:
 "
     - c:\msys64\usr\bin\pacman -Syu --noconfirm
     - c:\msys64\usr\bin\pacman -Syyu --noconfirm --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-make
-    - c:\msys64\usr\bin\pacman -SyU --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-boost-1.64.0-3-any.pkg.tar.xz
+    - c:\msys64\usr\bin\pacman -Syu --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-boost-1.64.0-3-any.pkg.tar.xz
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q -c conda-forge conda
     - conda info -a

--- a/appveyor-mingw.yml
+++ b/appveyor-mingw.yml
@@ -24,19 +24,19 @@ environment:
         - PYTHON_VERSION: 2.7
           MINICONDA: C:\Miniconda-x64
 
-cache:
+          #cache:
     # Cache MSYS2 packages to speed up builds. If version in repo changes, pacman will update it
-    - c:\msys64\mingw64
-    - c:\msys64\var\lib\pacman
-    - C:\Miniconda36-x64\Lib\site-packages
-    - C:\Miniconda-x64\Lib\site-packages
+    # - c:\msys64\mingw64
+      # - c:\msys64\var\lib\pacman
+      #- C:\Miniconda36-x64\Lib\site-packages
+      #- C:\Miniconda-x64\Lib\site-packages
 
 install:
     - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;C:\\msys64\\mingw64\\bin;C:\\Program Files\\7-Zip;%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\
 "
     - c:\msys64\usr\bin\pacman -Syu --noconfirm
     - c:\msys64\usr\bin\pacman -Syyu --noconfirm --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-make
-    - c:\msys64\usr\bin\pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-boost-1.64.0-3-any.pkg.tar.xz
+    - c:\msys64\usr\bin\pacman -SyU --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-boost-1.64.0-3-any.pkg.tar.xz
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q -c conda-forge conda
     - conda info -a

--- a/appveyor-mingw.yml
+++ b/appveyor-mingw.yml
@@ -34,8 +34,8 @@ cache:
 install:
     - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;C:\\msys64\\mingw64\\bin;C:\\Program Files\\7-Zip;%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\
 "
-    - c:\msys64\usr\bin\pacman -Sy --noconfirm
-    - c:\msys64\usr\bin\pacman -S --noconfirm --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-make
+    - c:\msys64\usr\bin\pacman -Syu --noconfirm
+    - c:\msys64\usr\bin\pacman -Syyu --noconfirm --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-make
     - c:\msys64\usr\bin\pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-boost-1.64.0-3-any.pkg.tar.xz
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q -c conda-forge conda

--- a/appveyor-mingw.yml
+++ b/appveyor-mingw.yml
@@ -24,12 +24,14 @@ environment:
         - PYTHON_VERSION: 2.7
           MINICONDA: C:\Miniconda-x64
 
-          #cache:
+cache:
     # Cache MSYS2 packages to speed up builds. If version in repo changes, pacman will update it
-    # - c:\msys64\mingw64
-      # - c:\msys64\var\lib\pacman
-      #- C:\Miniconda36-x64\Lib\site-packages
-      #- C:\Miniconda-x64\Lib\site-packages
+    # These lines below are commented, because disable caching is hot fix,
+    # but generally it's a usefull function, and when we find solution, they can be uncommented
+    #- c:\msys64\mingw64
+    #- c:\msys64\var\lib\pacman
+    - C:\Miniconda36-x64\Lib\site-packages
+    - C:\Miniconda-x64\Lib\site-packages
 
 install:
     - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;C:\\msys64\\mingw64\\bin;C:\\Program Files\\7-Zip;%SystemRoot%\\system32;%SystemRoot%;%SystemRoot%\\System32\\Wbem;%SYSTEMROOT%\\System32\\WindowsPowerShell\\v1.0\\

--- a/docs/download.txt
+++ b/docs/download.txt
@@ -3,7 +3,7 @@ Downloads
 
 * **Windows**
 
-  * Latest 64 bit release: `BigARTM_v0.9.0_win64 <https://github.com/bigartm/bigartm/releases/download/v0.9.0/BigARTM_v0.9.0_win64.7z>`_
+  * Latest 64 bit release: `BigARTM_v0.10.0_win64 <https://github.com/bigartm/bigartm/releases/download/v0.10.0/BigARTM_v0.10.0_win64.7z>`_
   * Latest build from master branch: `BigARTM_master_win64.7z <https://ci.appveyor.com/api/projects/bigartm/bigartm/artifacts/BigARTM.7z?branch=master&job=Environment%3A%20PYTHON_VERSION%3D3.6%2C%20MINICONDA%3DC%3A%5CMiniconda36-x64>`_ (warning, use this with caution)
   * All previous releases are available at https://github.com/bigartm/bigartm/releases
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -134,7 +134,7 @@ class BinaryDistribution(Distribution):
 
 setup_kwargs = dict(
     name='bigartm',
-    version='0.9.0',
+    version='0.10.0',
     packages=find_packages(),
     install_requires=[
         'pandas',

--- a/src/artm/CMakeLists.txt
+++ b/src/artm/CMakeLists.txt
@@ -37,7 +37,7 @@ add_custom_target(proto_generation ALL
 
 # The version number
 set(ARTM_VERSION_MAJOR 0)
-set(ARTM_VERSION_MINOR 9)
+set(ARTM_VERSION_MINOR 10)
 set(ARTM_VERSION_PATCH 0)
 
 # configure a header file to pass some of the CMake settings

--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -767,10 +767,7 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
       num_threads = 1;
       LOG(INFO) << "CollectionParserConfig.num_threads is set to 1 (default)";
     } else {
-      // number of threads shouldn't be higher than maximal allowable number of open files in a process
-      // because else there could be a situation when all the threads are trying to dump it's own batch
-      // to the external storage
-      num_threads = std::min(n, cooc_collector.config_.max_num_of_open_files_in_a_process());
+      num_threads = n;
       LOG(INFO) << "CollectionParserConfig.num_threads is automatically set to " << num_threads;
     }
   } else {

--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -1,4 +1,4 @@
-// Copyright 2018, Additive Regularization of Topic Models.
+// Copyright 2019, Additive Regularization of Topic Models.
 
 #include "artm/core/collection_parser.h"
 

--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -734,7 +734,7 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
       }  // End of parsing the items of 1 batch
       if (collection_parser_config.gather_cooc() && !cooc_stat_holder.Empty()) {
         // This function saves gathered statistics to the external storage
-        // After saving to the wxternal storage statistics from all the batches needs to be merged
+        // After saving to the external storage statistics from all the batches needs to be merged
         // This is implemented in ReadAndMergeCooccurrenceBatches(), so the next step is to call this method
         // Sorting is needed before storing all pairs of tokens to the external storage
         // (it's for the future aggregation)

--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -656,8 +656,7 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
           weights.push_back(token_weight);
 
           if (collection_parser_config.gather_cooc()) {  // Co-occurence gathering starts here
-            //const ClassId first_token_class_id = class_ids[0];
-            const ClassId first_token_class_id = current_class_id;  // ToDo:
+            const ClassId first_token_class_id = current_class_id;
 
             int first_token_id = -1;
             if (collection_parser_config.has_vocab_file_path()) {
@@ -666,7 +665,7 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
               if (first_token_id == TOKEN_NOT_FOUND) {
                 continue;
               }
-            } else {  // ToDo (MichaelSolotky): continue the case if there is no vocab
+            } else {  // ToDo (MichaelSolotky): consider the case if there is no vocab
               BOOST_THROW_EXCEPTION(InvalidOperation("No vocab file specified. Can't gather co-occurrences"));
             }
 

--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -760,19 +760,21 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
     }
   };
 
-  int num_threads = collection_parser_config.num_threads();
+  int num_threads = 0;
   if (!collection_parser_config.has_num_threads() || collection_parser_config.num_threads() < 0) {
     int n = std::thread::hardware_concurrency();
     if (n == 0) {
-      LOG(INFO) << "CollectionParserConfig.num_threads is set to 1 (default)";
       num_threads = 1;
+      LOG(INFO) << "CollectionParserConfig.num_threads is set to 1 (default)";
     } else {
-      LOG(INFO) << "CollectionParserConfig.num_threads is automatically set to " << n;
       // number of threads shouldn't be higher than maximal allowable number of open files in a process
       // because else there could be a situation when all the threads are trying to dump it's own batch
       // to the external storage
-      num_threads = std::min(n, cooc_collector.config_.max_num_of_open_files_in_a_thread());
+      num_threads = std::min(n, cooc_collector.config_.max_num_of_open_files_in_a_process());
+      LOG(INFO) << "CollectionParserConfig.num_threads is automatically set to " << num_threads;
     }
+  } else {
+    num_threads = collection_parser_config.num_threads();
   }
 
   Helpers::CreateFolderIfNotExists(collection_parser_config.target_folder());

--- a/src/artm/core/cooccurrence_collector.cc
+++ b/src/artm/core/cooccurrence_collector.cc
@@ -316,7 +316,7 @@ void CooccurrenceCollector::FirstStageOfMerging() {
                                              num_of_documents_token_occurred_in_,
                                              config_);
     std::vector<std::shared_ptr<CooccurrenceBatch>> portion_of_batches;
-    // Stage 1: take i-th portion from 
+    // Stage 1: take i-th portion from pull of batches
     {
       std::unique_lock<std::mutex> vector_of_batches_access_lock(vector_of_batches_access_mutex_);
       for (int j = i * portion_size; j < (i + 1) * portion_size &&

--- a/src/artm/core/cooccurrence_collector.cc
+++ b/src/artm/core/cooccurrence_collector.cc
@@ -279,8 +279,7 @@ void CooccurrenceCollector::ReadAndMergeCooccurrenceBatches() {
   open_files_counter_ -= buffer_for_output_files.open_files_counter_;
 }
 
-// ToDo (MichaelSolotky): find out why it doesn't use the whole power of all the cores
-// and sometimes runs a long time with a single thread
+// ToDo (MichaelSolotky): remove batches after merging
 void CooccurrenceCollector::FirstStageOfMerging() {
   // Stage 1: merging portions of batches into intermediate batches
   // The strategy is the folowing: divide the vector of batches into as much buckets as it's possible

--- a/src/artm/core/cooccurrence_collector.cc
+++ b/src/artm/core/cooccurrence_collector.cc
@@ -30,6 +30,7 @@
 #include "artm/core/collection_parser.h"
 #include "artm/core/common.h"
 #include "artm/core/exceptions.h"
+#include "artm/core/token.h"
 
 namespace fs = boost::filesystem;
 
@@ -43,15 +44,14 @@ namespace core {
 // 4. read batches in some order and count co-occurrences (use method LoadBatches)
 // 4.a understand how to extract text from batches
 // 5. think how to specify ppmi and cooc output files
+// 6. remove mutexes somewhere and make the code faster (even with little mistakes in clalculations)
 
 // ToDo (MichaelSolotky): search for all bad-written parts of code with CLion
 
-// ****************************** Methods of class CooccurrenceCollector ******************************
+// ************************************ Methods of class CooccurrenceCollector ************************************
 
 CooccurrenceCollector::CooccurrenceCollector(
-      const CollectionParserConfig& collection_parser_config) : open_files_counter_(0),
-                                                                total_num_of_pairs_(0),
-                                                                total_num_of_documents_(0) {
+      const CollectionParserConfig& collection_parser_config) : open_files_counter_(0) {
   config_.set_gather_cooc(collection_parser_config.gather_cooc());
   if (config_.gather_cooc()) {
     config_.set_gather_cooc_tf(collection_parser_config.gather_cooc_tf());
@@ -96,10 +96,12 @@ CooccurrenceCollector::CooccurrenceCollector(
     config_.set_cooc_window_width(collection_parser_config.cooc_window_width());
     config_.set_cooc_min_tf(collection_parser_config.cooc_min_tf());
     config_.set_cooc_min_df(collection_parser_config.cooc_min_df());
+    config_.set_num_items_per_batch(collection_parser_config.num_items_per_batch());
+
     // This is the maximal allowable number. With larger values there are problems in Mac OS
     // (experimentally found)
-    config_.set_max_num_of_open_files(245);
-    config_.set_num_items_per_batch(collection_parser_config.num_items_per_batch());
+    const int max_num_of_open_files_in_a_process = 251;
+    config_.set_max_num_of_open_files_in_a_process(max_num_of_open_files_in_a_process);
 
     if (!collection_parser_config.has_num_threads() || collection_parser_config.num_threads() < 0) {
       unsigned int n = std::thread::hardware_concurrency();
@@ -111,11 +113,36 @@ CooccurrenceCollector::CooccurrenceCollector(
         config_.set_num_threads(n);
       }
     } else {
-      config_.set_num_threads(collection_parser_config.num_threads());
+      // In agglomerative merge a larger number of threads would be suboptimal
+      config_.set_num_threads(std::min(collection_parser_config.num_threads(),
+                                       max_num_of_open_files_in_a_process / 3));
     }
+
+    const int max_num_of_open_files_in_a_thread = max_num_of_open_files_in_a_process / config_.num_threads();
+    config_.set_max_num_of_open_files_in_a_thread(max_num_of_open_files_in_a_thread);
   }
 }
 
+std::string CooccurrenceCollector::MakeKeyForVocab(const std::string& token_str, const std::string& modality) const {
+  return vocab_.MakeKey(token_str, modality);
+}
+
+int CooccurrenceCollector::FindTokenIdInVocab(const std::string& token_str, const std::string& modality) {
+  std::unique_lock<std::mutex> vocab_access_lock(vocab_access_mutex_);
+  return vocab_.FindTokenId(token_str, modality);
+}
+
+Vocab::TokenModality CooccurrenceCollector::FindTokenStrInVocab(const int token_id) {
+  std::unique_lock<std::mutex> vocab_access_lock(vocab_access_mutex_);
+  return vocab_.FindTokenStr(token_id);
+}
+
+unsigned CooccurrenceCollector::VocabSize() {
+  std::unique_lock<std::mutex> vocab_access_lock(vocab_access_mutex_);
+  return vocab_.VocabSize();
+}
+
+// Note: the method is no longer used
 void CooccurrenceCollector::CreateAndSetTargetFolder() {
   boost::uuids::uuid uuid = boost::uuids::random_generator()();
   fs::path dir(boost::lexical_cast<std::string>(uuid));
@@ -135,154 +162,6 @@ std::string CooccurrenceCollector::CreateFileInBatchDir() const {
   fs::path file_local_path(boost::lexical_cast<std::string>(uuid));
   fs::path full_filename = fs::path(config_.target_folder()) / file_local_path;
   return full_filename.string();
-}
-
-unsigned CooccurrenceCollector::VocabSize() const {
-  return vocab_.token_map_.size();
-}
-
-void CooccurrenceCollector::ReadVowpalWabbit() {
-  // This function works as follows:
-  // 1. Acquire lock for reading from vowpal wabbit file
-  // 2. Read a portion (doc_per_cooc_batch) of documents from file and save it
-  // in a local buffer (vector<string>)
-  // 3. Release the lock
-  // 4. Cut every document into tokens.
-  // 5. Search for each pair of tokens in vocab dictionary and if they're valid (were found),
-  // calculate their co-occurrences (absolute and documental) and othen statistics
-  // for future pmi calculation (in how many pairs and documents a specific token occured,
-  // total number of documents and pairs in collection).
-  // Co-occurrence counters are stored in map of maps (on external level of indexing are first_token_id's
-  // and on internal second_token_id's)
-  // Statistics that refer to unique tokens is stored in vector called token_statistics_
-  // 6. For each potion of documents create a batch (class CooccurrenceBatch) with co-occurrence statistics
-  // Repeat 1-6 for all portions (can work in parallel for different portions)
-  std::shared_ptr<std::ifstream> vowpal_wabbit_doc_ptr(new std::ifstream(config_.vw_file_path(),
-                                                                         std::ios::in));
-  if (!vowpal_wabbit_doc_ptr->is_open()) {
-    BOOST_THROW_EXCEPTION(InvalidOperation("Failed to open vowpal wabbit file"));
-  }
-  std::shared_ptr<std::mutex> read_mutex_ptr(new std::mutex);
-  std::mutex token_statistics_access;
-  std::mutex total_num_of_documents_arg_access;
-  std::mutex total_num_of_pairs_arg_access;
-
-  auto func = [&read_mutex_ptr, &token_statistics_access, &total_num_of_documents_arg_access,
-               &total_num_of_pairs_arg_access, &vowpal_wabbit_doc_ptr, this]() {
-    int64_t local_num_of_pairs = 0;
-    while (true) {  // Loop throgh portions.
-      // Steps 1-3:
-      std::vector<std::string> portion = ReadPortionOfDocuments(read_mutex_ptr, vowpal_wabbit_doc_ptr);
-      if (portion.empty()) {
-        break;
-      }
-      {
-        std::unique_lock<std::mutex> lock(total_num_of_documents_arg_access);
-        total_num_of_documents_ += portion.size();  // statistics for ppmi
-      }
-      // It will hold tf and df of pairs of tokens
-      // Every pair of valid tokens (both exist in vocab) is saved in this storage
-      // After walking through portion of documents all the statistics is dumped on disk
-      // and then this storage is destroyed
-      CooccurrenceStatisticsHolder cooc_stat_holder;
-
-      // For every token from vocab keep the information about the last document this token occured in
-      std::vector<unsigned> num_of_last_document_token_occured(vocab_.token_map_.size());
-
-      // When the document is processed (element of portion vector),
-      // memory for it can be freed by calling pop_back() from vector
-      // (large string will be popped and destroyed)
-      // portion.size() can be used as doc_id (it will in method SavePairOfTokens)
-      for (; portion.size() != 0; portion.pop_back()) {  // Loop through documents. Step 4:
-        std::vector<std::string> doc;
-        boost::split(doc, portion.back(), boost::is_any_of(" \t\r"));
-        // Step 5.a) Start the loop through a document
-        // Loop from 1 because the zero-th element is document title
-        std::string first_token_modality = "|@default_class";  // That's how modalities are presented in vw
-        for (unsigned j = 1; j < doc.size(); ++j) {  // Loop through tokens in document
-          if (doc[j].empty()) {
-            continue;
-          }
-          if (doc[j][0] == '|') {
-            first_token_modality = doc[j];
-            continue;
-          }
-          // 5.b) Check if a token is valid
-          int first_token_id = vocab_.FindTokenId(doc[j], first_token_modality);
-          if (first_token_id == TOKEN_NOT_FOUND) {
-            continue;
-          }
-          // 5.c) Collect statistics for document ppmi (in how many documents every token occured)
-          // The array is initialized with zeros, so for every portion.size() it isn't equal to initial value
-          if (num_of_last_document_token_occured[first_token_id] != portion.size()) {
-            num_of_last_document_token_occured[first_token_id] = portion.size();
-            std::unique_lock<std::mutex> lock(token_statistics_access);
-            ++num_of_documents_token_occurred_in_[first_token_id];
-          }
-          // 5.d) Take windows_width tokens (parameter) to the right of the current one
-          // If there are some words beginnig on '|' in the text the window should be extended
-          // and it's extended using not_a_word_counter
-          std::string second_token_modality = first_token_modality;
-          unsigned not_a_word_counter = 0;
-          // Loop through tokens in the window
-          for (unsigned k = 1; k <= config_.cooc_window_width() + not_a_word_counter &&
-                               j + k < doc.size(); ++k) {
-            if (doc[j + k].empty()) {
-              continue;
-            }
-            if (doc[j + k][0] == '|') {
-              second_token_modality = doc[j + k];
-              ++not_a_word_counter;
-              continue;
-            }
-            if (first_token_modality != second_token_modality) {
-              continue;
-            }
-            int second_token_id = vocab_.FindTokenId(doc[j + k], second_token_modality);
-            if (second_token_id == TOKEN_NOT_FOUND) {
-              continue;
-            }
-            // 5.e) When it's known these 2 tokens are valid, remember their co-occurrence
-            // Here portion.size() is used to identify a document
-            // (it's unique id during one portion of documents)
-            if (config_.use_symetric_cooc()) {
-              if (first_token_id < second_token_id) {
-                cooc_stat_holder.SavePairOfTokens(first_token_id, second_token_id, portion.size());
-              } else if (first_token_id > second_token_id) {
-                cooc_stat_holder.SavePairOfTokens(second_token_id, first_token_id, portion.size());
-              } else {
-                cooc_stat_holder.SavePairOfTokens(first_token_id, first_token_id, portion.size(), 2);
-              }
-            } else {
-              cooc_stat_holder.SavePairOfTokens(first_token_id, second_token_id, portion.size());
-              cooc_stat_holder.SavePairOfTokens(second_token_id, first_token_id, portion.size());
-            }
-            local_num_of_pairs += 2;  // statistics for ppmi
-          }
-        }
-      }
-      if (!cooc_stat_holder.storage_.empty()) {
-        // This function saves gathered statistics on disk
-        // After saving on disk statistics from all the batches needs to be merged
-        // This is implemented in ReadAndMergeCooccurrenceBatches(),
-        // so the next step is to call this method
-        // Sorting is needed before storing all pairs of tokens on disk (it's for future agregation)
-        UploadOnDisk(cooc_stat_holder);
-      }
-    }
-    {
-      std::unique_lock<std::mutex> lock(total_num_of_pairs_arg_access);
-      total_num_of_pairs_ += local_num_of_pairs;
-    }
-  };
-  // Launch reading and storing pairs of tokens in parallel
-  std::vector<std::shared_future<void>> tasks;
-  for (int i = 0; i < config_.num_threads(); ++i) {
-    tasks.emplace_back(std::async(std::launch::async, func));
-  }
-  for (int i = 0; i < config_.num_threads(); ++i) {
-    tasks[i].get();
-  }
 }
 
 std::vector<std::string> CooccurrenceCollector::ReadPortionOfDocuments(
@@ -320,16 +199,21 @@ void CooccurrenceCollector::UploadOnDisk(const CooccurrenceStatisticsHolder& coo
     batch->WriteCell();
   }
   CloseBatchOutputFile(batch);
-  vector_of_batches_.push_back(std::move(batch));
+  {
+    std::unique_lock<std::mutex> vector_of_batches_access_lock(vector_of_batches_access_mutex_);
+    vector_of_batches_.push_back(std::move(batch));
+  }
 }
 
-CooccurrenceBatch* CooccurrenceCollector::CreateNewCooccurrenceBatch() const {
+CooccurrenceBatch* CooccurrenceCollector::CreateNewCooccurrenceBatch() {
+  std::unique_lock<std::mutex> target_dir_access_lock(target_dir_access_mutex_);
   return new CooccurrenceBatch(config_.target_folder());
 }
 
 void CooccurrenceCollector::OpenBatchOutputFile(std::shared_ptr<CooccurrenceBatch> batch) {
   if (!batch->out_batch_.is_open()) {
-    assert(open_files_counter_ < config_.max_num_of_open_files());
+    std::unique_lock<std::mutex> open_close_file_lock(open_close_file_mutex_);
+    assert(open_files_counter_ < config_.max_num_of_open_files_in_a_process());
     batch->out_batch_.open(batch->filename_, std::ios::out);
     if (!batch->out_batch_.is_open()) {
       BOOST_THROW_EXCEPTION(InvalidOperation(
@@ -341,6 +225,7 @@ void CooccurrenceCollector::OpenBatchOutputFile(std::shared_ptr<CooccurrenceBatc
 
 void CooccurrenceCollector::CloseBatchOutputFile(std::shared_ptr<CooccurrenceBatch> batch) {
   if (batch->out_batch_.is_open()) {
+    std::unique_lock<std::mutex> open_close_file_lock(open_close_file_mutex_);
     batch->out_batch_.close();
     if (batch->out_batch_.is_open()) {
       BOOST_THROW_EXCEPTION(InvalidOperation(
@@ -350,7 +235,7 @@ void CooccurrenceCollector::CloseBatchOutputFile(std::shared_ptr<CooccurrenceBat
   }
 }
 
-unsigned CooccurrenceCollector::CooccurrenceBatchesQuantity() const {
+unsigned CooccurrenceCollector::NumOfCooccurrenceBatches() const {
   return vector_of_batches_.size();
 }
 
@@ -372,43 +257,70 @@ void CooccurrenceCollector::ReadAndMergeCooccurrenceBatches() {
   // If there would be a need to calculate ppmi or other values which depend on co-occurrences
   // this data can be read back from output file.
 
-  std::cerr << "\nMerging co-occurrence batches" << std::endl;
+  std::cerr << "\nMerging co-occurrence batches. Stage 1: parallel agglomerative merge" << std::endl;
   // This magic constant isn't the best and can be set to another value found in experiments
   const unsigned min_num_of_batches_to_be_merged_in_parallel = 32;
-  while (vector_of_batches_.size() > min_num_of_batches_to_be_merged_in_parallel) {
+  while (NumOfCooccurrenceBatches() > min_num_of_batches_to_be_merged_in_parallel) {
     FirstStageOfMerging();  // number of files is decreasing here
   }
-  ResultingBufferOfCooccurrences res(vocab_, num_of_documents_token_occurred_in_, config_);
-  open_files_counter_ += res.open_files_in_buf_;
-  SecondStageOfMerging(&res, &vector_of_batches_);
-  res.CalculatePpmi();
+  // vocab will be coppyied here into buffer_for_output_files
+  BufferOfCooccurrences buffer_for_output_files(OUTPUT_FILE, vocab_, num_of_documents_token_occurred_in_, config_);
+  open_files_counter_ += buffer_for_output_files.open_files_counter_;
+  std::cerr << "Merging co-occurrence batches. Stage 2: sequential merge" << std::endl;
+  SecondStageOfMerging(&buffer_for_output_files, &vector_of_batches_);
+  buffer_for_output_files.CalculatePpmi();
+  open_files_counter_ -= buffer_for_output_files.open_files_counter_;
 }
 
 void CooccurrenceCollector::FirstStageOfMerging() {
   // Stage 1: merging portions of batches into intermediate batches
-  // Note: one thread should merge at least 2 files and have the third to write in
-  int num_of_threads = std::min(std::min(static_cast<int>(vector_of_batches_.size() / 2),
-                                         config_.max_num_of_open_files() / 3),
-                                config_.num_threads());
-
-  int portion_size = std::min(static_cast<int>(vector_of_batches_.size() / num_of_threads),
-                              (config_.max_num_of_open_files() - num_of_threads) / num_of_threads);
+  // The strategy is the folowing: divide the vector of batches into as much buckets as it's possible
+  // and gives advantages (the best case is 2 batches into each bucket, and all these batches are open
+  // simultaneously), then create several threads which will take a portion of batches, merge them,
+  // then a free thread will take another not-merged portion of batches and so on until
+  // there are no portions left. This procedure produces new batches, but their number is much lower
+  // then but their number is much smaller than those which were sent at the input,
+  // so it could be needed to run it again in order to make that number small enough
+  const int num_of_batches = static_cast<int>(vector_of_batches_.size());
+  // Let k be number of buckets in which all the batches will be divided
+  // Let n be total number of batches
+  // k ≤ upper bound of n / 2
+  const int upper_constraint_due_to_num_of_batches = num_of_batches / 2 + num_of_batches % 2;
+  // The procedure would be uneffective if there had been some buckets with at least 1 closed file,
+  // so there should be at least 3 open files in each bucket: 1 for writing and at least 2 merging files
+  const int upper_constraint_due_to_num_of_open_files = config_.max_num_of_open_files_in_a_thread() / 3;
+  const int optimal_num_of_threads = std::min(upper_constraint_due_to_num_of_batches,
+                                              upper_constraint_due_to_num_of_open_files);
+  int num_of_threads = optimal_num_of_threads;
+  // The real number of threads shouldn't be higher the than value set by the user of number of cores in computer
+  if (config_.has_num_threads() && config_.num_threads() > 0) {
+    num_of_threads = std::min(optimal_num_of_threads, config_.num_threads());
+  }
+  // 1 is subtracted here because 1 file will be needed for writing in it
+  const int optimal_portion_size = std::min(static_cast<int>(vector_of_batches_.size() / num_of_threads),
+                                            config_.max_num_of_open_files_in_a_thread() - 1);
+  // Portion size lower than 2 would lead to cycling or an error
+  const int portion_size = std::max(optimal_portion_size, 2);
 
   std::shared_ptr<std::mutex> open_close_file_mutex_ptr(new std::mutex);
 
   auto func = [&open_close_file_mutex_ptr, portion_size, this](int i) {  // Wrapper around KWayMerge
     std::shared_ptr<CooccurrenceBatch> batch(CreateNewCooccurrenceBatch());
     OpenBatchOutputFile(batch);
-    ResultingBufferOfCooccurrences intermediate_buffer(vocab_,
-                                                       num_of_documents_token_occurred_in_,
-                                                       config_);
+    // vocab will be coppied here into buffer_for_a_batch
+    BufferOfCooccurrences buffer_for_a_batch(BATCH, vocab_,
+                                             num_of_documents_token_occurred_in_,
+                                             config_);
     std::vector<std::shared_ptr<CooccurrenceBatch>> portion_of_batches;
-    // Stage 1: take i-th portion from vector_of_batches_
-    for (int j = i * portion_size; j < (i + 1) * portion_size &&
-                                   j < static_cast<int>(vector_of_batches_.size()); ++j) {
-      portion_of_batches.push_back(std::move(vector_of_batches_[j]));
+    // Stage 1: take i-th portion from 
+    {
+      std::unique_lock<std::mutex> vector_of_batches_access_lock(vector_of_batches_access_mutex_);
+      for (int j = i * portion_size; j < (i + 1) * portion_size &&
+                                     j < static_cast<int>(vector_of_batches_.size()); ++j) {
+        portion_of_batches.push_back(std::move(vector_of_batches_[j]));
+      }
     }
-    KWayMerge(&intermediate_buffer, BATCH, &portion_of_batches, batch, open_close_file_mutex_ptr);
+    KWayMerge(&buffer_for_a_batch, BATCH, &portion_of_batches, batch, open_close_file_mutex_ptr);
     CloseBatchOutputFile(batch);
     return batch;
   };
@@ -453,23 +365,25 @@ void CooccurrenceCollector::FirstStageOfMerging() {
   vector_of_batches_ = std::move(intermediate_batches);
 }
 
-void CooccurrenceCollector::SecondStageOfMerging(ResultingBufferOfCooccurrences* res,
+void CooccurrenceCollector::SecondStageOfMerging(BufferOfCooccurrences* buffer_for_output_files,
                                std::vector<std::shared_ptr<CooccurrenceBatch>>* intermediate_batches) {
   // Stage 2: merging of final batches (in single thread)
   std::shared_ptr<std::mutex> open_close_file_mutex_ptr(new std::mutex);
   // Note: the 4th arg is fake, it's not used later if mode == OUTPUT_FILE
-  KWayMerge(res, OUTPUT_FILE, intermediate_batches, (*intermediate_batches)[0], open_close_file_mutex_ptr);
+  KWayMerge(buffer_for_output_files, OUTPUT_FILE, intermediate_batches,
+            (*intermediate_batches)[0], open_close_file_mutex_ptr);
   // Files are explicitly closed here, because it's necesery to push the data in files on this step
   if (config_.gather_cooc_tf()) {
-    res->cooc_tf_dict_out_.close();
+    buffer_for_output_files->cooc_tf_dict_out_.close();
   }
   if (config_.gather_cooc_df()) {
-    res->cooc_df_dict_out_.close();
+    buffer_for_output_files->cooc_df_dict_out_.close();
   }
+  buffer_for_output_files->open_files_counter_ -= 2;
   open_files_counter_ -= 2;
 }
 
-void CooccurrenceCollector::KWayMerge(ResultingBufferOfCooccurrences* res, const int mode,
+void CooccurrenceCollector::KWayMerge(BufferOfCooccurrences* buffer, const int mode,
                                       std::vector<std::shared_ptr<CooccurrenceBatch>>* vector_of_input_batches_ptr,
                                       std::shared_ptr<CooccurrenceBatch> out_batch,
                                       std::shared_ptr<std::mutex> open_close_file_mutex_ptr) {
@@ -482,99 +396,81 @@ void CooccurrenceCollector::KWayMerge(ResultingBufferOfCooccurrences* res, const
   // 1. Initially first cells of all the batches are read in their buffers
   // 2. Then batches are sorted (std::make_heap) by first_token_id of the cell
   // 3. Then a cell with the lowest first_token_id is extaracted and put in
-  // resulting buffer and the next cell is read from corresponding batch
+  // buffer and the next cell is read from corresponding batch
   // 4. If the lowest first token id equals first token id of cell of this buffer, they are merged
   // else the current cell is written in file and the new one is loaded.
   // Writing and empting is done in order to keep low memory consumption
   // During execution of this function (if mode is OUTPUT_FILE) n_u is calculated and saved,
   // so after merge all the information needed to calculate ppmi will be gathered and
-  // available from class ResultingBufferOfCooccurrences
+  // available from class BufferOfCooccurrences
   // Note: here's only 1 way to communicate between threads - through open_files_counter
 
   // Step 1:
   std::vector<std::shared_ptr<CooccurrenceBatch>>& vector_of_input_batches = *vector_of_input_batches_ptr;
   auto iter = vector_of_input_batches.begin();
-  {  // Open all when it's possible
+  {  // Open all files and read the first cell
     std::unique_lock<std::mutex> open_close_file_lock(*open_close_file_mutex_ptr);
-    for (; iter != vector_of_input_batches.end() &&
-           open_files_counter_ < config_.max_num_of_open_files() - 1; ++iter) {
+    for (; iter != vector_of_input_batches.end(); ++iter) {
       OpenBatchInputFile(*iter);
       (*iter)->ReadCell();
     }
-  }
-  // Open and close when it's imposible to hold open all the files
-  for (; iter != vector_of_input_batches.end(); ++iter) {
-    std::unique_lock<std::mutex> open_close_file_lock(*open_close_file_mutex_ptr);
-    OpenBatchInputFile(*iter);
-    (*iter)->ReadCell();
-    CloseBatchInputFile(*iter);
   }
   // Step 2:
   std::make_heap(vector_of_input_batches.begin(), vector_of_input_batches.end(),
                  CooccurrenceBatch::CoocBatchComparator());
   if (!vector_of_input_batches.empty()) {
-    res->cell_ = Cell();
-    res->cell_.first_token_id = (*vector_of_input_batches[0]).cell_.first_token_id;
+    buffer->cell_ = Cell();
+    buffer->cell_.first_token_id = (*vector_of_input_batches[0]).cell_.first_token_id;
   }
   while (!vector_of_input_batches.empty()) {
     // Step 4:
-    if (res->cell_.first_token_id == (*vector_of_input_batches[0]).cell_.first_token_id) {
-      res->MergeWithExistingCell(*vector_of_input_batches[0]);
+    if (buffer->cell_.first_token_id == (*vector_of_input_batches[0]).cell_.first_token_id) {
+      buffer->MergeWithExistingCell(*vector_of_input_batches[0]);
     } else {
       if (mode == BATCH) {
-        out_batch->cell_ = res->cell_;
+        out_batch->cell_ = buffer->cell_;
         out_batch->WriteCell();
       } else if (mode == OUTPUT_FILE) {
         if (config_.calculate_ppmi_tf()) {
-          res->CalculateTFStatistics();
+          buffer->CalculateTFStatistics();
         }
         if (config_.gather_cooc_tf()) {
-          res->WriteCoocFromCell(TokenCoocFrequency, config_.cooc_min_tf());
+          buffer->WriteCoocFromCell(TokenCoocFrequency, config_.cooc_min_tf());
         }
         if (config_.gather_cooc_df()) {
-          res->WriteCoocFromCell(DocumentCoocFrequency, config_.cooc_min_df());
+          buffer->WriteCoocFromCell(DocumentCoocFrequency, config_.cooc_min_df());
         }
         // It's importants to set size = 0 after popping, because this value will be checked later
-        res->cell_.records.resize(0);
+        buffer->cell_.records.resize(0);
       }
-      res->cell_ = (*vector_of_input_batches[0]).cell_;
+      buffer->cell_ = (*vector_of_input_batches[0]).cell_;
     }
     // Step 3:
     std::pop_heap(vector_of_input_batches.begin(), vector_of_input_batches.end(),
                   CooccurrenceBatch::CoocBatchComparator());
-    if (!vector_of_input_batches.back()->in_batch_.is_open()) {
-      std::unique_lock<std::mutex> open_close_file_lock(*open_close_file_mutex_ptr);
-      OpenBatchInputFile(vector_of_input_batches.back());
-    }
     // if there are some data to read ReadCell reads it and returns true, else returns false
     if (vector_of_input_batches.back()->ReadCell()) {
-      if (open_files_counter_ == config_.max_num_of_open_files()) {
-        std::unique_lock<std::mutex> open_close_file_lock(*open_close_file_mutex_ptr);
-        CloseBatchInputFile(vector_of_input_batches.back());
-      }
       std::push_heap(vector_of_input_batches.begin(), vector_of_input_batches.end(),
                      CooccurrenceBatch::CoocBatchComparator());
     } else {
-      if (IsOpenBatchInputFile(*vector_of_input_batches.back())) {
-        std::unique_lock<std::mutex> open_close_file_lock(*open_close_file_mutex_ptr);
-        CloseBatchInputFile(vector_of_input_batches.back());
-      }
+      std::unique_lock<std::mutex> open_close_file_lock(*open_close_file_mutex_ptr);
+      CloseBatchInputFile(vector_of_input_batches.back());
       vector_of_input_batches.pop_back();
     }
   }
-  if (!res->cell_.records.empty()) {
+  if (!buffer->cell_.records.empty()) {
     if (mode == BATCH) {
-      out_batch->cell_ = res->cell_;
+      out_batch->cell_ = buffer->cell_;
       out_batch->WriteCell();
     } else if (mode == OUTPUT_FILE) {
       if (config_.calculate_ppmi_tf()) {
-        res->CalculateTFStatistics();
+        buffer->CalculateTFStatistics();
       }
       if (config_.gather_cooc_tf()) {
-        res->WriteCoocFromCell(TokenCoocFrequency, config_.cooc_min_tf());
+        buffer->WriteCoocFromCell(TokenCoocFrequency, config_.cooc_min_tf());
       }
       if (config_.gather_cooc_df()) {
-        res->WriteCoocFromCell(DocumentCoocFrequency, config_.cooc_min_df());
+        buffer->WriteCoocFromCell(DocumentCoocFrequency, config_.cooc_min_df());
       }
     }
   }
@@ -582,7 +478,8 @@ void CooccurrenceCollector::KWayMerge(ResultingBufferOfCooccurrences* res, const
 
 void CooccurrenceCollector::OpenBatchInputFile(std::shared_ptr<CooccurrenceBatch> batch) {
   if (!batch->in_batch_.is_open()) {
-    assert(open_files_counter_ < config_.max_num_of_open_files());
+    std::unique_lock<std::mutex> open_close_file_lock(open_close_file_mutex_);
+    assert(open_files_counter_ < config_.max_num_of_open_files_in_a_process());
     batch->in_batch_.open(batch->filename_, std::ios::in);
     if (!batch->in_batch_.is_open()) {
       BOOST_THROW_EXCEPTION(InvalidOperation(
@@ -600,6 +497,7 @@ bool CooccurrenceCollector::IsOpenBatchInputFile(const CooccurrenceBatch& batch)
 
 void CooccurrenceCollector::CloseBatchInputFile(std::shared_ptr<CooccurrenceBatch> batch) {
   if (batch->in_batch_.is_open()) {
+    std::unique_lock<std::mutex> open_close_file_lock(open_close_file_mutex_);
     batch->in_batch_offset_ = batch->in_batch_.tellg();
     batch->in_batch_.close();
     if (batch->in_batch_.is_open()) {
@@ -629,7 +527,7 @@ Vocab::Vocab(const std::string& path_to_vocab) {
     if (!strs[0].empty()) {
       std::string modality;
       if (strs.size() == 1) {
-        modality = "@default_class";  // Here is how modality is indicated in vocab file (without '|')
+        modality = DefaultClass;  // Here is how modality is indicated in vocab file (without '|')
       } else {
         int pos_of_modality = 1;
         for (; strs[pos_of_modality].empty(); ++pos_of_modality) { }
@@ -666,6 +564,10 @@ Vocab::TokenModality Vocab::FindTokenStr(const int token_id) const {
     return TokenModality();
   }
   return token_ref->second;
+}
+
+unsigned Vocab::VocabSize() const {
+  return token_map_.size();
 }
 
 // ****************************** Methods of class CooccurrenceStatisticsHolder ******************************
@@ -721,7 +623,6 @@ void CooccurrenceBatch::FormNewCell(const std::map<int, CooccurrenceStatisticsHo
   // Here is initialization of a new cell
   // A cell consists on first_token_id, number of records it includes
   // Then records go, every reord consists on second_token_id, cooc_tf, cooc_df
-
   cell_.first_token_id = cooc_stat_node->first;
   // while reading from file it's necessery to know how many records to read
   auto second_token_reference = cooc_stat_node->second.second_token_reference;
@@ -793,53 +694,63 @@ void CooccurrenceBatch::ReadRecords() {
   }
 }
 
-// **************************** Methods of class ResultingBufferOfCooccurrences ****************************
+// ********************************* Methods of class BufferOfCooccurrences *********************************
+
+// ToDo (MichaeSolotky): logic of this class isn't obvious, it would be cool to express thoughts clearer
 
 // The main purpose of this class is to store statistics of co-occurrences and some
-// variables calculated on base of them, perform that calculations, write that in file
-// resulting file and read from it.
+// variables calculated on base of them, perform that calculations, write that in
+// target file and read from it.
 // This class stores data in cells (special structure) before they are written in resulting files
 // A cell can from a batch can come in this buffer and be merged with current stored
 // (in case first_token_ids of cells are equal) or the current cell can be pushed from buffer in file
 // (in case first_token_ids aren't equal) and new cell takes place of the old one
-ResultingBufferOfCooccurrences::ResultingBufferOfCooccurrences(
-    const Vocab& vocab,
+// This buffer can be used for writing in a batch or in a target file (like file of co-occurrences
+// or file of pPMI), the target_ parameter is responsible for this, it can be either
+// OUTPUT_FILE or BATCH
+BufferOfCooccurrences::BufferOfCooccurrences(
+    const int target, const Vocab& vocab,
     const std::vector<unsigned>& num_of_documents_token_occurred_in,
-    const CooccurrenceCollectorConfig& config) : vocab_(vocab),
+    const CooccurrenceCollectorConfig& config) : target_(target), vocab_(vocab),
                       num_of_documents_token_occurred_in_(num_of_documents_token_occurred_in),
-                      open_files_in_buf_(0), config_(config) {
+                      open_files_counter_(0), config_(config) {
   num_of_pairs_token_occurred_in_.resize(vocab_.token_map_.size());
-  // ToDo (MichaelSolotky): make it easier to read
-  if (config_.has_gather_cooc_tf()) {  // It's important firstly to create file (open output file)
-    cooc_tf_dict_out_.open(config_.cooc_tf_file_path(), std::ios::out);
-    CheckOutputFile(cooc_tf_dict_out_, config_.cooc_tf_file_path());
-    cooc_tf_dict_in_.open(config_.cooc_tf_file_path(), std::ios::in);
-    CheckInputFile(cooc_tf_dict_in_, config_.cooc_tf_file_path());
-  }
-  if (config_.has_gather_cooc_df()) {
-    cooc_df_dict_out_.open(config_.cooc_df_file_path(), std::ios::out);
-    CheckOutputFile(cooc_df_dict_out_, config_.cooc_df_file_path());
-    cooc_df_dict_in_.open(config_.cooc_df_file_path(), std::ios::in);
-    CheckInputFile(cooc_df_dict_in_, config_.cooc_df_file_path());
-  }
-  if (config_.has_calculate_ppmi_tf()) {
-    ppmi_tf_dict_.open(config_.ppmi_tf_file_path(), std::ios::out);
-    CheckOutputFile(ppmi_tf_dict_, config_.ppmi_tf_file_path());
-  }
-  if (config_.has_calculate_ppmi_df()) {
-    ppmi_df_dict_.open(config_.ppmi_df_file_path(), std::ios::out);
-    CheckOutputFile(ppmi_df_dict_, config_.ppmi_df_file_path());
+  if (target_ == OUTPUT_FILE) {  // Open that files only if planning to write in them
+    if (config_.has_gather_cooc_tf()) {  // It's important firstly to create file (open output file)
+      cooc_tf_dict_out_.open(config_.cooc_tf_file_path(), std::ios::out);
+      CheckOutputFile(cooc_tf_dict_out_, config_.cooc_tf_file_path());
+      cooc_tf_dict_in_.open(config_.cooc_tf_file_path(), std::ios::in);
+      CheckInputFile(cooc_tf_dict_in_, config_.cooc_tf_file_path());
+      open_files_counter_ += 2;
+    }
+    if (config_.has_gather_cooc_df()) {
+      cooc_df_dict_out_.open(config_.cooc_df_file_path(), std::ios::out);
+      CheckOutputFile(cooc_df_dict_out_, config_.cooc_df_file_path());
+      cooc_df_dict_in_.open(config_.cooc_df_file_path(), std::ios::in);
+      CheckInputFile(cooc_df_dict_in_, config_.cooc_df_file_path());
+      open_files_counter_ += 2;
+    }
+    if (config_.has_calculate_ppmi_tf()) {
+      ppmi_tf_dict_.open(config_.ppmi_tf_file_path(), std::ios::out);
+      CheckOutputFile(ppmi_tf_dict_, config_.ppmi_tf_file_path());
+      ++open_files_counter_;
+    }
+    if (config_.has_calculate_ppmi_df()) {
+      ppmi_df_dict_.open(config_.ppmi_df_file_path(), std::ios::out);
+      CheckOutputFile(ppmi_df_dict_, config_.ppmi_df_file_path());
+      ++open_files_counter_;
+    }
   }
 }
 
-void ResultingBufferOfCooccurrences::CheckInputFile(const std::ifstream& file, const std::string& filename) {
+void BufferOfCooccurrences::CheckInputFile(const std::ifstream& file, const std::string& filename) {
   if (!file.good()) {
     BOOST_THROW_EXCEPTION(InvalidOperation("Failed to open input file " +
                                             filename + " in working directory"));
   }
 }
 
-void ResultingBufferOfCooccurrences::CheckOutputFile(const std::ofstream& file, const std::string& filename) {
+void BufferOfCooccurrences::CheckOutputFile(const std::ofstream& file, const std::string& filename) {
   if (!file.good()) {
     BOOST_THROW_EXCEPTION(InvalidOperation("Failed to open or create output file " +
                                             filename + " in working directory"));
@@ -847,15 +758,15 @@ void ResultingBufferOfCooccurrences::CheckOutputFile(const std::ofstream& file, 
 }
 
 // ToDo (MichaelSolotky): may be this can be implemented in more optimal way
-void ResultingBufferOfCooccurrences::MergeWithExistingCell(const CooccurrenceBatch& batch) {
+void BufferOfCooccurrences::MergeWithExistingCell(const CooccurrenceBatch& batch) {
   // All the data in buffer are stored in a cell, so here are rules of updating each cell
   // This function takes two vectors (one of the current cell and one which is stored in batch),
   // merges them in folowing way:
   // 1. If two elements of vector are different (different second token id),
   // stacks them one to another in ascending order
   // 2. It these two elemnts are equal, adds their cooc_tf and cooc_df and
-  // stores resulting cell with this parameters
-  // After merging resulting vector is sorted in ascending order
+  // stores fianl cell with this parameters
+  // After merging final vector is sorted in ascending order
   std::vector<CoocInfo> old_vector = cell_.records;
   cell_.records.resize(old_vector.size() + batch.cell_.records.size());
   auto fi_iter = old_vector.begin();
@@ -882,7 +793,7 @@ void ResultingBufferOfCooccurrences::MergeWithExistingCell(const CooccurrenceBat
   std::copy(se_iter, batch.cell_.records.end(), std::back_inserter(cell_.records));
 }
 
-void ResultingBufferOfCooccurrences::CalculateTFStatistics() {
+void BufferOfCooccurrences::CalculateTFStatistics() {
   // Calculate statistics of occurrence (of first token which is associated with current cell)
   int64_t n_u = 0;
   for (unsigned i = 0; i < cell_.records.size(); ++i) {
@@ -894,16 +805,16 @@ void ResultingBufferOfCooccurrences::CalculateTFStatistics() {
   num_of_pairs_token_occurred_in_[cell_.first_token_id] += n_u;
 }
 
-void ResultingBufferOfCooccurrences::WriteCoocFromCell(const std::string mode, const unsigned cooc_min) {
+void BufferOfCooccurrences::WriteCoocFromCell(const std::string mode, const unsigned cooc_min) {
   // This function takes a cell from buffer and writes data from cell in file
   // Output file format(s) are defined here
   // stringstream is used for fast bufferized i/o operations
   // Note: before writing in file all the information is stored in ram
   std::stringstream output_buf;
   bool no_cooc_found = true;
-  std::string prev_modality = "@default_class";
+  std::string prev_modality = DefaultClass;
   Vocab::TokenModality first_token = vocab_.FindTokenStr(cell_.first_token_id);
-  if (first_token.modality != "@default_class") {
+  if (first_token.modality != DefaultClass) {
     output_buf << '|' << first_token.modality << ' ';
     prev_modality = first_token.modality;
   }
@@ -929,7 +840,7 @@ void ResultingBufferOfCooccurrences::WriteCoocFromCell(const std::string mode, c
   }
 }
 
-void ResultingBufferOfCooccurrences::CalculatePpmi() {  // Wrapper around CalculateAndWritePpmi
+void BufferOfCooccurrences::CalculatePpmi() {  // Wrapper around CalculateAndWritePpmi
   std::cerr << "Calculating pPMI" << std::endl;
   if (config_.calculate_ppmi_tf()) {
     CalculateAndWritePpmi(TokenCoocFrequency, config_.total_num_of_pairs());
@@ -939,7 +850,7 @@ void ResultingBufferOfCooccurrences::CalculatePpmi() {  // Wrapper around Calcul
   }
 }
 
-void ResultingBufferOfCooccurrences::CalculateAndWritePpmi(const std::string mode, const long double n) {
+void BufferOfCooccurrences::CalculateAndWritePpmi(const std::string mode, const long double n) {
   // This function reads cooc file line by line, calculates ppmi and saves them in external file of ppmi
   // stringstream is used for fast bufferized i/o operations
   // Note: before writing in file all the information is stored in ram
@@ -1005,7 +916,7 @@ void ResultingBufferOfCooccurrences::CalculateAndWritePpmi(const std::string mod
   }
 }
 
-double ResultingBufferOfCooccurrences::GetTokenFreq(const std::string& mode, const int token_id) const {
+double BufferOfCooccurrences::GetTokenFreq(const std::string& mode, const int token_id) const {
   if (mode == TokenCoocFrequency) {
     return num_of_pairs_token_occurred_in_[token_id];
   } else {

--- a/src/artm/core/cooccurrence_collector.cc
+++ b/src/artm/core/cooccurrence_collector.cc
@@ -100,7 +100,11 @@ CooccurrenceCollector::CooccurrenceCollector(
 
     // This is the maximal allowable number. With larger values there are problems in Mac OS
     // (experimentally found)
-    const int max_num_of_open_files_in_a_process = 251;
+    int max_num_of_open_files_in_a_process = 251;
+    // The subtraction was done in order to run on all the machines
+    // Maybe in the other systems this limit is lower and without subtracion this code would crash
+    // (although it works on my MacOS Mojave 10.14.2)
+    max_num_of_open_files_in_a_process -= 10;
     config_.set_max_num_of_open_files_in_a_process(max_num_of_open_files_in_a_process);
 
     if (!collection_parser_config.has_num_threads() || collection_parser_config.num_threads() < 0) {

--- a/src/artm/core/cooccurrence_collector.h
+++ b/src/artm/core/cooccurrence_collector.h
@@ -26,7 +26,7 @@ namespace core {
 enum {
   TOKEN_NOT_FOUND = -1,
   BATCH = 0,
-  OUTPUT_FILE = 1,
+  OUTPUT_FILE = 1
 };
 
 struct CoocInfo {

--- a/src/artm/core/cooccurrence_collector.h
+++ b/src/artm/core/cooccurrence_collector.h
@@ -90,7 +90,7 @@ class CooccurrenceCollector {
   friend class CollectionParser;
  public:
   explicit CooccurrenceCollector(const CollectionParserConfig& config);
-  
+
   std::vector<std::string> ReadPortionOfDocuments(std::shared_ptr<std::mutex> read_lock,
                                                   std::shared_ptr<std::ifstream> vowpal_wabbit_doc_ptr);
   unsigned NumOfCooccurrenceBatches() const;

--- a/src/artm/core/cooccurrence_collector.h
+++ b/src/artm/core/cooccurrence_collector.h
@@ -26,7 +26,7 @@ namespace core {
 enum {
   TOKEN_NOT_FOUND = -1,
   BATCH = 0,
-  OUTPUT_FILE = 1
+  OUTPUT_FILE = 1,
 };
 
 struct CoocInfo {
@@ -59,11 +59,11 @@ class CooccurrenceCollector;
 class Vocab;
 class CooccurrenceStatisticsHolder;
 class CooccurrenceBatch;
-class ResultingBufferOfCooccurrences;
+class BufferOfCooccurrences;
 
 class Vocab {
   friend class CooccurrenceCollector;
-  friend class ResultingBufferOfCooccurrences;
+  friend class BufferOfCooccurrences;
   friend class CollectionParser;
  public:
   struct TokenModality {
@@ -80,34 +80,38 @@ class Vocab {
   std::string MakeKey(const std::string& token_str, const std::string& modality) const;
   int FindTokenId(const std::string& token_str, const std::string& modality) const;
   TokenModality FindTokenStr(const int token_id) const;
+  unsigned VocabSize() const;
 
-  std::unordered_map<std::string, int> token_map_;  // token|modality -> token_id
-  std::unordered_map<int, TokenModality> inverse_token_map_;  // token_id -> (token, modality)
+  std::unordered_map<std::string, int> token_map_;  // "token|modality" -> token_id (str -> int)
+  std::unordered_map<int, TokenModality> inverse_token_map_;  // token_id -> ("token", "modality") (int -> strs)
 };
 
 class CooccurrenceCollector {
   friend class CollectionParser;
  public:
   explicit CooccurrenceCollector(const CollectionParserConfig& config);
-  unsigned VocabSize() const;
-  void ReadVowpalWabbit();
+  
   std::vector<std::string> ReadPortionOfDocuments(std::shared_ptr<std::mutex> read_lock,
                                                   std::shared_ptr<std::ifstream> vowpal_wabbit_doc_ptr);
-  unsigned CooccurrenceBatchesQuantity() const;
+  unsigned NumOfCooccurrenceBatches() const;
   void ReadAndMergeCooccurrenceBatches();
 
  private:
+  std::string MakeKeyForVocab(const std::string& token_str, const std::string& modality) const;
+  int FindTokenIdInVocab(const std::string& token_str, const std::string& modality);
+  Vocab::TokenModality FindTokenStrInVocab(const int token_id);
+  unsigned VocabSize();
   void CreateAndSetTargetFolder();
   std::string CreateFileInBatchDir() const;
   void UploadOnDisk(const CooccurrenceStatisticsHolder& cooc_stat_holder);
   void FirstStageOfMerging();
-  void SecondStageOfMerging(ResultingBufferOfCooccurrences* res,
+  void SecondStageOfMerging(BufferOfCooccurrences* res,
                             std::vector<std::shared_ptr<CooccurrenceBatch>>* intermediate_batches);
-  void KWayMerge(ResultingBufferOfCooccurrences* res, const int mode,
+  void KWayMerge(BufferOfCooccurrences* res, const int mode,
                  std::vector<std::shared_ptr<CooccurrenceBatch>>* vector_of_batches_ptr,
                  std::shared_ptr<CooccurrenceBatch> out_batch,
                  std::shared_ptr<std::mutex> open_close_file_mutex_ptr);
-  CooccurrenceBatch* CreateNewCooccurrenceBatch() const;
+  CooccurrenceBatch* CreateNewCooccurrenceBatch();
   void OpenBatchInputFile(std::shared_ptr<CooccurrenceBatch> batch);
   void OpenBatchOutputFile(std::shared_ptr<CooccurrenceBatch> batch);
   bool IsOpenBatchInputFile(const CooccurrenceBatch& batch) const;
@@ -115,11 +119,13 @@ class CooccurrenceCollector {
   void CloseBatchOutputFile(std::shared_ptr<CooccurrenceBatch> batch);
 
   Vocab vocab_;  // Holds mapping tokens to their indices
-  std::vector<unsigned> num_of_documents_token_occurred_in_;  // index is token_id
+  std::vector<unsigned> num_of_documents_token_occurred_in_;  // the index here is token_id
   std::vector<std::shared_ptr<CooccurrenceBatch>> vector_of_batches_;
   int open_files_counter_;
-  int64_t total_num_of_pairs_;
-  unsigned total_num_of_documents_;
+  std::mutex open_close_file_mutex_;
+  std::mutex vocab_access_mutex_;
+  std::mutex vector_of_batches_access_mutex_;
+  std::mutex target_dir_access_mutex_;
   CooccurrenceCollectorConfig config_;
 };
 
@@ -155,9 +161,10 @@ struct CooccurrenceStatisticsHolder::SecondTokenAndCooccurrence {
 // Cooccurrence Batch is an intermidiate buffer between other data in RAM and
 // a spesific file stored on disc. This buffer holds only one cell at a time.
 // Also it's a wrapper around a ifstream and ofstream of an external file
+// Co-occurrence batch can be created only by a special method of class CooccurrenceCollector
 class CooccurrenceBatch: private boost::noncopyable {
   friend class CooccurrenceCollector;
-  friend class ResultingBufferOfCooccurrences;
+  friend class BufferOfCooccurrences;
  public:
   struct CoocBatchComparator;
   void FormNewCell(const std::map<int, CooccurrenceStatisticsHolder::FirstToken>::const_iterator& cooc_stat_node);
@@ -183,15 +190,15 @@ struct CooccurrenceBatch::CoocBatchComparator {
   }
 };
 
-class ResultingBufferOfCooccurrences {
+class BufferOfCooccurrences {
   friend class CooccurrenceCollector;
  public:
   void CalculatePpmi();
 
  private:
-  ResultingBufferOfCooccurrences(const Vocab& vocab,
-                                 const std::vector<unsigned>& num_of_documents_token_occurred_in_,
-                                 const CooccurrenceCollectorConfig& config);
+  BufferOfCooccurrences(const int target, const Vocab& vocab,
+                        const std::vector<unsigned>& num_of_documents_token_occurred_in_,
+                        const CooccurrenceCollectorConfig& config);
   void CheckInputFile(const std::ifstream& file, const std::string& filename);
   void CheckOutputFile(const std::ofstream& file, const std::string& filename);
   void MergeWithExistingCell(const CooccurrenceBatch& batch);
@@ -201,16 +208,17 @@ class ResultingBufferOfCooccurrences {
   void CalculateAndWritePpmi(const std::string mode, const long double n);
   double GetTokenFreq(const std::string& mode, const int token_id) const;
 
+  const int target_;  // can be either OUTPUT_FILE or BATCH
   const Vocab& vocab_;  // Holds mapping tokens to their indices
   const std::vector<unsigned>& num_of_documents_token_occurred_in_;
   std::vector<int64_t> num_of_pairs_token_occurred_in_;
-  int open_files_in_buf_;
   std::ifstream cooc_tf_dict_in_;
   std::ofstream cooc_tf_dict_out_;
   std::ifstream cooc_df_dict_in_;
   std::ofstream cooc_df_dict_out_;
   std::ofstream ppmi_tf_dict_;
   std::ofstream ppmi_df_dict_;
+  int open_files_counter_;
   Cell cell_;
   CooccurrenceCollectorConfig config_;
 };

--- a/src/artm/core/cooccurrence_collector.h
+++ b/src/artm/core/cooccurrence_collector.h
@@ -1,4 +1,4 @@
-// Copyright 2018, Additive Regularization of Topic Models.
+// Copyright 2019, Additive Regularization of Topic Models.
 
 #pragma once
 

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -534,7 +534,7 @@ message CooccurrenceCollectorConfig {
   optional int32 cooc_min_df = 16 [default = 1];
   optional int32 max_num_of_open_files = 17;
   optional int32 num_items_per_batch = 18 [default = 1000];
-  optional int32 num_of_cpu = 19;
+  optional int32 num_threads = 19;
   optional int64 total_num_of_pairs = 20;
   optional int32 total_num_of_documents = 21;
   repeated string class_id = 22;

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -532,12 +532,13 @@ message CooccurrenceCollectorConfig {
   optional int32 cooc_window_width = 14 [default = 10];
   optional int32 cooc_min_tf = 15 [default = 1];
   optional int32 cooc_min_df = 16 [default = 1];
-  optional int32 max_num_of_open_files = 17;
+  optional int32 max_num_of_open_files_in_a_thread = 17;
   optional int32 num_items_per_batch = 18 [default = 1000];
   optional int32 num_threads = 19;
   optional int64 total_num_of_pairs = 20;
   optional int32 total_num_of_documents = 21;
   repeated string class_id = 22;
+  optional int32 max_num_of_open_files_in_a_process = 23;
 }
 
 // Represents an argument of 'initialize model' operation

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -1,4 +1,4 @@
-// Copyright 2018, Additive Regularization of Topic Models.
+// Copyright 2019, Additive Regularization of Topic Models.
 
 #include <stdlib.h>
 

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -1112,6 +1112,8 @@ class BatchVectorizer {
           collection_parser_config.set_vocab_file_path(options_.read_uci_vocab);
         }
 
+        collection_parser_config.set_num_threads(options_.threads);
+
         collection_parser_config.set_target_folder(batch_folder_);
         collection_parser_config.set_num_items_per_batch(options_.batch_size);
         collection_parser_config.set_name_type(options_.b_guid_batch_name ? CollectionParserConfig_BatchNameType_Guid : CollectionParserConfig_BatchNameType_Code);


### PR DESCRIPTION
Major changes:
1) The command line key "--threads" didn't affect parsing of a collection, because it hasn't been sending in collection parsing config (fixed).
2) Added mutexes places of access to shared resources like paths to co-occurrence batches in the target dir and token map.
3) Set more correct maximal number of files that a process is allowed to hold open simultaneously (my experiments with MacOS showed that this number is about 251 files, it's a pity, but I couldn't find any purpose of that. A process was just refusing to open any more files after exceeding this limit and no exceptions had been throwing, the program was finishing correctly, but with the wrong output). Also, I didn't use the value 251, but 241 in order to prevent crashes on other platforms.
4) Explicitly limit the number of parallel threads in merging of co-occurrence batches (if it would be greater than maximal number of open files / 3, that would be ineffective, because in merging frequent opens and closes of files will be needed, but it's an expensive operation
5) Initialize uninitialized variables in BufferOfCooccurrences
6) Make vocab parsing more powerful (now it can parse files with commas that divide tokens and modalities)
7) Fixed determination of current modality in text
8) Fixed one more trouble with AppVeyor-mingw that suddenly appeared: due to caching of some packages one of them couldn't be upgraded. The installation process was trying to create a dir with a special name "/var/lib/pacman/local/msys2-runtime-2.11.2-1/" which existed due to caching. More details you can find here: https://ci.appveyor.com/project/bigartm/bigartm-542mi/builds/22092938/job/scnqe4nle8fn3eto
9) Bump version to 0.10.0 due to the bug-fix and no interface change

Minor changes:
1) Renamed some variables in order to better represent their sense (like config_ -> collection_parser_config_ since there is a co-occurrence collector config, ResultingBufferOfCooccurrences -> BufferOfCooccurrences since this buffer can be used as intermediate storage)
2) Corrected some grammatical mistakes in comments
3) Removed the function CooccurrenceCollector::ReadVowpalWabbit since it's not used, instead, the function from the collection_parser is used to read and parse VowpalWabbit files
4) Rewrote more clearly the function CooccurrenceCollector::FirstStageOfMerging with lots of comments
5) Removed rudiments of opening-closing files during the KWayMerge procedure