### PR TITLE
Fix README:

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ from numpy import array
 
 cv = CountVectorizer(max_features=1000, stop_words='english')
 n_wd = array(cv.fit_transform(fetch_20newsgroups().data).todense()).T
-vocabulary = cv.get_feature_names()
+vocabulary = cv.get_feature_names_out()
 
 bv = artm.BatchVectorizer(data_format='bow_n_wd',
                           n_wd=n_wd,


### PR DESCRIPTION
Function get_feature_names is deprecated; get_feature_names is deprecated in 1.0 and will be removed in 1.2. Please use get_feature_names_out instead.