### PR TITLE
hopefully fix deprecation warning

### DIFF
--- a/3rdparty/protobuf-3.0.0/python/google/protobuf/pyext/message.cc
+++ b/3rdparty/protobuf-3.0.0/python/google/protobuf/pyext/message.cc
@@ -682,7 +682,7 @@ PyObject* CheckString(PyObject* arg, const FieldDescriptor* descriptor) {
       encoded_string = arg;  // Already encoded.
       Py_INCREF(encoded_string);
     } else {
-      encoded_string = PyUnicode_AsEncodedObject(arg, "utf-8", NULL);
+      encoded_string = PyCodec_Encode(arg, "utf-8", NULL);
     }
   } else {
     // In this case field type is "bytes".


### PR DESCRIPTION
Apparently, the function used in protobuf code was deprecated:
https://python.readthedocs.io/en/latest/whatsnew/3.6.html#deprecated-functions-and-types-of-the-c-api

which leads to the following warnings (see #975):

```
DeprecationWarning: PyUnicode_AsEncodedObject() is deprecated; use PyUnicode_AsEncodedString() to encode from str to bytes or PyCodec_Encode() for generic encoding
```

I *think* I found the sole line responsible and the fix is really simple, but I'm out of my depth here; could someone please check that everything works and backward-compatible?
