### PR TITLE
improve python API for working with DictionaryData

### DIFF
--- a/python/artm/dictionary.py
+++ b/python/artm/dictionary.py
@@ -113,9 +113,8 @@ class Dictionary(object):
         print(type(getattr(dictionary_data, 'token')))
         dict_pandas = {field: list(getattr(dictionary_data, field))
                        for field in FIELDS}
-        # TODO (bt): probably should be pd.DataFrame.from_dict
-        # with dtype specification (at least specify that token_value is float, not double)
-        # but dtype specification seems to be wonky:
+        # TODO (bt): find out if this is memory-efficient
+        # dtype specification seems to be wonky:
         # https://github.com/pandas-dev/pandas/issues/14655
         return pd.DataFrame.from_dict(dict_pandas).astype(FIELD_DTYPES)
 

--- a/python/artm/dictionary.py
+++ b/python/artm/dictionary.py
@@ -110,7 +110,7 @@ class Dictionary(object):
             but has no I/O overhead
         """
         dictionary_data = self._master.get_dictionary(self._name)
-        print(getattr(dictionary_data, 'token'))
+        print(type(getattr(dictionary_data, 'token')))
         dict_pandas = {field: list(getattr(dictionary_data, field))
                        for field in FIELDS}
         # TODO (bt): probably should be pd.DataFrame.from_dict

--- a/python/artm/dictionary.py
+++ b/python/artm/dictionary.py
@@ -154,17 +154,11 @@ class Dictionary(object):
         :param pandas.DataFrame dataframe: DataFrame having all the columns specified in FIELDS
         """
         new_dictionary_data = messages.DictionaryData()
-        old_dictionary_data = self._master.get_dictionary(self._name)
-
-        dictionary_data.name = old_dictionary_data.name
-        dictionary_data.num_items_in_collection = old_dictionary_data.num_items_in_collection
 
         self._reset()
         for field in FIELDS:
-            # TODO (bt): this isn't the best way to do this,
-            # but just .values doesn't work for some reason
-            for entry in dataframe[field].values:
-                getattr(new_dictionary_data, field).append(entry)
+            # https://stackoverflow.com/questions/23726335/how-to-assign-to-repeated-field
+            getattr(new_dictionary_data, field).extend(dataframe[field].values)
 
         self._master.create_dictionary(dictionary_data=new_dictionary_data, dictionary_name=self._name)
 

--- a/python/artm/dictionary.py
+++ b/python/artm/dictionary.py
@@ -116,7 +116,7 @@ class Dictionary(object):
         # with dtype specification (at least specify that token_value is float, not double)
         # but dtype specification seems to be wonky:
         # https://github.com/pandas-dev/pandas/issues/14655
-        return pd.DataFrame(dict_pandas).astype(FIELD_DTYPES)
+        return pd.DataFrame.from_dict(dict_pandas).astype(FIELD_DTYPES)
 
     def load_text(self, dictionary_path, encoding='utf-8'):
         """

--- a/python/artm/dictionary.py
+++ b/python/artm/dictionary.py
@@ -155,10 +155,10 @@ class Dictionary(object):
         self._reset()
         for field in FIELDS:
             # TODO (bt): this isn't the best way to do this,
-            # but just .values doesn't work for some reason 
+            # but just .values doesn't work for some reason
             for entry in dataframe[field].values:
                 getattr(new_dictionary_data, field).append(entry)
-            
+
         self._master.create_dictionary(dictionary_data=new_dictionary_data, dictionary_name=self._name)
 
     def create(self, dictionary_data):
@@ -236,5 +236,3 @@ class Dictionary(object):
     def __repr__(self):
         descr = next(x for x in self._master.get_info().dictionary if x.name == self.name)
         return 'artm.Dictionary(name={0}, num_entries={1})'.format(descr.name, descr.num_entries)
-
-

--- a/python/artm/dictionary.py
+++ b/python/artm/dictionary.py
@@ -110,7 +110,8 @@ class Dictionary(object):
             but has no I/O overhead
         """
         dictionary_data = self._master.get_dictionary(self._name)
-        dict_pandas = {field: getattr(dictionary_data, field)
+        print(getattr(dictionary_data, 'token'))
+        dict_pandas = {field: list(getattr(dictionary_data, field))
                        for field in FIELDS}
         # TODO (bt): probably should be pd.DataFrame.from_dict
         # with dtype specification (at least specify that token_value is float, not double)

--- a/python/artm/dictionary.py
+++ b/python/artm/dictionary.py
@@ -110,7 +110,6 @@ class Dictionary(object):
             but has no I/O overhead
         """
         dictionary_data = self._master.get_dictionary(self._name)
-        print(type(getattr(dictionary_data, 'token')))
         dict_pandas = {field: list(getattr(dictionary_data, field))
                        for field in FIELDS}
         # TODO (bt): find out if this is memory-efficient

--- a/python/artm/dictionary.py
+++ b/python/artm/dictionary.py
@@ -4,6 +4,7 @@ import codecs
 import uuid
 
 from six.moves import range
+import pandas as pd
 
 from . import master_component
 from . import wrapper
@@ -14,6 +15,11 @@ __all__ = [
 ]
 
 FIELDS = 'token class_id token_value token_tf token_df'.split()
+FIELD_DTYPES = {
+    'token_value': 'float32',
+    'token_tf': 'float32',
+    'token_df': 'float32',
+}
 
 
 class Dictionary(object):
@@ -110,7 +116,7 @@ class Dictionary(object):
         # with dtype specification (at least specify that token_value is float, not double)
         # but dtype specification seems to be wonky:
         # https://github.com/pandas-dev/pandas/issues/14655
-        return pd.DataFrame(dict_pandas)
+        return pd.DataFrame(dict_pandas).astype(FIELD_DTYPES)
 
     def load_text(self, dictionary_path, encoding='utf-8'):
         """

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -108,11 +108,14 @@ def test_func():
         dict7_df = dictionary_7.save_dataframe()
         filtered_df = dict7_df.query("2 <= token_df <= 100 and 1 <= token_tf <= 20").copy()
 
-        dictionary_7.filter(min_df=2, max_df=100, min_tf=1, max_tf=20, recalculate_value=True)
+        dictionary_7.filter(min_df=2, max_df=100, min_tf=1, max_tf=20, recalculate_value=False)
         dictionary_path = os.path.join(batches_folder, 'saved_text_dict_7.txt')
         dictionary_7.save_text(dictionary_path=dictionary_path)
         loaded_df = pd.read_csv(dictionary_path, sep=', *', skiprows=[0])
-        assert loaded_df == filtered_df
+        print(loaded_df.head())
+        print(filtered_df.head())
+        assert loaded_df.shape == filtered_df.shape
+        assert sorted(loaded_df.index) == sorted(filtered_df.index)
 
         dictionary_7_clone = artm.Dictionary()
         dictionary_7_clone.load_from_dataframe(filtered_df.head(2000))

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -7,6 +7,7 @@ import os
 import pytest
 
 from six.moves import range
+import pandas as pd
 
 import artm
 

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -107,7 +107,7 @@ def test_func():
         dictionary_7.load(dictionary_path=os.path.join(batches_folder, 'saved_dict_1.dict'))
         dict7_df = dictionary_7.save_dataframe()
         filtered_df = dict7_df.query("2 <= token_df <= 100 and 1 <= token_tf <= 20").copy()
-        filtered_df = filtered_df[filtered_df.index]
+        # filtered_df = filtered_df[filtered_df.index]
 
         dictionary_7.filter(min_df=2, max_df=100, min_tf=1, max_tf=20, recalculate_value=False)
         dictionary_path = os.path.join(batches_folder, 'saved_text_dict_7.txt')
@@ -119,6 +119,13 @@ def test_func():
         print(filtered_df.describe())
         print(loaded_df.tail())
         print(filtered_df.tail())
+        print("^^^^^^^^^^^^^^^^^^^^^^^^^^")
+        strange_tokens = set(filtered_df.token) - set(loaded_df.token)
+        print(filtered_df.query("token in @strange_tokens").head(22))
+
+        strange_tokens = set(loaded_df.token) - set(filtered_df.token)
+        print(loaded_df.query("token in @strange_tokens").head(22))
+
         assert loaded_df.shape == filtered_df.shape
         assert sorted(loaded_df.token) == sorted(filtered_df.token)
 

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -91,6 +91,7 @@ def test_func():
 
         dictionary_6 = artm.Dictionary()
         dictionary_6.load(dictionary_path=os.path.join(batches_folder, 'saved_dict_1.dict'))
+
         dictionary_6.filter(min_df=2, max_df=100, min_tf=1, max_tf=20, recalculate_value=True)
         dictionary_6.save_text(dictionary_path=os.path.join(batches_folder, 'saved_text_dict_6.txt'))
         _check_num_tokens_in_saved_text_dictionary(os.path.join(batches_folder, 'saved_text_dict_6.txt'), case_type=2)
@@ -98,6 +99,22 @@ def test_func():
         dictionary_6.filter(min_df_rate=0.001, max_df_rate=0.002, recalculate_value=True)
         dictionary_6.save_text(dictionary_path=os.path.join(batches_folder, 'saved_text_dict_6.txt'))
         _check_num_tokens_in_saved_text_dictionary(os.path.join(batches_folder, 'saved_text_dict_6.txt'), case_type=3)
+
+
+        # check dictionary-dataframe interoperability
+        dictionary_7 = artm.Dictionary()
+        dictionary_7.load(dictionary_path=os.path.join(batches_folder, 'saved_dict_1.dict'))
+        dict7_df = dictionary_7.save_dataframe()
+        filtered_df = dict7_df.query("2 <= token_df <= 100 and 1 <= token_tf <= 20").copy()
+
+        dictionary_7.filter(min_df=2, max_df=100, min_tf=1, max_tf=20, recalculate_value=True)
+        dictionary_7.save_text(dictionary_path=os.path.join(batches_folder, 'saved_text_dict_7.txt'))
+        loaded_df = pd.DataFrame.read_csv('saved_text_dict_7.txt', sep=', *', skiprows=[0])
+        assert loaded_df == filtered_df
+
+        dictionary_7_clone = artm.Dictionary()
+        dictionary_7_clone.load_from_dataframe(filtered_df.head(2000))
+        assert dictionary_7_clone.save_dataframe().shape == (2000, 6)
     finally:
         shutil.rmtree(batches_folder)
 

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -107,6 +107,7 @@ def test_func():
         dictionary_7.load(dictionary_path=os.path.join(batches_folder, 'saved_dict_1.dict'))
         dict7_df = dictionary_7.save_dataframe()
         filtered_df = dict7_df.query("2 <= token_df <= 100 and 1 <= token_tf <= 20").copy()
+        filtered_df = filtered_df[filtered_df.index]
 
         dictionary_7.filter(min_df=2, max_df=100, min_tf=1, max_tf=20, recalculate_value=False)
         dictionary_path = os.path.join(batches_folder, 'saved_text_dict_7.txt')
@@ -114,8 +115,12 @@ def test_func():
         loaded_df = pd.read_csv(dictionary_path, sep=', *', skiprows=[0])
         print(loaded_df.head())
         print(filtered_df.head())
+        print(loaded_df.describe())
+        print(filtered_df.describe())
+        print(loaded_df.tail())
+        print(filtered_df.tail())
         assert loaded_df.shape == filtered_df.shape
-        assert sorted(loaded_df.index) == sorted(filtered_df.index)
+        assert sorted(loaded_df.token) == sorted(filtered_df.token)
 
         dictionary_7_clone = artm.Dictionary()
         dictionary_7_clone.load_from_dataframe(filtered_df.head(2000))

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -112,25 +112,14 @@ def test_func():
         dictionary_path = os.path.join(batches_folder, 'saved_text_dict_7.txt')
         dictionary_7.save_text(dictionary_path=dictionary_path)
         loaded_df = pd.read_csv(dictionary_path, sep=', *', skiprows=[0])
-        print(loaded_df.head())
-        print(filtered_df.head())
-        print(loaded_df.describe())
-        print(filtered_df.describe())
-        print(loaded_df.tail())
-        print(filtered_df.tail())
-        print("^^^^^^^^^^^^^^^^^^^^^^^^^^")
-        strange_tokens = set(filtered_df.token) - set(loaded_df.token)
-        print(filtered_df.query("token in @strange_tokens").head(22))
-
-        strange_tokens = set(loaded_df.token) - set(filtered_df.token)
-        print(loaded_df.query("token in @strange_tokens").head(22))
-
+        
         assert loaded_df.shape == filtered_df.shape
         assert sorted(loaded_df.token) == sorted(filtered_df.token)
+        assert loaded_df[['token', 'token_df', 'token_tf']] == filtered_df[['token', 'token_df', 'token_tf']]
 
         dictionary_7_clone = artm.Dictionary()
         dictionary_7_clone.load_from_dataframe(filtered_df.head(2000))
-        assert dictionary_7_clone.save_dataframe().shape == (2000, 6)
+        assert dictionary_7_clone.save_dataframe().shape[0] == 2000
     finally:
         shutil.rmtree(batches_folder)
 

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -110,7 +110,7 @@ def test_func():
 
         dictionary_7.filter(min_df=2, max_df=100, min_tf=1, max_tf=20, recalculate_value=True)
         dictionary_7.save_text(dictionary_path=os.path.join(batches_folder, 'saved_text_dict_7.txt'))
-        loaded_df = pd.DataFrame.read_csv('saved_text_dict_7.txt', sep=', *', skiprows=[0])
+        loaded_df = pd.read_csv('saved_text_dict_7.txt', sep=', *', skiprows=[0])
         assert loaded_df == filtered_df
 
         dictionary_7_clone = artm.Dictionary()

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -117,7 +117,7 @@ def test_func():
         assert sorted(loaded_df.token) == sorted(filtered_df.token)
         first = loaded_df.reset_index()[['token', 'token_df', 'token_tf']].sort_values(by='token')
         second = filtered_df.reset_index()[['token', 'token_df', 'token_tf']].sort_values(by='token')
-        assert (first == second).all()
+        assert (first == second).all().all()
 
         dictionary_7_clone = artm.Dictionary()
         dictionary_7_clone.load_from_dataframe(filtered_df.head(2000))

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -106,8 +106,7 @@ def test_func():
         dictionary_7 = artm.Dictionary()
         dictionary_7.load(dictionary_path=os.path.join(batches_folder, 'saved_dict_1.dict'))
         dict7_df = dictionary_7.save_dataframe()
-        filtered_df = dict7_df.query("2 <= token_df <= 100 and 1 <= token_tf <= 20").copy()
-        # filtered_df = filtered_df[filtered_df.index]
+        filtered_df = dict7_df.query("2 <= token_df < 100 and 1 <= token_tf < 20").copy()
 
         dictionary_7.filter(min_df=2, max_df=100, min_tf=1, max_tf=20, recalculate_value=False)
         dictionary_path = os.path.join(batches_folder, 'saved_text_dict_7.txt')

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -109,8 +109,9 @@ def test_func():
         filtered_df = dict7_df.query("2 <= token_df <= 100 and 1 <= token_tf <= 20").copy()
 
         dictionary_7.filter(min_df=2, max_df=100, min_tf=1, max_tf=20, recalculate_value=True)
-        dictionary_7.save_text(dictionary_path=os.path.join(batches_folder, 'saved_text_dict_7.txt'))
-        loaded_df = pd.read_csv('saved_text_dict_7.txt', sep=', *', skiprows=[0])
+        dictionary_path = os.path.join(batches_folder, 'saved_text_dict_7.txt')
+        dictionary_7.save_text(dictionary_path=dictionary_path)
+        loaded_df = pd.read_csv(dictionary_path, sep=', *', skiprows=[0])
         assert loaded_df == filtered_df
 
         dictionary_7_clone = artm.Dictionary()

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -115,7 +115,9 @@ def test_func():
         
         assert loaded_df.shape == filtered_df.shape
         assert sorted(loaded_df.token) == sorted(filtered_df.token)
-        assert loaded_df[['token', 'token_df', 'token_tf']] == filtered_df[['token', 'token_df', 'token_tf']]
+        first = loaded_df.reset_index()[['token', 'token_df', 'token_tf']].sort_values(by='token')
+        second = filtered_df.reset_index()[['token', 'token_df', 'token_tf']].sort_values(by='token')
+        assert first == second
 
         dictionary_7_clone = artm.Dictionary()
         dictionary_7_clone.load_from_dataframe(filtered_df.head(2000))

--- a/python/tests/artm/test_dictionary.py
+++ b/python/tests/artm/test_dictionary.py
@@ -117,7 +117,7 @@ def test_func():
         assert sorted(loaded_df.token) == sorted(filtered_df.token)
         first = loaded_df.reset_index()[['token', 'token_df', 'token_tf']].sort_values(by='token')
         second = filtered_df.reset_index()[['token', 'token_df', 'token_tf']].sort_values(by='token')
-        assert first == second
+        assert (first == second).all()
 
         dictionary_7_clone = artm.Dictionary()
         dictionary_7_clone.load_from_dataframe(filtered_df.head(2000))


### PR DESCRIPTION
Are tests required here?

This pattern works:

```
df = artm_dict.save_dataframe()

# fiddle with numbers until you get reasonable cutoff point
df.query("token_df == 6 and class_id == '@lemmatized'").head(25)

# OK, 6 is good
MIN_TOKEN_DF_WORD = 6.0
artm_dict.filter(class_id='@lemmatized', min_df=MIN_TOKEN_DF_WORD, recalculate_value=True)
```

This pattern is inefficient (but might be improved)

```
df = artm_dict.save_dataframe()

# change everything manually
df = df.query("token != 'the')

artm_dict.load_from_dataframe(df)
```

PS: On somewhat related note, is it expected behaviour?
```
>>> df = artm_dict.save_dataframe()
>>> df.query("class_id == '@lemmatized'").token_value.sum()

0.8612454659903541
```
Should not it be equal to 1.0?
