### PR TITLE
Fix the warning of scipy

### DIFF
--- a/python/artm/batches_utils.py
+++ b/python/artm/batches_utils.py
@@ -231,7 +231,7 @@ class BatchVectorizer(object):
             return batch, {}
 
         try:
-            from scipy.sparse.base import spmatrix
+            from scipy.sparse import spmatrix
         except ImportError:
             spmatrix = tuple()
 


### PR DESCRIPTION
/usr/local/lib/python3.8/dist-packages/artm/batches_utils.py:227: DeprecationWarning: Please use `spmatrix` from the `scipy.sparse` namespace, the `scipy.sparse.base` namespace is deprecated.
  from scipy.sparse.base import spmatrix