### PR TITLE
Fix missing terms in `load_artm_model`

### DIFF
--- a/src/artm/core/master_component.cc
+++ b/src/artm/core/master_component.cc
@@ -473,9 +473,12 @@ void MasterComponent::ImportModel(const ImportModelArgs& args) {
     }
 
     topic_model.set_name(args.model_name());
-    target = std::make_shared<DensePhiMatrix>(args.model_name(),
-                                              topic_model.topic_name(),
-                                              instance_->config()->min_sparsity_rate());
+    if (target == nullptr){
+      target = std::make_shared<DensePhiMatrix>(args.model_name(),
+                                                topic_model.topic_name(),
+                                                instance_->config()->min_sparsity_rate());
+    }
+
 
     PhiMatrixOperations::ApplyTopicModelOperation(topic_model, 1.0f, /* add_missing_tokens = */ true, target.get());
   }


### PR DESCRIPTION
Fix https://github.com/bigartm/bigartm/issues/984
Probably fix https://github.com/bigartm/bigartm/issues/953 too

## Problem description

ARTM splitting large phi matrix to several partitions in `dump_artm_model` -> `MasterComponent::ExportModel` (by protobuf size limitation I guess).
In `load_artm_model` -> `MasterComponent::ImportModel`, `DensePhiMatrix` re-created for every partition, for this reason, instead of full phi matrix, artm load only last partition.

## Solution

Just don't re-create `DensePhiMatrix`, init them only once (and "modify" on every new partition)