### PR TITLE
Add support for PeakMemory score for Mac systems

### DIFF
--- a/src/artm/score/peak_memory.cc
+++ b/src/artm/score/peak_memory.cc
@@ -35,9 +35,11 @@ std::shared_ptr<Score> PeakMemory::CalculateScore(const artm::core::PhiMatrix& p
 #elif defined(__linux__) || defined(__APPLE__)
   rusage info;
   if (!getrusage(RUSAGE_SELF, &info)) {
-#if defined(__linux__) // For linux `ru_maxrss` field contains kilobytes
+#if defined(__linux__)
+    // For linux `ru_maxrss` field contains kilobytes
     peak_memory_score->set_value((size_t) info.ru_maxrss * (int64_t) 1024);
-#else // For MacOS `ru_maxrss` field contains bytes
+#else
+    // For MacOS `ru_maxrss` field contains bytes
     peak_memory_score->set_value((size_t) info.ru_maxrss);
 #endif
   } else {


### PR DESCRIPTION
I found that `getrusage` has been supported on MacOS too for a long time.
So I simply add check for MacOS-defined macros.
Note: in MacOS `getrusage` returns max rss in bytes, not kilobytes.

Tested locally on MacOS 10.15.4.

Fixes second part of #825 