### PR TITLE
change vocab parsing rule with commas

### DIFF
--- a/src/artm/core/cooccurrence_collector.cc
+++ b/src/artm/core/cooccurrence_collector.cc
@@ -558,7 +558,8 @@ Vocab::Vocab(const std::string& path_to_vocab) {
           break;
         }
       }
-      strs[i] = curr_str.substr(begin_ind, end_ind + 1 - begin_ind);
+      curr_str = curr_str.substr(begin_ind, end_ind + 1 - begin_ind);
+      strs[i] = curr_str;
       if (!curr_str.empty()) {
         if (token.empty()) {
           token = curr_str;


### PR DESCRIPTION
There's a small important change that is going to help people use the co-occurrence collector. There can be tokens in some tasks that contain commas inside themselves and they shouldn't be split up in cases if there are no delimiters like ' ',  '\t',  '\n' near the comma.