### PR TITLE
ARTM_model.load() crashes due to transactions

### DIFF
--- a/python/artm/artm_model.py
+++ b/python/artm/artm_model.py
@@ -716,9 +716,10 @@ class ARTM(object):
         self._class_ids = class_ids
 
         if hasattr(config, 'transaction_typename'):
+            transaction_typenames = {}
             for transaction_typename in config.transaction_typename:
                 transaction_typenames[transaction_typename] = 1.0
-        self._transaction_typenames = transaction_typenames
+            self._transaction_typenames = transaction_typenames
 
         # Remove all info about previous iterations
         self._score_tracker = {}


### PR DESCRIPTION
@MelLain does it look OK?
Currently "ARTM.load()" fails because ``transaction_typenames`` variable does not exist.