### PR TITLE
Fix readthedocs builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ sys.path.insert(0, os.path.abspath('../python'))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.4.3'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 protobuf==3.0.0
+Sphinx>=1.4.3


### PR DESCRIPTION
Readthedocs builds are failing as follows:
```
Extension error:
Could not import extension sphinx.ext.pngmath (exception: No module named pngmath)
```
Trying the solution described here:
https://github.com/rtfd/readthedocs.org/issues/2418