### PR TITLE
Add topic names for coherence scores (fix #1016)

### DIFF
--- a/python/artm/score_tracker.py
+++ b/python/artm/score_tracker.py
@@ -190,7 +190,9 @@ _set_properties(TopTokensScoreTracker, {'num_tokens': {'proto_name': 'num_entrie
                                                    'proto_qualifier': 'repeated'},
                                         'weights': {'proto_name': 'weight',
                                                     'proto_qualifier': 'repeated'},
-                                        'coherence': {'proto_type': 'array'},
+                                        'coherence': {'proto_type': 'array',
+                                                      'key_field_name': 'coherence_topic_name'},
+
                                         'average_coherence': {}})
 
 

--- a/src/artm/messages.proto
+++ b/src/artm/messages.proto
@@ -360,8 +360,9 @@ message TopTokensScore {
   repeated int32 topic_index = 3;
   repeated string token = 4;
   repeated float weight = 5;
-  repeated float coherence = 6;
-  optional float average_coherence = 7;
+  repeated string coherence_topic_name = 6;
+  repeated float coherence = 7;
+  optional float average_coherence = 8;
 }
 
 // Represents a configuration of a theta snippet score

--- a/src/artm/score/top_tokens.cc
+++ b/src/artm/score/top_tokens.cc
@@ -103,6 +103,7 @@ std::shared_ptr<Score> TopTokens::CalculateScore(const artm::core::PhiMatrix& p_
     }
 
     if (count_coherence) {
+      top_tokens_score->add_coherence_topic_name(topic_name.Get(topic_ids[i]));
       float topic_coherence = dictionary_ptr->CountTopicCoherence(tokens_for_coherence);
       average_coherence += topic_coherence;
       coherence->Add(topic_coherence);


### PR DESCRIPTION
Currently there is inappropriate use of `topic_name` field for labeling coherence scores.
While `coherence` field of `TopTokensScore` has one number per requested topics, `topic_name` field has at most `num_tokens` numbers per requested topics.

We may true to use some parts of `topic_name` filed, e.g. we can try to get each `num_tokens`-th element, but there are at least two problems:
* It complicates code
* In fact it's wrong: actual number of gathered top tokens per topic can be less than `num_tokens`, because tokens with small probability cannot be gathered.

Instead of this approach, let's simply add another field into protobuf message `TopTokensScore` which contains topic_names and is aligned with coherence values.