### PR TITLE
 add store-symeric-cooc flag 

### DIFF
--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -708,7 +708,7 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
                 BOOST_THROW_EXCEPTION(InvalidOperation("No vocab file specified. Can't gather co-occurrences"));
               }
 
-              if (cooc_collector.config_.store_symetric_cooc_values()) {
+              if (cooc_collector.config_.store_symmetric_cooc_values()) {
                 if (first_token_id < second_token_id) {
                   cooc_stat_holder.SavePairOfTokens(first_token_id, second_token_id, str_index);
                 } else if (first_token_id > second_token_id) {

--- a/src/artm/core/collection_parser.cc
+++ b/src/artm/core/collection_parser.cc
@@ -708,7 +708,7 @@ CollectionParserInfo CollectionParser::ParseVowpalWabbit() {
                 BOOST_THROW_EXCEPTION(InvalidOperation("No vocab file specified. Can't gather co-occurrences"));
               }
 
-              if (cooc_collector.config_.use_symetric_cooc()) {
+              if (cooc_collector.config_.store_symetric_cooc_values()) {
                 if (first_token_id < second_token_id) {
                   cooc_stat_holder.SavePairOfTokens(first_token_id, second_token_id, str_index);
                 } else if (first_token_id > second_token_id) {

--- a/src/artm/core/cooccurrence_collector.cc
+++ b/src/artm/core/cooccurrence_collector.cc
@@ -56,7 +56,7 @@ CooccurrenceCollector::CooccurrenceCollector(
   if (config_.gather_cooc()) {
     config_.set_gather_cooc_tf(collection_parser_config.gather_cooc_tf());
     config_.set_gather_cooc_df(collection_parser_config.gather_cooc_df());
-    config_.set_use_symetric_cooc(true);
+    config_.set_store_symetric_cooc_values(collection_parser_config.store_symetric_cooc_values());
     config_.set_vw_file_path(collection_parser_config.docword_file_path());
 
     if (collection_parser_config.has_vocab_file_path()) {
@@ -809,7 +809,7 @@ void BufferOfCooccurrences::CalculateTFStatistics() {
   // Calculate statistics of occurrence (of first token which is associated with current cell)
   int64_t n_u = 0;
   for (unsigned i = 0; i < cell_.records.size(); ++i) {
-    if (config_.use_symetric_cooc() && cell_.first_token_id != cell_.records[i].second_token_id) {
+    if (config_.store_symetric_cooc_values() && cell_.first_token_id != cell_.records[i].second_token_id) {
       num_of_pairs_token_occurred_in_[cell_.records[i].second_token_id] += cell_.records[i].cooc_tf;
     }  // pairs <u u> have double weight so in symetric case they should be taken once
     n_u += cell_.records[i].cooc_tf;

--- a/src/artm/core/cooccurrence_collector.cc
+++ b/src/artm/core/cooccurrence_collector.cc
@@ -56,7 +56,7 @@ CooccurrenceCollector::CooccurrenceCollector(
   if (config_.gather_cooc()) {
     config_.set_gather_cooc_tf(collection_parser_config.gather_cooc_tf());
     config_.set_gather_cooc_df(collection_parser_config.gather_cooc_df());
-    config_.set_store_symetric_cooc_values(collection_parser_config.store_symetric_cooc_values());
+    config_.set_store_symmetric_cooc_values(collection_parser_config.store_symmetric_cooc_values());
     config_.set_vw_file_path(collection_parser_config.docword_file_path());
 
     if (collection_parser_config.has_vocab_file_path()) {
@@ -809,9 +809,9 @@ void BufferOfCooccurrences::CalculateTFStatistics() {
   // Calculate statistics of occurrence (of first token which is associated with current cell)
   int64_t n_u = 0;
   for (unsigned i = 0; i < cell_.records.size(); ++i) {
-    if (config_.store_symetric_cooc_values() && cell_.first_token_id != cell_.records[i].second_token_id) {
+    if (config_.store_symmetric_cooc_values() && cell_.first_token_id != cell_.records[i].second_token_id) {
       num_of_pairs_token_occurred_in_[cell_.records[i].second_token_id] += cell_.records[i].cooc_tf;
-    }  // pairs <u u> have double weight so in symetric case they should be taken once
+    }  // pairs <u u> have double weight so in symmetric case they should be taken once
     n_u += cell_.records[i].cooc_tf;
   }
   num_of_pairs_token_occurred_in_[cell_.first_token_id] += n_u;

--- a/src/artm/core/dictionary_operations.cc
+++ b/src/artm/core/dictionary_operations.cc
@@ -421,7 +421,7 @@ std::shared_ptr<Dictionary> DictionaryOperations::Gather(const GatherDictionaryA
                                                     strs[pos_of_first_token][0] == '|'); ++pos_of_first_token) {
           if (!strs[pos_of_first_token].empty()) {
             first_token_class_id = strs[pos_of_first_token];
-            first_token_class_id.erase(0);
+            first_token_class_id.erase(0, 1);
           }
         }
         if (pos_of_first_token >= strs.size()) {
@@ -443,7 +443,7 @@ std::shared_ptr<Dictionary> DictionaryOperations::Gather(const GatherDictionaryA
                                                           ++not_a_word_counter) {
             if (!strs[i + not_a_word_counter].empty()) {
               second_token_class_id = strs[i + not_a_word_counter];
-              second_token_class_id.erase(0);
+              second_token_class_id.erase(0, 1);
             }
           }
           if (i + not_a_word_counter + 1 >= strs.size()) {

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -503,6 +503,7 @@ message CollectionParserConfig {
   optional int32 cooc_window_width = 17 [default = 10];
   optional int32 cooc_min_tf = 18 [default = 1];
   optional int32 cooc_min_df = 19 [default = 1];
+  optional bool store_symetric_cooc_values = 20 [default = false];
 }
 
 // Misc statistics produced by collection parser
@@ -519,7 +520,7 @@ message CooccurrenceCollectorConfig {
   optional bool gather_cooc = 1;
   optional bool gather_cooc_tf = 2;
   optional bool gather_cooc_df = 3;
-  optional bool use_symetric_cooc = 4;
+  optional bool store_symetric_cooc_values = 4;
   optional bool calculate_ppmi_tf = 5;
   optional bool calculate_ppmi_df = 6;
   optional string vw_file_path = 7;

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -503,7 +503,7 @@ message CollectionParserConfig {
   optional int32 cooc_window_width = 17 [default = 10];
   optional int32 cooc_min_tf = 18 [default = 1];
   optional int32 cooc_min_df = 19 [default = 1];
-  optional bool store_symetric_cooc_values = 20 [default = false];
+  optional bool store_symmetric_cooc_values = 20 [default = false];
 }
 
 // Misc statistics produced by collection parser
@@ -520,7 +520,7 @@ message CooccurrenceCollectorConfig {
   optional bool gather_cooc = 1;
   optional bool gather_cooc_tf = 2;
   optional bool gather_cooc_df = 3;
-  optional bool store_symetric_cooc_values = 4;
+  optional bool store_symmetric_cooc_values = 4;
   optional bool calculate_ppmi_tf = 5;
   optional bool calculate_ppmi_df = 6;
   optional string vw_file_path = 7;

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -271,7 +271,7 @@ struct artm_options {
   int cooc_window;
   int cooc_min_df;
   int cooc_min_tf;
-  bool store_symetric_cooc_values;
+  bool store_symmetric_cooc_values;
 
   // Model
   std::string load_model;
@@ -1143,7 +1143,7 @@ class BatchVectorizer {
         collection_parser_config.set_cooc_window_width(options_.cooc_window);
         collection_parser_config.set_cooc_min_tf(options_.cooc_min_tf);
         collection_parser_config.set_cooc_min_df(options_.cooc_min_df);
-        collection_parser_config.set_store_symetric_cooc_values(options_.store_symetric_cooc_values);
+        collection_parser_config.set_store_symmetric_cooc_values(options_.store_symmetric_cooc_values);
 
         // If user specifies specific modalities "use_modality", pass it to collection parser to limit set of modalities available in batches
         std::vector<std::pair<std::string, float>> class_ids = parseKeyValuePairs<float>(options_.use_modality);
@@ -1770,7 +1770,7 @@ int main(int argc, char * argv[]) {
       ("cooc-window", po::value(&options.cooc_window)->default_value(5), "number of tokens around specific token, which are used in calculation of cooccurrences")
       ("dictionary-min-df", po::value(&options.dictionary_min_df)->default_value(""), "filter out tokens present in less than N documents / less than P% of documents")
       ("dictionary-max-df", po::value(&options.dictionary_max_df)->default_value(""), "filter out tokens present in less than N documents / less than P% of documents")
-      ("store-symetric-cooc", po::bool_switch(&options.store_symetric_cooc_values)->default_value(false), "to not write repeating pairs in co-occurrence dictionary, like if the pair (token_a, token_b) is written, to not write the pair (token_b, token_a)")
+      ("store-symmetric-cooc", po::bool_switch(&options.store_symmetric_cooc_values)->default_value(false), "to not write repeating pairs in co-occurrence dictionary, like if the pair (token_a, token_b) is written, to not write the pair (token_b, token_a)")
       ("dictionary-size", po::value(&options.dictionary_size)->default_value(0), "limit dictionary size by filtering out tokens with high document frequency")
       ("use-dictionary", po::value(&options.use_dictionary)->default_value(""), "filename of binary dictionary file to use")
     ;

--- a/src/bigartm/srcmain.cc
+++ b/src/bigartm/srcmain.cc
@@ -271,6 +271,7 @@ struct artm_options {
   int cooc_window;
   int cooc_min_df;
   int cooc_min_tf;
+  bool store_symetric_cooc_values;
 
   // Model
   std::string load_model;
@@ -1142,6 +1143,7 @@ class BatchVectorizer {
         collection_parser_config.set_cooc_window_width(options_.cooc_window);
         collection_parser_config.set_cooc_min_tf(options_.cooc_min_tf);
         collection_parser_config.set_cooc_min_df(options_.cooc_min_df);
+        collection_parser_config.set_store_symetric_cooc_values(options_.store_symetric_cooc_values);
 
         // If user specifies specific modalities "use_modality", pass it to collection parser to limit set of modalities available in batches
         std::vector<std::pair<std::string, float>> class_ids = parseKeyValuePairs<float>(options_.use_modality);
@@ -1768,6 +1770,7 @@ int main(int argc, char * argv[]) {
       ("cooc-window", po::value(&options.cooc_window)->default_value(5), "number of tokens around specific token, which are used in calculation of cooccurrences")
       ("dictionary-min-df", po::value(&options.dictionary_min_df)->default_value(""), "filter out tokens present in less than N documents / less than P% of documents")
       ("dictionary-max-df", po::value(&options.dictionary_max_df)->default_value(""), "filter out tokens present in less than N documents / less than P% of documents")
+      ("store-symetric-cooc", po::bool_switch(&options.store_symetric_cooc_values)->default_value(false), "to not write repeating pairs in co-occurrence dictionary, like if the pair (token_a, token_b) is written, to not write the pair (token_b, token_a)")
       ("dictionary-size", po::value(&options.dictionary_size)->default_value(0), "limit dictionary size by filtering out tokens with high document frequency")
       ("use-dictionary", po::value(&options.use_dictionary)->default_value(""), "filename of binary dictionary file to use")
     ;


### PR DESCRIPTION
There should be a flag available from CLI that allows writing co-occurrences in vowpal wabbit format in 2 different ways:
1) to not store the pair (token_b, token_a) if the pair (token_a, token_b) is stored (store-symeric-cooc is true)
2) to store all the pairs (store-symeric-cooc is false)
Now there's no such flag and value use_symetric_cooc is hardcoded in true