### PR TITLE
Change base class for ArtmException

### DIFF
--- a/python/artm/wrapper/exceptions.py
+++ b/python/artm/wrapper/exceptions.py
@@ -10,7 +10,7 @@ ARTM_STILL_WORKING = -1
 # TODO: add docstrings
 
 
-class ArtmException(BaseException):
+class ArtmException(Exception):
     pass
 
 


### PR DESCRIPTION
The accepted practice for user-defined exceptions is to inherit
Exception class, not BaseException.

Currently, the Python code which tries to handle errors fails to catch
any ArtmException.